### PR TITLE
UX and Fix: Claude Code detection + UV gating (Cursor/Windsurf) + VSCode mcp.json schema

### DIFF
--- a/UnityMcpBridge/Editor/Data/McpClients.cs
+++ b/UnityMcpBridge/Editor/Data/McpClients.cs
@@ -87,7 +87,7 @@ namespace UnityMcpBridge.Editor.Data
                     Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                     "Code",
                     "User",
-                    "settings.json"
+                    "mcp.json"
                 ),
                 linuxConfigPath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -95,7 +95,7 @@ namespace UnityMcpBridge.Editor.Data
                     "Application Support",
                     "Code",
                     "User",
-                    "settings.json"
+                    "mcp.json"
                 ),
                 mcpType = McpTypes.VSCode,
                 configStatus = "Not Configured",

--- a/UnityMcpBridge/Editor/Models/MCPConfigServer.cs
+++ b/UnityMcpBridge/Editor/Models/MCPConfigServer.cs
@@ -11,5 +11,9 @@ namespace UnityMcpBridge.Editor.Models
 
         [JsonProperty("args")]
         public string[] args;
+
+        // VSCode expects a transport type; default to stdio for compatibility
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
+        public string type = "stdio";
     }
 }


### PR DESCRIPTION
## Summary
Makes setup far more self‑serve. Adds Claude Code binary picker with NVM auto‑detection, gates Cursor/Windsurf on `uv` with an inline help flow, and updates VSCode to the new `mcp.json` top‑level `servers` schema. Robust parsing prevents bad states and avoids cross‑client status mix‑ups.

Addresses #195 , #204, #205, possibly #189.

## What changed
- Claude Code (claude CLI)
  - Dynamic “Claude Not Found” state with orange inline help link and “Choose Claude Install Location”
  - Auto‑register after picking the binary; persist override between sessions
  - NVM auto‑detection of `claude` under `~/.nvm/versions/node/*/bin` (pick newest)
  - Removed “Auto‑connect to MCP Clients” toggle; simplified to Register/Unregister once found
- Cursor/Windsurf (uv gating)
  - If `uv` missing: red “uv Not Found”, orange help link to troubleshooting, single “Choose UV Install Location” button
  - Saving a `uv` path persists and immediately attempts configure
  - Hide config filename until `uv` is available
- VSCode GitHub Copilot
  - Switch to new config path: `~/Library/Application Support/Code/User/mcp.json` (mac), `%APPDATA%/Code/User/mcp.json` (Windows)
  - Write new schema: top‑level `servers.unityMCP` with `"type": "stdio"`
  - Read both new (`servers`) and legacy (`mcp.servers`) for back‑compat
  - Robust parse/merge: empty files initialize silently; warn only when non‑empty and invalid JSON encountered
- Status isolation
  - Each client’s status is determined only from its own config; deleting Claude Desktop’s file no longer flips VSCode to “Missing Unity MCP Config”

## Why
- Many users launch Unity from Finder/Hub, so PATH‑based discovery fails (macOS GUI env mismatch).
- NVM installs of Claude Code are common and not found by default PATH in Unity; adding a picker and NVM scan removes friction.
- Cursor/Windsurf require `uv`; gating with a single, guided fix prevents confusing partial states.
- VSCode moved to `mcp.json` and a new schema; writing/reading the right shape avoids config breakage.

## How to verify
- Claude Code
  1. Ensure `claude` is NOT on PATH; open `Window > Unity MCP`; select Claude Code → see “Claude Not Found” with help and “Choose Claude Install Location”.
  2. Pick `~/.nvm/versions/node/<ver>/bin/claude` → status turns green and Register/Unregister button appears; picker hidden.
- Cursor/Windsurf
  1. Temporarily rename/move `uv`; open `Window > Unity MCP`; pick Cursor/Windsurf → see “uv Not Found”, help, and “Choose UV Install Location”.
  2. Pick the `uv` binary; status/config updates and normal controls reappear.
- VSCode
  1. Confirm config written to `Code/User/mcp.json` with:
     ```json
     {
       "servers": {
         "unityMCP": {
           "command": "uv",
           "args": ["--directory", "<UnityMcpServer/src>", "run", "server.py"],
           "type": "stdio"
         }
       }
     }
     ```
  2. If `mcp.json` is empty, Auto Configure should populate it without warnings.
  3. If legacy `mcp.servers` exists, read‑back should still show “Configured”.
- Cross‑client isolation
  1. Delete only the Claude Desktop config file; Claude Desktop shows missing, VSCode remains “Configured”.

## Scope
- Code only:
  - `UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs`
  - `UnityMcpBridge/Editor/Data/McpClients.cs`
  - `UnityMcpBridge/Editor/Models/MCPConfigServer.cs`
- No breaking API changes; VSCode config schema updated intentionally to match its latest format.