### PR TITLE
Fix on focus config check

### DIFF
--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -58,10 +58,10 @@ namespace UnityMcpBridge.Editor.Windows
         
         private void OnFocus()
         {
-            // Refresh configuration status when window gains focus
-            foreach (McpClient mcpClient in mcpClients.clients)
+            if (mcpClients.clients.Count > 0 && selectedClientIndex < mcpClients.clients.Count)
             {
-                CheckMcpConfiguration(mcpClient);
+                McpClient selectedClient = mcpClients.clients[selectedClientIndex];
+                CheckMcpConfiguration(selectedClient);
             }
             Repaint();
         }


### PR DESCRIPTION
Ref: https://discord.com/channels/1394050967917428756/1396128287771590757/1401040388541648998

Prevents the log spam, slightly more efficient check when the Window is back in focus.

This change was added very recently in #175, maybe check with the author first before merging this in, it continues to work for my connection but I'm not sure if this unwittingly breaks something. Feels safe so far 