### PR TITLE
Fix: ReadConsole tool: stable log severity classification and reliable console reads across Unity versions

### DIFF
--- a/UnityMcpBridge/Editor/Tools/ReadConsole.cs
+++ b/UnityMcpBridge/Editor/Tools/ReadConsole.cs
@@ -274,25 +274,18 @@ namespace UnityMcpBridge.Editor.Tools
                     }
 
                     bool want;
-                    if (types.Contains("all"))
+                    // Treat Exception/Assert as errors for filtering convenience
+                    if (unityType == LogType.Exception)
                     {
-                        want = true;
+                        want = types.Contains("error") || types.Contains("exception");
+                    }
+                    else if (unityType == LogType.Assert)
+                    {
+                        want = types.Contains("error") || types.Contains("assert");
                     }
                     else
                     {
-                        // Treat Exception/Assert as errors for filtering convenience
-                        if (unityType == LogType.Exception)
-                        {
-                            want = types.Contains("error") || types.Contains("exception");
-                        }
-                        else if (unityType == LogType.Assert)
-                        {
-                            want = types.Contains("error") || types.Contains("assert");
-                        }
-                        else
-                        {
-                            want = types.Contains(unityType.ToString().ToLowerInvariant());
-                        }
+                        want = types.Contains(unityType.ToString().ToLowerInvariant());
                     }
 
                     if (!want) continue;


### PR DESCRIPTION
## Summary
Short: Improves read_console severity classification (CSxxxx warnings/errors; Debug.Log stays Log) and ensures consistent results across domain reloads. No API/schema changes.

Addresses #199 & #125 

## What changed
- Classify severity via stacktrace/message first (LogError/LogWarning/Exception/Assertion), with safe fallback to mode‑bit mapping
- Correct error/warning/log filtering; Exceptions/Asserts counted as errors for filtering
- Remove debug spam; tool now returns the current console buffer consistently
- Scope limited to `UnityMcpBridge/Editor/Tools/ReadConsole.cs` (no API/schema changes)

## Why
Unity’s internal `LogEntry.mode` bitfield can differ between versions, which caused misclassification (e.g., errors showing as warnings). Stacktrace‑first classification is stable and version‑resilient.

## How to verify
1. Generate one of each: `Debug.Log`, `Debug.LogWarning`, `Debug.LogError` (and optionally an exception/assert)
2. Run the `read_console` tool with type filters (`log`, `warning`, `error`) and confirm correct classification
3. Trigger a domain reload; `read_console` continues to return the current buffer accurately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved log severity classification using message content with a mode fallback.
  * Stack traces are now extracted and included in console entries.

* **Bug Fixes**
  * More accurate filtering across all log types, preserving Exception and Assert handling.
  * Output now reports the actual inferred log type.
  * More robust entry retrieval with guaranteed cleanup and controlled error handling.

* **Chores**
  * sinceTimestamp parsed but not yet applied; warning logged.
  * Removed unused calibration code and simplified comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->