### PR TITLE
Adjust the package before publishing on OpenUPM

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,107 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: "Version bump type"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+        required: true
+    
+jobs:
+  bump:
+    name: "Bump version and tag"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute new version
+        id: compute
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUMP="${{ inputs.version_bump }}"
+          CURRENT_VERSION=$(jq -r '.version' "UnityMcpBridge/package.json")
+          echo "CURRENT_VERSION version: $CURRENT_VERSION"
+
+          IFS='.' read -r MA MI PA <<< "$CURRENT_VERSION"
+          case "$BUMP" in
+            major)
+              ((MA+=1)); MI=0; PA=0
+              ;;
+            minor)
+              ((MI+=1)); PA=0
+              ;;
+            patch)
+              ((PA+=1))
+              ;;
+            *)
+              echo "Unknown version_bump: $BUMP" >&2
+              exit 1
+              ;;
+          esac
+
+          NEW_VERSION="$MA.$MI.$PA"
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update files to new version
+        env:
+          NEW_VERSION: ${{ steps.compute.outputs.new_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Updating UnityMcpBridge/package.json to $NEW_VERSION"
+          jq ".version = \"${NEW_VERSION}\"" UnityMcpBridge/package.json > UnityMcpBridge/package.json.tmp
+          mv UnityMcpBridge/package.json.tmp UnityMcpBridge/package.json
+
+          echo "Updating UnityMcpBridge/UnityMcpServer~/src/pyproject.toml to $NEW_VERSION"
+          sed -i '0,/^version = ".*"/s//version = "'"$NEW_VERSION"'"/' "UnityMcpBridge/UnityMcpServer~/src/pyproject.toml"
+
+      - name: Commit and push changes
+        env:
+          NEW_VERSION: ${{ steps.compute.outputs.new_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add UnityMcpBridge/package.json "UnityMcpBridge/UnityMcpServer~/src/pyproject.toml"
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+          else
+            git commit -m "chore: bump version to ${NEW_VERSION}"
+          fi
+
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          echo "Pushing to branch: $BRANCH"
+          git push origin "$BRANCH"
+
+      - name: Create and push tag
+        env:
+          NEW_VERSION: ${{ steps.compute.outputs.new_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${NEW_VERSION}"
+          echo "Preparing to create tag $TAG"
+
+          if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
+            echo "Tag $TAG already exists on remote. Skipping tag creation."
+            exit 0
+          fi
+
+          git tag -a "$TAG" -m "Version ${NEW_VERSION}"
+          git push origin "$TAG"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Unity MCP connects your tools using two components:
 ### Prerequisites
 
   *   **Python:** Version 3.12 or newer. [Download Python](https://www.python.org/downloads/)
-  *   **Unity Hub & Editor:** Version 2020.3 LTS or newer. [Download Unity](https://unity.com/download)
+  *   **Unity Hub & Editor:** Version 2021.3 LTS or newer. [Download Unity](https://unity.com/download)
   *   **uv (Python package manager):**
       ```bash
       pip install uv

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Unity MCP connects your tools using two components:
 
         **Note:** Without Roslyn, script validation falls back to basic structural checks. Roslyn enables full C# compiler diagnostics with precise error reporting.</details>
 
-### 🌟Step 1: Install the Unity Package (Bridge)🌟
+### 🌟Step 1: Install the Unity Package🌟
+
+### To install via Git URL
 
 1.  Open your Unity project.
 2.  Go to `Window > Package Manager`.
@@ -110,6 +112,12 @@ Unity MCP connects your tools using two components:
     ```
 5.  Click `Add`.
 6. The MCP Server should automatically be installed onto your machine as a result of this process.
+
+### To install via OpenUPM
+
+1.  Instal the [OpenUPM CLI](https://openupm.com/docs/getting-started-cli.html)
+2.  Open a terminal (PowerShell, Terminal, etc.) and navigate to your Unity project directory
+3.  Run `openupm add com.coplaydev.unity-mcp`
 
 **Note:** If you installed the MCP Server before Coplay's maintenance, you will need to uninstall the old package before re-installing the new one.
 

--- a/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
+++ b/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "UnityMcpServer"
-version = "2.0.0"
+version = "2.1.2"
 description = "Unity MCP Server: A Unity package for Unity Editor integration via the Model Context Protocol (MCP)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
+++ b/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "UnityMcpServer"
-version = "2.1.2"
+version = "2.0.0"
 description = "Unity MCP Server: A Unity package for Unity Editor integration via the Model Context Protocol (MCP)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/UnityMcpBridge/package.json
+++ b/UnityMcpBridge/package.json
@@ -1,9 +1,9 @@
 {
   "name": "com.coplaydev.unity-mcp",
   "version": "2.1.1",
-  "displayName": "Unity MCP Bridge",
-  "description": "A bridge that manages and communicates with the sister application, Unity MCP Server, which allows for communications with MCP Clients like Claude Desktop or Cursor.",
-  "unity": "2020.3",
+  "displayName": "Unity MCP",
+  "description": "A bridge that connects an LLM to Unity via the MCP (Model Context Protocol). This allows MCP Clients like Claude Desktop or Cursor to directly control your Unity Editor.",
+  "unity": "2021.3",
   "documentationUrl": "https://github.com/CoplayDev/unity-mcp",
   "licensesUrl": "https://github.com/CoplayDev/unity-mcp/blob/main/LICENSE",
   "dependencies": {

--- a/UnityMcpBridge/package.json
+++ b/UnityMcpBridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.coplaydev.unity-mcp",
-  "version": "2.1.2",
+  "version": "2.1.1",
   "displayName": "Unity MCP",
   "description": "A bridge that connects an LLM to Unity via the MCP (Model Context Protocol). This allows MCP Clients like Claude Desktop or Cursor to directly control your Unity Editor.",
   "unity": "2021.3",

--- a/UnityMcpBridge/package.json
+++ b/UnityMcpBridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.coplaydev.unity-mcp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "displayName": "Unity MCP",
   "description": "A bridge that connects an LLM to Unity via the MCP (Model Context Protocol). This allows MCP Clients like Claude Desktop or Cursor to directly control your Unity Editor.",
   "unity": "2021.3",


### PR DESCRIPTION
- Change the package name to Unity MCP
- Modify the package description so it's more clear what's happening
- Add instructions on how to install via OpenUPM
- Add a GH workflow to bump the version more consistently
- Raise minimum supported Unity version to 2021.3

Closes #213, #217 and #218