### PR TITLE
Rename namespace and public facing plugin output from "Unity MCP" to "MCP for Unity"

### DIFF
--- a/CursorHelp.md
+++ b/CursorHelp.md
@@ -1,11 +1,11 @@
 ### Cursor/VSCode/Windsurf: UV path issue on Windows (diagnosis and fix)
 
 #### The issue
-- Some Windows machines have multiple `uv.exe` locations. Our auto-config sometimes picked a less stable path, causing the MCP client to fail to launch the MCP For Unity Server or for the path to be auto-rewritten on repaint/restart.
+- Some Windows machines have multiple `uv.exe` locations. Our auto-config sometimes picked a less stable path, causing the MCP client to fail to launch the MCP for Unity Server or for the path to be auto-rewritten on repaint/restart.
 
 #### Typical symptoms
-- Cursor shows the MCP For Unity server but never connects or reports it “can’t start.”
-- Your `%USERPROFILE%\\.cursor\\mcp.json` flips back to a different `command` path when Unity or the MCP For Unity window refreshes.
+- Cursor shows the MCP for Unity server but never connects or reports it “can’t start.”
+- Your `%USERPROFILE%\\.cursor\\mcp.json` flips back to a different `command` path when Unity or the MCP for Unity window refreshes.
 
 #### Real-world example
 - Wrong/fragile path (auto-picked):
@@ -15,7 +15,7 @@
   - `C:\Users\mrken\AppData\Local\Microsoft\WinGet\Links\uv.exe`
 
 #### Quick fix (recommended)
-1) In MCP For Unity: `Window > MCP For Unity` → select your MCP client (Cursor or Windsurf)
+1) In MCP for Unity: `Window > MCP for Unity` → select your MCP client (Cursor or Windsurf)
 2) If you see “uv Not Found,” click “Choose `uv` Install Location” and browse to:
    - `C:\Users\<YOU>\AppData\Local\Microsoft\WinGet\Links\uv.exe`
 3) If uv is already found but wrong, still click “Choose `uv` Install Location” and select the `Links\uv.exe` path above. This saves a persistent override.
@@ -72,7 +72,7 @@ If that runs without error, restart Cursor and it should connect.
 Recommended practice
 
 - Prefer the WinGet Links shim paths above. If present, select one via “Choose `uv` Install Location”.
-- If the unity window keeps rewriting to a different `uv.exe`, pick the Links shim again; MCP For Unity saves a pinned override and will stop auto-rewrites.
+- If the unity window keeps rewriting to a different `uv.exe`, pick the Links shim again; MCP for Unity saves a pinned override and will stop auto-rewrites.
 - If neither Links path exists, a reasonable fallback is `~/.local/bin/uv.exe` (uv tools bin) or a Scoop shim, but Links is preferred for stability.
 
 References

--- a/CursorHelp.md
+++ b/CursorHelp.md
@@ -1,11 +1,11 @@
 ### Cursor/VSCode/Windsurf: UV path issue on Windows (diagnosis and fix)
 
 #### The issue
-- Some Windows machines have multiple `uv.exe` locations. Our auto-config sometimes picked a less stable path, causing the MCP client to fail to launch the Unity MCP Server or for the path to be auto-rewritten on repaint/restart.
+- Some Windows machines have multiple `uv.exe` locations. Our auto-config sometimes picked a less stable path, causing the MCP client to fail to launch the MCP For Unity Server or for the path to be auto-rewritten on repaint/restart.
 
 #### Typical symptoms
-- Cursor shows the UnityMCP server but never connects or reports it “can’t start.”
-- Your `%USERPROFILE%\\.cursor\\mcp.json` flips back to a different `command` path when Unity or the Unity MCP window refreshes.
+- Cursor shows the MCP For Unity server but never connects or reports it “can’t start.”
+- Your `%USERPROFILE%\\.cursor\\mcp.json` flips back to a different `command` path when Unity or the MCP For Unity window refreshes.
 
 #### Real-world example
 - Wrong/fragile path (auto-picked):
@@ -15,7 +15,7 @@
   - `C:\Users\mrken\AppData\Local\Microsoft\WinGet\Links\uv.exe`
 
 #### Quick fix (recommended)
-1) In Unity: `Window > Unity MCP` → select your MCP client (Cursor or Windsurf)
+1) In MCP For Unity: `Window > MCP For Unity` → select your MCP client (Cursor or Windsurf)
 2) If you see “uv Not Found,” click “Choose UV Install Location” and browse to:
    - `C:\Users\<YOU>\AppData\Local\Microsoft\WinGet\Links\uv.exe`
 3) If uv is already found but wrong, still click “Choose UV Install Location” and select the `Links\uv.exe` path above. This saves a persistent override.
@@ -72,7 +72,7 @@ If that runs without error, restart Cursor and it should connect.
 Recommended practice
 
 - Prefer the WinGet Links shim paths above. If present, select one via “Choose UV Install Location”.
-- If the unity window keeps rewriting to a different `uv.exe`, pick the Links shim again; Unity MCP saves a pinned override and will stop auto-rewrites.
+- If the unity window keeps rewriting to a different `uv.exe`, pick the Links shim again; MCP For Unity saves a pinned override and will stop auto-rewrites.
 - If neither Links path exists, a reasonable fallback is `~/.local/bin/uv.exe` (uv tools bin) or a Scoop shim, but Links is preferred for stability.
 
 References

--- a/CursorHelp.md
+++ b/CursorHelp.md
@@ -16,9 +16,9 @@
 
 #### Quick fix (recommended)
 1) In MCP For Unity: `Window > MCP For Unity` → select your MCP client (Cursor or Windsurf)
-2) If you see “uv Not Found,” click “Choose UV Install Location” and browse to:
+2) If you see “uv Not Found,” click “Choose `uv` Install Location” and browse to:
    - `C:\Users\<YOU>\AppData\Local\Microsoft\WinGet\Links\uv.exe`
-3) If uv is already found but wrong, still click “Choose UV Install Location” and select the `Links\uv.exe` path above. This saves a persistent override.
+3) If uv is already found but wrong, still click “Choose `uv` Install Location” and select the `Links\uv.exe` path above. This saves a persistent override.
 4) Click “Auto Configure” (or re-open the client) and restart Cursor.
 
 This sets an override stored in the Editor (key: `UnityMCP.UvPath`) so UnityMCP won’t auto-rewrite the config back to a different `uv.exe` later.
@@ -71,7 +71,7 @@ If that runs without error, restart Cursor and it should connect.
 
 Recommended practice
 
-- Prefer the WinGet Links shim paths above. If present, select one via “Choose UV Install Location”.
+- Prefer the WinGet Links shim paths above. If present, select one via “Choose `uv` Install Location”.
 - If the unity window keeps rewriting to a different `uv.exe`, pick the Links shim again; MCP For Unity saves a pinned override and will stop auto-rewrites.
 - If neither Links path exists, a reasonable fallback is `~/.local/bin/uv.exe` (uv tools bin) or a Scoop shim, but Links is preferred for stability.
 

--- a/CursorHelp.md
+++ b/CursorHelp.md
@@ -21,7 +21,7 @@
 3) If uv is already found but wrong, still click “Choose `uv` Install Location” and select the `Links\uv.exe` path above. This saves a persistent override.
 4) Click “Auto Configure” (or re-open the client) and restart Cursor.
 
-This sets an override stored in the Editor (key: `MCPForUnity.UvPath`) so UnityMCP won’t auto-rewrite the config back to a different `uv.exe` later.
+This sets an override stored in the Editor (key: `MCPForUnity.UvPath`) so MCP for Unity won’t auto-rewrite the config back to a different `uv.exe` later.
 
 #### Verify the fix
 - Confirm global Cursor config is at: `%USERPROFILE%\\.cursor\\mcp.json`

--- a/CursorHelp.md
+++ b/CursorHelp.md
@@ -21,7 +21,7 @@
 3) If uv is already found but wrong, still click “Choose `uv` Install Location” and select the `Links\uv.exe` path above. This saves a persistent override.
 4) Click “Auto Configure” (or re-open the client) and restart Cursor.
 
-This sets an override stored in the Editor (key: `UnityMCP.UvPath`) so UnityMCP won’t auto-rewrite the config back to a different `uv.exe` later.
+This sets an override stored in the Editor (key: `MCPForUnity.UvPath`) so UnityMCP won’t auto-rewrite the config back to a different `uv.exe` later.
 
 #### Verify the fix
 - Confirm global Cursor config is at: `%USERPROFILE%\\.cursor\\mcp.json`

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,16 +1,16 @@
-# MCP For Unity Development Tools
+# MCP for Unity Development Tools
 
-Welcome to the MCP For Unity development environment! This directory contains tools and utilities to streamline MCP For Unity core development.
+Welcome to the MCP for Unity development environment! This directory contains tools and utilities to streamline MCP for Unity core development.
 
 ## 🚀 Available Development Features
 
 ### ✅ Development Deployment Scripts
-Quick deployment and testing tools for MCP For Unity core changes.
+Quick deployment and testing tools for MCP for Unity core changes.
 
 ### 🔄 Coming Soon
 - **Development Mode Toggle**: Built-in Unity editor development features
 - **Hot Reload System**: Real-time code updates without Unity restarts  
-- **Plugin Development Kit**: Tools for creating custom MCP For Unity extensions
+- **Plugin Development Kit**: Tools for creating custom MCP for Unity extensions
 - **Automated Testing Suite**: Comprehensive testing framework for contributions
 - **Debug Dashboard**: Advanced debugging and monitoring tools
 
@@ -18,7 +18,7 @@ Quick deployment and testing tools for MCP For Unity core changes.
 
 ## Development Deployment Scripts
 
-These deployment scripts help you quickly test changes to MCP For Unity core code.
+These deployment scripts help you quickly test changes to MCP for Unity core code.
 
 ## Scripts
 
@@ -60,7 +60,7 @@ X:\UnityProject\Library\PackageCache\com.coplaydev.unity-mcp@272123cfd97e
 
 To find it reliably:
 1. Open Unity Package Manager
-2. Select "MCP For Unity" package
+2. Select "MCP for Unity" package
 3. Right click the package and choose "Show in Explorer"
 4. That opens the exact cache folder Unity is using for your project
 
@@ -77,7 +77,7 @@ Note: In recent builds, the Python server sources are also bundled inside the pa
 
 ## Switching MCP package sources quickly
 
-Use `mcp_source.py` to quickly switch between different MCP For Unity package sources:
+Use `mcp_source.py` to quickly switch between different MCP for Unity package sources:
 
 **Usage:**
 ```bash
@@ -96,7 +96,7 @@ After switching, open Package Manager and Refresh to re-resolve packages.
 
 ### "Path not found" errors running the .bat file
 - Verify Unity package cache path is correct
-- Check that MCP For Unity package is actually installed
+- Check that MCP for Unity package is actually installed
 - Ensure server is installed via MCP client
 
 ### "Permission denied" errors

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -110,4 +110,4 @@ After switching, open Package Manager and Refresh to re-resolve packages.
 - Verify backup directory path is correct
 
 ### Windows uv path issues
-- On Windows, when testing GUI clients, prefer the WinGet Links `uv.exe`; if multiple `uv.exe` exist, use "Choose UV Install Location" to pin the Links shim.
+- On Windows, when testing GUI clients, prefer the WinGet Links `uv.exe`; if multiple `uv.exe` exist, use "Choose `uv` Install Location" to pin the Links shim.

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,16 +1,16 @@
-# Unity MCP Development Tools
+# MCP For Unity Development Tools
 
-Welcome to the Unity MCP development environment! This directory contains tools and utilities to streamline Unity MCP core development.
+Welcome to the MCP For Unity development environment! This directory contains tools and utilities to streamline MCP For Unity core development.
 
 ## 🚀 Available Development Features
 
 ### ✅ Development Deployment Scripts
-Quick deployment and testing tools for Unity MCP core changes.
+Quick deployment and testing tools for MCP For Unity core changes.
 
 ### 🔄 Coming Soon
 - **Development Mode Toggle**: Built-in Unity editor development features
 - **Hot Reload System**: Real-time code updates without Unity restarts  
-- **Plugin Development Kit**: Tools for creating custom Unity MCP extensions
+- **Plugin Development Kit**: Tools for creating custom MCP For Unity extensions
 - **Automated Testing Suite**: Comprehensive testing framework for contributions
 - **Debug Dashboard**: Advanced debugging and monitoring tools
 
@@ -18,7 +18,7 @@ Quick deployment and testing tools for Unity MCP core changes.
 
 ## Development Deployment Scripts
 
-These deployment scripts help you quickly test changes to Unity MCP core code.
+These deployment scripts help you quickly test changes to MCP For Unity core code.
 
 ## Scripts
 
@@ -60,7 +60,7 @@ X:\UnityProject\Library\PackageCache\com.coplaydev.unity-mcp@272123cfd97e
 
 To find it reliably:
 1. Open Unity Package Manager
-2. Select "Unity MCP" package
+2. Select "MCP For Unity" package
 3. Right click the package and choose "Show in Explorer"
 4. That opens the exact cache folder Unity is using for your project
 
@@ -77,7 +77,7 @@ Note: In recent builds, the Python server sources are also bundled inside the pa
 
 ## Switching MCP package sources quickly
 
-Use `mcp_source.py` to quickly switch between different Unity MCP package sources:
+Use `mcp_source.py` to quickly switch between different MCP For Unity package sources:
 
 **Usage:**
 ```bash
@@ -96,7 +96,7 @@ After switching, open Package Manager and Refresh to re-resolve packages.
 
 ### "Path not found" errors running the .bat file
 - Verify Unity package cache path is correct
-- Check that Unity MCP package is actually installed
+- Check that MCP For Unity package is actually installed
 - Ensure server is installed via MCP client
 
 ### "Permission denied" errors

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MCP For Unity ✨
+# MCP for Unity ✨
 
 #### Proudly sponsored and maintained by [Coplay](https://www.coplay.dev/?ref=unity-mcp), the AI assistant for Unity. [Read the backstory here.](https://www.coplay.dev/blog/coplay-and-open-source-unity-mcp-join-forces)
 
@@ -13,13 +13,13 @@
 
 **Create your Unity apps with LLMs!**
 
-MCP For Unity acts as a bridge, allowing AI assistants (like Claude, Cursor) to interact directly with your Unity Editor via a local **MCP (Model Context Protocol) Client**. Give your LLM tools to manage assets, control scenes, edit scripts, and automate tasks within Unity.
+MCP for Unity acts as a bridge, allowing AI assistants (like Claude, Cursor) to interact directly with your Unity Editor via a local **MCP (Model Context Protocol) Client**. Give your LLM tools to manage assets, control scenes, edit scripts, and automate tasks within Unity.
 
 ## 💬 Join Our Community
 
 ### [Discord](https://discord.gg/y4p8KfzrN4)
 
-**Get help, share ideas, and collaborate with other MCP For Unity developers!**  
+**Get help, share ideas, and collaborate with other MCP for Unity developers!**  
 
 ---
 
@@ -49,12 +49,12 @@ MCP For Unity acts as a bridge, allowing AI assistants (like Claude, Cursor) to 
 
 ## How It Works 🤔
 
-MCP For Unity connects your tools using two components:
+MCP for Unity connects your tools using two components:
 
-1.  **MCP For Unity Bridge:** A Unity package running inside the Editor. (Installed via Package Manager).
-2.  **MCP For Unity Server:** A Python server that runs locally, communicating between the Unity Bridge and your MCP Client. (Installed automatically by the package on first run or via Auto-Setup; manual setup is available as a fallback).
+1.  **MCP for Unity Bridge:** A Unity package running inside the Editor. (Installed via Package Manager).
+2.  **MCP for Unity Server:** A Python server that runs locally, communicating between the Unity Bridge and your MCP Client. (Installed automatically by the package on first run or via Auto-Setup; manual setup is available as a fallback).
 
-**Flow:** `[Your LLM via MCP Client] <-> [MCP For Unity Server (Python)] <-> [MCP For Unity Bridge (Unity Editor)]`
+**Flow:** `[Your LLM via MCP Client] <-> [MCP for Unity Server (Python)] <-> [MCP for Unity Bridge (Unity Editor)]`
 
 ---
 
@@ -129,14 +129,14 @@ Connect your MCP Client (Claude, Cursor, etc.) to the Python server set up in St
 
 **Option A: Auto-Setup (Recommended for Claude/Cursor/VSC Copilot)**
 
-1.  In Unity, go to `Window > MCP For Unity`.
+1.  In Unity, go to `Window > MCP for Unity`.
 2.  Click `Auto-Setup`.
 3.  Look for a green status indicator 🟢 and "Connected ✓". *(This attempts to modify the MCP Client\'s config file automatically).* 
 
 <details><summary><strong>Client-specific troubleshooting</strong></summary>
 
-  - **VSCode**: uses `Code/User/mcp.json` with top-level `servers.unityMCP` and `"type": "stdio"`. On Windows, MCP For Unity writes an absolute `uv.exe` (prefers WinGet Links shim) to avoid PATH issues.
-  - **Cursor / Windsurf** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf): if `uv` is missing, the MCP For Unity window shows "uv Not Found" with a quick [HELP] link and a "Choose `uv` Install Location" button.
+  - **VSCode**: uses `Code/User/mcp.json` with top-level `servers.unityMCP` and `"type": "stdio"`. On Windows, MCP for Unity writes an absolute `uv.exe` (prefers WinGet Links shim) to avoid PATH issues.
+  - **Cursor / Windsurf** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf): if `uv` is missing, the MCP for Unity window shows "uv Not Found" with a quick [HELP] link and a "Choose `uv` Install Location" button.
   - **Claude Code** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/2.-Fix-Unity-MCP-and-Claude-Code): if `claude` isn't found, the window shows "Claude Not Found" with [HELP] and a "Choose Claude Location" button. Unregister now updates the UI immediately.</details>
 
 
@@ -252,9 +252,9 @@ claude mcp add UnityMCP -- "C:/Users/USERNAME/AppData/Roaming/Python/Python313/S
 
 ## Usage ▶️
 
-1. **Open your Unity Project.** The MCP For Unity package should connect automatically. Check status via Window > MCP For Unity.
+1. **Open your Unity Project.** The MCP for Unity package should connect automatically. Check status via Window > MCP for Unity.
     
-2. **Start your MCP Client** (Claude, Cursor, etc.). It should automatically launch the MCP For Unity Server (Python) using the configuration from Installation Step 2.
+2. **Start your MCP Client** (Claude, Cursor, etc.). It should automatically launch the MCP for Unity Server (Python) using the configuration from Installation Step 2.
     
 3. **Interact!** Unity tools should now be available in your MCP Client.
     
@@ -304,9 +304,9 @@ claude mcp add UnityMCP -- "C:/Users/USERNAME/AppData/Roaming/Python/Python313/S
 
 ### Development Tools
 
-If you\'re contributing to MCP For Unity or want to test core changes, we have development tools to streamline your workflow:
+If you\'re contributing to MCP for Unity or want to test core changes, we have development tools to streamline your workflow:
 
-- **Development Deployment Scripts**: Quickly deploy and test your changes to MCP For Unity Bridge and Python Server
+- **Development Deployment Scripts**: Quickly deploy and test your changes to MCP for Unity Bridge and Python Server
 - **Automatic Backup System**: Safe testing with easy rollback capabilities  
 - **Hot Reload Workflow**: Fast iteration cycle for core development
 - **More coming!**
@@ -315,7 +315,7 @@ If you\'re contributing to MCP For Unity or want to test core changes, we have d
 
 ### Contributing 🤝
 
-Help make MCP For Unity better!
+Help make MCP for Unity better!
 
 1. **Fork** the main repository.
     
@@ -338,7 +338,7 @@ Help make MCP For Unity better!
 
 - **Unity Bridge Not Running/Connecting:**
     - Ensure Unity Editor is open.
-    - Check the status window: Window > MCP For Unity.
+    - Check the status window: Window > MCP for Unity.
     - Restart Unity.
 - **MCP Client Not Connecting / Server Not Starting:**
     - **Verify Server Path:** Double-check the --directory path in your MCP Client\'s JSON config. It must exactly match the location where you cloned the UnityMCP repository in Installation Step 1 (e.g., .../Programs/UnityMCP/UnityMcpServer/src).

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ claude mcp add UnityMCP -- "C:/Users/USERNAME/AppData/Roaming/Python/Python313/S
 
 1. **Open your Unity Project.** The MCP For Unity package should connect automatically. Check status via Window > MCP For Unity.
     
-2. **Start your MCP Client** (Claude, Cursor, etc.). It should automatically launch the MCP For Unity Server (Python) using the configuration from Installation Step 3.
+2. **Start your MCP Client** (Claude, Cursor, etc.). It should automatically launch the MCP For Unity Server (Python) using the configuration from Installation Step 2.
     
 3. **Interact!** Unity tools should now be available in your MCP Client.
     

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unity MCP ✨
+# MCP For Unity ✨
 
 #### Proudly sponsored and maintained by [Coplay](https://www.coplay.dev/?ref=unity-mcp), the AI assistant for Unity. [Read the backstory here.](https://www.coplay.dev/blog/coplay-and-open-source-unity-mcp-join-forces)
 
@@ -13,13 +13,13 @@
 
 **Create your Unity apps with LLMs!**
 
-Unity MCP acts as a bridge, allowing AI assistants (like Claude, Cursor) to interact directly with your Unity Editor via a local **MCP (Model Context Protocol) Client**. Give your LLM tools to manage assets, control scenes, edit scripts, and automate tasks within Unity.
+MCP For Unity acts as a bridge, allowing AI assistants (like Claude, Cursor) to interact directly with your Unity Editor via a local **MCP (Model Context Protocol) Client**. Give your LLM tools to manage assets, control scenes, edit scripts, and automate tasks within Unity.
 
 ## 💬 Join Our Community
 
 ### [Discord](https://discord.gg/y4p8KfzrN4)
 
-**Get help, share ideas, and collaborate with other Unity MCP developers!**  
+**Get help, share ideas, and collaborate with other MCP For Unity developers!**  
 
 ---
 
@@ -49,12 +49,12 @@ Unity MCP acts as a bridge, allowing AI assistants (like Claude, Cursor) to inte
 
 ## How It Works 🤔
 
-Unity MCP connects your tools using two components:
+MCP For Unity connects your tools using two components:
 
-1.  **Unity MCP Bridge:** A Unity package running inside the Editor. (Installed via Package Manager).
-2.  **Unity MCP Server:** A Python server that runs locally, communicating between the Unity Bridge and your MCP Client. (Installed manually).
+1.  **MCP For Unity Bridge:** A Unity package running inside the Editor. (Installed via Package Manager).
+2.  **MCP For Unity Server:** A Python server that runs locally, communicating between the Unity Bridge and your MCP Client. (Installed manually).
 
-**Flow:** `[Your LLM via MCP Client] <-> [Unity MCP Server (Python)] <-> [Unity MCP Bridge (Unity Editor)]`
+**Flow:** `[Your LLM via MCP Client] <-> [MCP For Unity Server (Python)] <-> [MCP For Unity Bridge (Unity Editor)]`
 
 ---
 
@@ -125,18 +125,18 @@ Unity MCP connects your tools using two components:
 
 Connect your MCP Client (Claude, Cursor, etc.) to the Python server you installed in Step 1.
 
-<img width="648" height="599" alt="UnityMCP-Readme-Image" src="https://github.com/user-attachments/assets/b4a725da-5c43-4bd6-80d6-ee2e3cca9596" />
+<img width="648" height="599" alt="MCPForUnity-Readme-Image" src="https://github.com/user-attachments/assets/b4a725da-5c43-4bd6-80d6-ee2e3cca9596" />
 
 **Option A: Auto-Setup (Recommended for Claude/Cursor/VSC Copilot)**
 
-1.  In Unity, go to `Window > Unity MCP`.
+1.  In Unity, go to `Window > MCP For Unity`.
 2.  Click `Auto-Setup`.
 3.  Look for a green status indicator 🟢 and "Connected ✓". *(This attempts to modify the MCP Client\'s config file automatically).* 
 
 <details><summary><strong>Client-specific troubleshooting</strong></summary>
 
-  - **VSCode**: uses `Code/User/mcp.json` with top-level `servers.unityMCP` and `"type": "stdio"`. On Windows, Unity MCP writes an absolute `uv.exe` (prefers WinGet Links shim) to avoid PATH issues.
-  - **Cursor / Windsurf** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf): if `uv` is missing, the Unity MCP window shows "uv Not Found" with a quick [HELP] link and a "Choose UV Install Location" button.
+  - **VSCode**: uses `Code/User/mcp.json` with top-level `servers.unityMCP` and `"type": "stdio"`. On Windows, MCP For Unity writes an absolute `uv.exe` (prefers WinGet Links shim) to avoid PATH issues.
+  - **Cursor / Windsurf** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf): if `uv` is missing, the MCP For Unity window shows "uv Not Found" with a quick [HELP] link and a "Choose UV Install Location" button.
   - **Claude Code** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/2.-Fix-Unity-MCP-and-Claude-Code): if `claude` isn't found, the window shows "Claude Not Found" with [HELP] and a "Choose Claude Location" button. Unregister now updates the UI immediately.</details>
 
 
@@ -252,9 +252,9 @@ claude mcp add UnityMCP -- "C:/Users/USERNAME/AppData/Roaming/Python/Python313/S
 
 ## Usage ▶️
 
-1. **Open your Unity Project.** The Unity MCP Bridge (package) should connect automatically. Check status via Window > Unity MCP.
+1. **Open your Unity Project.** The MCP For Unity package should connect automatically. Check status via Window > MCP For Unity.
     
-2. **Start your MCP Client** (Claude, Cursor, etc.). It should automatically launch the Unity MCP Server (Python) using the configuration from Installation Step 3.
+2. **Start your MCP Client** (Claude, Cursor, etc.). It should automatically launch the MCP For Unity Server (Python) using the configuration from Installation Step 3.
     
 3. **Interact!** Unity tools should now be available in your MCP Client.
     
@@ -304,9 +304,9 @@ claude mcp add UnityMCP -- "C:/Users/USERNAME/AppData/Roaming/Python/Python313/S
 
 ### Development Tools
 
-If you\'re contributing to Unity MCP or want to test core changes, we have development tools to streamline your workflow:
+If you\'re contributing to MCP For Unity or want to test core changes, we have development tools to streamline your workflow:
 
-- **Development Deployment Scripts**: Quickly deploy and test your changes to Unity MCP Bridge and Python Server
+- **Development Deployment Scripts**: Quickly deploy and test your changes to MCP For Unity Bridge and Python Server
 - **Automatic Backup System**: Safe testing with easy rollback capabilities  
 - **Hot Reload Workflow**: Fast iteration cycle for core development
 - **More coming!**
@@ -315,7 +315,7 @@ If you\'re contributing to Unity MCP or want to test core changes, we have devel
 
 ### Contributing 🤝
 
-Help make Unity MCP better!
+Help make MCP For Unity better!
 
 1. **Fork** the main repository.
     
@@ -338,7 +338,7 @@ Help make Unity MCP better!
 
 - **Unity Bridge Not Running/Connecting:**
     - Ensure Unity Editor is open.
-    - Check the status window: Window > Unity MCP.
+    - Check the status window: Window > MCP For Unity.
     - Restart Unity.
 - **MCP Client Not Connecting / Server Not Starting:**
     - **Verify Server Path:** Double-check the --directory path in your MCP Client\'s JSON config. It must exactly match the location where you cloned the UnityMCP repository in Installation Step 1 (e.g., .../Programs/UnityMCP/UnityMcpServer/src).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ MCP For Unity acts as a bridge, allowing AI assistants (like Claude, Cursor) to 
 MCP For Unity connects your tools using two components:
 
 1.  **MCP For Unity Bridge:** A Unity package running inside the Editor. (Installed via Package Manager).
-2.  **MCP For Unity Server:** A Python server that runs locally, communicating between the Unity Bridge and your MCP Client. (Installed manually).
+2.  **MCP For Unity Server:** A Python server that runs locally, communicating between the Unity Bridge and your MCP Client. (Installed automatically by the package on first run or via Auto-Setup; manual setup is available as a fallback).
 
 **Flow:** `[Your LLM via MCP Client] <-> [MCP For Unity Server (Python)] <-> [MCP For Unity Bridge (Unity Editor)]`
 
@@ -111,7 +111,7 @@ MCP For Unity connects your tools using two components:
     https://github.com/CoplayDev/unity-mcp.git?path=/UnityMcpBridge
     ```
 5.  Click `Add`.
-6. The MCP Server should automatically be installed onto your machine as a result of this process.
+6. The MCP server is installed automatically by the package on first run or via Auto-Setup. If that fails, use Manual Configuration (below).
 
 #### To install via OpenUPM
 
@@ -123,7 +123,7 @@ MCP For Unity connects your tools using two components:
 
 ### Step 2: Configure Your MCP Client
 
-Connect your MCP Client (Claude, Cursor, etc.) to the Python server you installed in Step 1.
+Connect your MCP Client (Claude, Cursor, etc.) to the Python server set up in Step 1 (auto) or via Manual Configuration (below).
 
 <img width="648" height="599" alt="MCPForUnity-Readme-Image" src="https://github.com/user-attachments/assets/b4a725da-5c43-4bd6-80d6-ee2e3cca9596" />
 
@@ -136,7 +136,7 @@ Connect your MCP Client (Claude, Cursor, etc.) to the Python server you installe
 <details><summary><strong>Client-specific troubleshooting</strong></summary>
 
   - **VSCode**: uses `Code/User/mcp.json` with top-level `servers.unityMCP` and `"type": "stdio"`. On Windows, MCP For Unity writes an absolute `uv.exe` (prefers WinGet Links shim) to avoid PATH issues.
-  - **Cursor / Windsurf** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf): if `uv` is missing, the MCP For Unity window shows "uv Not Found" with a quick [HELP] link and a "Choose UV Install Location" button.
+  - **Cursor / Windsurf** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf): if `uv` is missing, the MCP For Unity window shows "uv Not Found" with a quick [HELP] link and a "Choose `uv` Install Location" button.
   - **Claude Code** [(**help link**)](https://github.com/CoplayDev/unity-mcp/wiki/2.-Fix-Unity-MCP-and-Claude-Code): if `claude` isn't found, the window shows "Claude Not Found" with [HELP] and a "Choose Claude Location" button. Unregister now updates the UI immediately.</details>
 
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/CommandRegistryTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/CommandRegistryTests.cs
@@ -1,9 +1,9 @@
 using System;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using UnityMcpBridge.Editor.Tools;
+using MCPForUnity.Editor.Tools;
 
-namespace UnityMCPTests.EditMode
+namespace MCPForUnityTests.Editor
 {
     public class CommandRegistryTests
     {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/MCPForUnityTests.Editor.asmdef
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/MCPForUnityTests.Editor.asmdef
@@ -1,8 +1,8 @@
 {
-  "name": "UnityMCPTests.EditMode",
+  "name": "MCPForUnityTests.EditMode",
   "rootNamespace": "",
   "references": [
-    "UnityMcpBridge.Editor",
+    "MCPForUnity.Editor",
     "UnityEngine.TestRunner",
     "UnityEditor.TestRunner"
   ],

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/MCPForUnityTests.Editor.asmdef.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/MCPForUnityTests.Editor.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b28bd738cf38847dfa90ffcbfb130965
+guid: 32956d76430ba4ea4a794f28ee983d16
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/UnityMcpBridge/Documentation.meta
+++ b/UnityMcpBridge/Documentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ffd4d8a39e99432c81ef0a5d1eb8d39
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityMcpBridge/Documentation.meta
+++ b/UnityMcpBridge/Documentation.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 2ffd4d8a39e99432c81ef0a5d1eb8d39
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/UnityMcpBridge/Editor/Data/DefaultServerConfig.cs
+++ b/UnityMcpBridge/Editor/Data/DefaultServerConfig.cs
@@ -1,6 +1,6 @@
-using UnityMcpBridge.Editor.Models;
+using MCPForUnity.Editor.Models;
 
-namespace UnityMcpBridge.Editor.Data
+namespace MCPForUnity.Editor.Data
 {
     public class DefaultServerConfig : ServerConfig
     {

--- a/UnityMcpBridge/Editor/Data/McpClients.cs
+++ b/UnityMcpBridge/Editor/Data/McpClients.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityMcpBridge.Editor.Models;
+using MCPForUnity.Editor.Models;
 
-namespace UnityMcpBridge.Editor.Data
+namespace MCPForUnity.Editor.Data
 {
     public class McpClients
     {

--- a/UnityMcpBridge/Editor/Helpers/ExecPath.cs
+++ b/UnityMcpBridge/Editor/Helpers/ExecPath.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using UnityEditor;
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     internal static class ExecPath
     {

--- a/UnityMcpBridge/Editor/Helpers/ExecPath.cs
+++ b/UnityMcpBridge/Editor/Helpers/ExecPath.cs
@@ -10,7 +10,7 @@ namespace MCPForUnity.Editor.Helpers
 {
     internal static class ExecPath
     {
-        private const string PrefClaude = "UnityMCP.ClaudeCliPath";
+        private const string PrefClaude = "MCPForUnity.ClaudeCliPath";
 
         // Resolve Claude CLI absolute path. Pref → env → common locations → PATH.
         internal static string ResolveClaude()

--- a/UnityMcpBridge/Editor/Helpers/GameObjectSerializer.cs
+++ b/UnityMcpBridge/Editor/Helpers/GameObjectSerializer.cs
@@ -6,9 +6,9 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Runtime.Serialization; // For Converters
+using MCPForUnity.Runtime.Serialization; // For Converters
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     /// <summary>
     /// Handles serialization of GameObjects and Components for MCP responses.

--- a/UnityMcpBridge/Editor/Helpers/PackageInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/PackageInstaller.cs
@@ -25,18 +25,18 @@ namespace MCPForUnity.Editor.Helpers
         {
             try
             {
-                Debug.Log("<b><color=#2EA3FF>UNITY-MCP</color></b>: Installing Python server...");
+                Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Installing Python server...");
                 ServerInstaller.EnsureServerInstalled();
                 
                 // Mark as installed
                 EditorPrefs.SetBool(InstallationFlagKey, true);
                 
-                Debug.Log("<b><color=#2EA3FF>UNITY-MCP</color></b>: Python server installation completed successfully.");
+                Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Python server installation completed successfully.");
             }
             catch (System.Exception ex)
             {
-                Debug.LogError($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Failed to install Python server: {ex.Message}");
-                Debug.LogWarning("<b><color=#2EA3FF>UNITY-MCP</color></b>: You may need to manually install the Python server. Check the Unity MCP Editor Window for instructions.");
+                Debug.LogError($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Failed to install Python server: {ex.Message}");
+                Debug.LogWarning("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: You may need to manually install the Python server. Check the MCP for Unity Editor Window for instructions.");
             }
         }
     }

--- a/UnityMcpBridge/Editor/Helpers/PackageInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/PackageInstaller.cs
@@ -1,7 +1,7 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     /// <summary>
     /// Handles automatic installation of the Python server when the package is first installed.

--- a/UnityMcpBridge/Editor/Helpers/PackageInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/PackageInstaller.cs
@@ -9,7 +9,7 @@ namespace MCPForUnity.Editor.Helpers
     [InitializeOnLoad]
     public static class PackageInstaller
     {
-        private const string InstallationFlagKey = "UnityMCP.ServerInstalled";
+        private const string InstallationFlagKey = "MCPForUnity.ServerInstalled";
         
         static PackageInstaller()
         {

--- a/UnityMcpBridge/Editor/Helpers/PortManager.cs
+++ b/UnityMcpBridge/Editor/Helpers/PortManager.cs
@@ -18,7 +18,7 @@ namespace MCPForUnity.Editor.Helpers
     {
         private static bool IsDebugEnabled()
         {
-            try { return EditorPrefs.GetBool("UnityMCP.DebugLogs", false); }
+            try { return EditorPrefs.GetBool("MCPForUnity.DebugLogs", false); }
             catch { return false; }
         }
 

--- a/UnityMcpBridge/Editor/Helpers/PortManager.cs
+++ b/UnityMcpBridge/Editor/Helpers/PortManager.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 namespace MCPForUnity.Editor.Helpers
 {
     /// <summary>
-    /// Manages dynamic port allocation and persistent storage for Unity MCP Bridge
+    /// Manages dynamic port allocation and persistent storage for MCP for Unity
     /// </summary>
     public static class PortManager
     {
@@ -131,21 +131,21 @@ namespace MCPForUnity.Editor.Helpers
         }
 
         /// <summary>
-        /// Check if a port is currently being used by Unity MCP Bridge
+        /// Check if a port is currently being used by MCP for Unity
         /// This helps avoid unnecessary port changes when Unity itself is using the port
         /// </summary>
         /// <param name="port">Port to check</param>
-        /// <returns>True if port appears to be used by Unity MCP</returns>
+        /// <returns>True if port appears to be used by MCP for Unity</returns>
         public static bool IsPortUsedByUnityMcp(int port)
         {
             try
             {
-                // Try to make a quick connection to see if it's a Unity MCP server
+                // Try to make a quick connection to see if it's an MCP for Unity server
                 using var client = new TcpClient();
                 var connectTask = client.ConnectAsync(IPAddress.Loopback, port);
                 if (connectTask.Wait(100)) // 100ms timeout
                 {
-                    // If connection succeeded, it's likely the Unity MCP server
+                    // If connection succeeded, it's likely the MCP for Unity server
                     return client.Connected;
                 }
                 return false;

--- a/UnityMcpBridge/Editor/Helpers/PortManager.cs
+++ b/UnityMcpBridge/Editor/Helpers/PortManager.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     /// <summary>
     /// Manages dynamic port allocation and persistent storage for Unity MCP Bridge

--- a/UnityMcpBridge/Editor/Helpers/PortManager.cs
+++ b/UnityMcpBridge/Editor/Helpers/PortManager.cs
@@ -48,7 +48,7 @@ namespace MCPForUnity.Editor.Helpers
                 string.Equals(storedConfig.project_path ?? string.Empty, Application.dataPath ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
                 IsPortAvailable(storedConfig.unity_port))
             {
-                if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Using stored port {storedConfig.unity_port} for current project");
+                if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Using stored port {storedConfig.unity_port} for current project");
                 return storedConfig.unity_port;
             }
 
@@ -57,7 +57,7 @@ namespace MCPForUnity.Editor.Helpers
             {
                 if (WaitForPortRelease(storedConfig.unity_port, 1500))
                 {
-                    if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Stored port {storedConfig.unity_port} became available after short wait");
+                    if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Stored port {storedConfig.unity_port} became available after short wait");
                     return storedConfig.unity_port;
                 }
                 // Prefer sticking to the same port; let the caller handle bind retries/fallbacks
@@ -78,7 +78,7 @@ namespace MCPForUnity.Editor.Helpers
         {
             int newPort = FindAvailablePort();
             SavePort(newPort);
-            if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Discovered and saved new port: {newPort}");
+            if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Discovered and saved new port: {newPort}");
             return newPort;
         }
 
@@ -91,18 +91,18 @@ namespace MCPForUnity.Editor.Helpers
             // Always try default port first
             if (IsPortAvailable(DefaultPort))
             {
-                if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Using default port {DefaultPort}");
+                if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Using default port {DefaultPort}");
                 return DefaultPort;
             }
 
-            if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Default port {DefaultPort} is in use, searching for alternative...");
+            if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Default port {DefaultPort} is in use, searching for alternative...");
 
             // Search for alternatives
             for (int port = DefaultPort + 1; port < DefaultPort + MaxPortAttempts; port++)
             {
                 if (IsPortAvailable(port))
                 {
-                    if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Found available port {port}");
+                    if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Found available port {port}");
                     return port;
                 }
             }
@@ -211,7 +211,7 @@ namespace MCPForUnity.Editor.Helpers
                 string legacy = Path.Combine(GetRegistryDirectory(), RegistryFileName);
                 File.WriteAllText(legacy, json);
 
-                if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: Saved port {port} to storage");
+                if (IsDebugEnabled()) Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Saved port {port} to storage");
             }
             catch (Exception ex)
             {

--- a/UnityMcpBridge/Editor/Helpers/PortManager.cs
+++ b/UnityMcpBridge/Editor/Helpers/PortManager.cs
@@ -136,7 +136,7 @@ namespace MCPForUnity.Editor.Helpers
         /// </summary>
         /// <param name="port">Port to check</param>
         /// <returns>True if port appears to be used by MCP for Unity</returns>
-        public static bool IsPortUsedByUnityMcp(int port)
+        public static bool IsPortUsedByMCPForUnity(int port)
         {
             try
             {
@@ -173,7 +173,7 @@ namespace MCPForUnity.Editor.Helpers
                 }
 
                 // If the port is in use by an MCP instance, continue waiting briefly
-                if (!IsPortUsedByUnityMcp(port))
+                if (!IsPortUsedByMCPForUnity(port))
                 {
                     // In use by something else; don't keep waiting
                     return false;

--- a/UnityMcpBridge/Editor/Helpers/Response.cs
+++ b/UnityMcpBridge/Editor/Helpers/Response.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     /// <summary>
     /// Provides static methods for creating standardized success and error response objects.

--- a/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
@@ -13,7 +13,7 @@ namespace MCPForUnity.Editor.Helpers
         private const string ServerFolder = "UnityMcpServer";
 
         /// <summary>
-        /// Ensures the unity-mcp-server is installed locally by copying from the embedded package source.
+        /// Ensures the mcp-for-unity-server is installed locally by copying from the embedded package source.
         /// No network calls or Git operations are performed.
         /// </summary>
         public static void EnsureServerInstalled()

--- a/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
@@ -49,7 +49,7 @@ namespace MCPForUnity.Editor.Helpers
 
                 if (hasInstalled || TryGetEmbeddedServerSource(out _))
                 {
-                    Debug.LogWarning($"MCP For Unity: Using existing server; skipped install. Details: {ex.Message}");
+                    Debug.LogWarning($"MCP for Unity: Using existing server; skipped install. Details: {ex.Message}");
                     return;
                 }
 

--- a/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
@@ -246,7 +246,7 @@ namespace MCPForUnity.Editor.Helpers
                     return false;
                 }
 
-                Debug.Log("<b><color=#2EA3FF>UNITY-MCP</color></b>: Python environment repaired successfully.");
+                Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Python environment repaired successfully.");
                 return true;
             }
             catch (Exception ex)

--- a/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
@@ -5,7 +5,7 @@ using System.Text;
 using UnityEditor;
 using UnityEngine;
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     public static class ServerInstaller
     {

--- a/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
@@ -49,7 +49,7 @@ namespace MCPForUnity.Editor.Helpers
 
                 if (hasInstalled || TryGetEmbeddedServerSource(out _))
                 {
-                    Debug.LogWarning($"UnityMCP: Using existing server; skipped install. Details: {ex.Message}");
+                    Debug.LogWarning($"MCP For Unity: Using existing server; skipped install. Details: {ex.Message}");
                     return;
                 }
 
@@ -261,7 +261,7 @@ namespace MCPForUnity.Editor.Helpers
             // Allow user override via EditorPrefs
             try
             {
-                string overridePath = EditorPrefs.GetString("UnityMCP.UvPath", string.Empty);
+                string overridePath = EditorPrefs.GetString("MCPForUnity.UvPath", string.Empty);
                 if (!string.IsNullOrEmpty(overridePath) && File.Exists(overridePath))
                 {
                     if (ValidateUvBinary(overridePath)) return overridePath;

--- a/UnityMcpBridge/Editor/Helpers/ServerPathResolver.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerPathResolver.cs
@@ -3,7 +3,7 @@ using System.IO;
 using UnityEditor;
 using UnityEngine;
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     public static class ServerPathResolver
     {

--- a/UnityMcpBridge/Editor/Helpers/ServerPathResolver.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerPathResolver.cs
@@ -113,7 +113,7 @@ namespace MCPForUnity.Editor.Helpers
             if (warnOnLegacyPackageId && p.name == LegacyId)
             {
                 Debug.LogWarning(
-                    "MCP For Unity: Detected legacy package id 'com.justinpbarnett.unity-mcp'. " +
+                    "MCP for Unity: Detected legacy package id 'com.justinpbarnett.unity-mcp'. " +
                     "Please update Packages/manifest.json to 'com.coplaydev.unity-mcp' to avoid future breakage.");
             }
 

--- a/UnityMcpBridge/Editor/Helpers/ServerPathResolver.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerPathResolver.cs
@@ -113,7 +113,7 @@ namespace MCPForUnity.Editor.Helpers
             if (warnOnLegacyPackageId && p.name == LegacyId)
             {
                 Debug.LogWarning(
-                    "UnityMCP: Detected legacy package id 'com.justinpbarnett.unity-mcp'. " +
+                    "MCP For Unity: Detected legacy package id 'com.justinpbarnett.unity-mcp'. " +
                     "Please update Packages/manifest.json to 'com.coplaydev.unity-mcp' to avoid future breakage.");
             }
 

--- a/UnityMcpBridge/Editor/Helpers/Vector3Helper.cs
+++ b/UnityMcpBridge/Editor/Helpers/Vector3Helper.cs
@@ -1,7 +1,7 @@
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 
-namespace UnityMcpBridge.Editor.Helpers
+namespace MCPForUnity.Editor.Helpers
 {
     /// <summary>
     /// Helper class for Vector3 operations

--- a/UnityMcpBridge/Editor/MCPForUnity.Editor.asmdef
+++ b/UnityMcpBridge/Editor/MCPForUnity.Editor.asmdef
@@ -1,8 +1,8 @@
 {
-    "name": "UnityMcpBridge.Editor",
-    "rootNamespace": "UnityMcpBridge.Editor",
+    "name": "MCPForUnity.Editor",
+    "rootNamespace": "MCPForUnity.Editor",
     "references": [
-        "UnityMcpBridge.Runtime",
+        "MCPForUnity.Runtime",
         "GUID:560b04d1a97f54a46a2660c3cc343a6f" 
     ],
     "includePlatforms": [

--- a/UnityMcpBridge/Editor/MCPForUnity.Editor.asmdef.meta
+++ b/UnityMcpBridge/Editor/MCPForUnity.Editor.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 04b0581466993404a8fae14802c2a5a6
+guid: 98f702da6ca044be59a864a9419c4eab
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/UnityMcpBridge/Editor/MCPForUnityBridge.cs
+++ b/UnityMcpBridge/Editor/MCPForUnityBridge.cs
@@ -17,7 +17,7 @@ using MCPForUnity.Editor.Tools;
 namespace MCPForUnity.Editor
 {
     [InitializeOnLoad]
-    public static partial class UnityMcpBridge
+    public static partial class MCPForUnityBridge
     {
         private static TcpListener listener;
         private static bool isRunning = false;
@@ -94,7 +94,7 @@ namespace MCPForUnity.Editor
             return Directory.Exists(fullPath);
         }
 
-        static UnityMcpBridge()
+        static MCPForUnityBridge()
         {
             // Skip bridge in headless/batch environments (CI/builds)
             if (Application.isBatchMode)
@@ -227,7 +227,7 @@ namespace MCPForUnity.Editor
                 // Don't restart if already running on a working port
                 if (isRunning && listener != null)
                 {
-                    Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMcpBridge already running on port {currentUnityPort}");
+                    Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: MCPForUnityBridge already running on port {currentUnityPort}");
                     return;
                 }
 
@@ -310,7 +310,7 @@ namespace MCPForUnity.Editor
 
                     isRunning = true;
                     isAutoConnectMode = false;
-                    Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMcpBridge started on port {currentUnityPort}.");
+                    Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: MCPForUnityBridge started on port {currentUnityPort}.");
                     Task.Run(ListenerLoop);
                     EditorApplication.update += ProcessCommands;
                     // Write initial heartbeat immediately
@@ -343,11 +343,11 @@ namespace MCPForUnity.Editor
                     listener?.Stop();
                     listener = null;
                     EditorApplication.update -= ProcessCommands;
-                    Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMcpBridge stopped.");
+                    Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: MCPForUnityBridge stopped.");
                 }
                 catch (Exception ex)
                 {
-                    Debug.LogError($"Error stopping UnityMcpBridge: {ex.Message}");
+                    Debug.LogError($"Error stopping MCPForUnityBridge: {ex.Message}");
                 }
             }
         }

--- a/UnityMcpBridge/Editor/MCPForUnityBridge.cs.meta
+++ b/UnityMcpBridge/Editor/MCPForUnityBridge.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e0fb0e418dd19345a8236c44078972b
+guid: 96dc847eb7f7a45e0b91241db934a4be
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/UnityMcpBridge/Editor/Models/Command.cs
+++ b/UnityMcpBridge/Editor/Models/Command.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json.Linq;
 
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     /// <summary>
     /// Represents a command received from the MCP client

--- a/UnityMcpBridge/Editor/Models/MCPConfigServer.cs
+++ b/UnityMcpBridge/Editor/Models/MCPConfigServer.cs
@@ -1,7 +1,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     [Serializable]
     public class McpConfigServer

--- a/UnityMcpBridge/Editor/Models/MCPConfigServers.cs
+++ b/UnityMcpBridge/Editor/Models/MCPConfigServers.cs
@@ -1,7 +1,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     [Serializable]
     public class McpConfigServers

--- a/UnityMcpBridge/Editor/Models/McpClient.cs
+++ b/UnityMcpBridge/Editor/Models/McpClient.cs
@@ -1,4 +1,4 @@
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     public class McpClient
     {

--- a/UnityMcpBridge/Editor/Models/McpClient.cs
+++ b/UnityMcpBridge/Editor/Models/McpClient.cs
@@ -22,7 +22,7 @@ namespace MCPForUnity.Editor.Models
                 McpStatus.CommunicationError => "Communication Error",
                 McpStatus.NoResponse => "No Response",
                 McpStatus.UnsupportedOS => "Unsupported OS",
-                McpStatus.MissingConfig => "Missing UnityMCP Config",
+                McpStatus.MissingConfig => "Missing MCPForUnity Config",
                 McpStatus.Error => configStatus.StartsWith("Error:") ? configStatus : "Error",
                 _ => "Unknown",
             };

--- a/UnityMcpBridge/Editor/Models/McpConfig.cs
+++ b/UnityMcpBridge/Editor/Models/McpConfig.cs
@@ -1,7 +1,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     [Serializable]
     public class McpConfig

--- a/UnityMcpBridge/Editor/Models/McpStatus.cs
+++ b/UnityMcpBridge/Editor/Models/McpStatus.cs
@@ -1,4 +1,4 @@
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     // Enum representing the various status states for MCP clients
     public enum McpStatus

--- a/UnityMcpBridge/Editor/Models/McpTypes.cs
+++ b/UnityMcpBridge/Editor/Models/McpTypes.cs
@@ -1,4 +1,4 @@
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     public enum McpTypes
     {

--- a/UnityMcpBridge/Editor/Models/ServerConfig.cs
+++ b/UnityMcpBridge/Editor/Models/ServerConfig.cs
@@ -1,7 +1,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace UnityMcpBridge.Editor.Models
+namespace MCPForUnity.Editor.Models
 {
     [Serializable]
     public class ServerConfig

--- a/UnityMcpBridge/Editor/Tools/CommandRegistry.cs
+++ b/UnityMcpBridge/Editor/Tools/CommandRegistry.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Registry for all MCP command handlers (Refactored Version)

--- a/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
+++ b/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic; // Added for HashSet
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Helpers; // For Response class
+using MCPForUnity.Editor.Helpers; // For Response class
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles executing Unity Editor menu items by path.

--- a/UnityMcpBridge/Editor/Tools/ManageAsset.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageAsset.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Helpers; // For Response class
+using MCPForUnity.Editor.Helpers; // For Response class
 
 #if UNITY_6000_0_OR_NEWER
 using PhysicsMaterialType = UnityEngine.PhysicsMaterial;
@@ -16,7 +16,7 @@ using PhysicsMaterialType = UnityEngine.PhysicMaterial;
 using PhysicsMaterialCombine = UnityEngine.PhysicMaterialCombine;
 #endif
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles asset management operations within the Unity project.

--- a/UnityMcpBridge/Editor/Tools/ManageEditor.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageEditor.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEditorInternal; // Required for tag management
 using UnityEngine;
-using UnityMcpBridge.Editor.Helpers; // For Response class
+using MCPForUnity.Editor.Helpers; // For Response class
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles operations related to controlling and querying the Unity Editor state,

--- a/UnityMcpBridge/Editor/Tools/ManageGameObject.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageGameObject.cs
@@ -9,10 +9,10 @@ using UnityEditor.SceneManagement;
 using UnityEditorInternal;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityMcpBridge.Editor.Helpers; // For Response class
-using UnityMcpBridge.Runtime.Serialization;
+using MCPForUnity.Editor.Helpers; // For Response class
+using MCPForUnity.Runtime.Serialization;
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles GameObject manipulation within the current scene (CRUD, find, components).

--- a/UnityMcpBridge/Editor/Tools/ManageScene.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageScene.cs
@@ -7,9 +7,9 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityMcpBridge.Editor.Helpers; // For Response class
+using MCPForUnity.Editor.Helpers; // For Response class
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles scene management operations like loading, saving, creating, and querying hierarchy.

--- a/UnityMcpBridge/Editor/Tools/ManageScript.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageScript.cs
@@ -411,7 +411,7 @@ namespace MCPForUnity.Editor.Tools
         /// </summary>
         private static ValidationLevel GetValidationLevelFromGUI()
         {
-            string savedLevel = EditorPrefs.GetString("UnityMCP_ScriptValidationLevel", "standard");
+            string savedLevel = EditorPrefs.GetString("MCPForUnity_ScriptValidationLevel", "standard");
             return savedLevel.ToLower() switch
             {
                 "basic" => ValidationLevel.Basic,

--- a/UnityMcpBridge/Editor/Tools/ManageScript.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageScript.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Helpers;
+using MCPForUnity.Editor.Helpers;
 
 #if USE_ROSLYN
 using Microsoft.CodeAnalysis;
@@ -17,7 +17,7 @@ using UnityEditor.Compilation;
 #endif
 
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles CRUD operations for C# scripts within the Unity project.

--- a/UnityMcpBridge/Editor/Tools/ManageShader.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageShader.cs
@@ -5,9 +5,9 @@ using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Helpers;
+using MCPForUnity.Editor.Helpers;
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles CRUD operations for shader files within the Unity project.

--- a/UnityMcpBridge/Editor/Tools/ReadConsole.cs
+++ b/UnityMcpBridge/Editor/Tools/ReadConsole.cs
@@ -6,9 +6,9 @@ using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
-using UnityMcpBridge.Editor.Helpers; // For Response class
+using MCPForUnity.Editor.Helpers; // For Response class
 
-namespace UnityMcpBridge.Editor.Tools
+namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Handles reading and clearing Unity Editor console log entries.

--- a/UnityMcpBridge/Editor/UnityMcpBridge.cs
+++ b/UnityMcpBridge/Editor/UnityMcpBridge.cs
@@ -46,7 +46,7 @@ namespace MCPForUnity.Editor
         {
             if (IsDebugEnabled())
             {
-                Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: [{stage}]");
+                Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: [{stage}]");
             }
         }
 
@@ -227,7 +227,7 @@ namespace MCPForUnity.Editor
                 // Don't restart if already running on a working port
                 if (isRunning && listener != null)
                 {
-                    Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: UnityMcpBridge already running on port {currentUnityPort}");
+                    Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMcpBridge already running on port {currentUnityPort}");
                     return;
                 }
 
@@ -310,7 +310,7 @@ namespace MCPForUnity.Editor
 
                     isRunning = true;
                     isAutoConnectMode = false;
-                    Debug.Log($"<b><color=#2EA3FF>UNITY-MCP</color></b>: UnityMcpBridge started on port {currentUnityPort}.");
+                    Debug.Log($"<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMcpBridge started on port {currentUnityPort}.");
                     Task.Run(ListenerLoop);
                     EditorApplication.update += ProcessCommands;
                     // Write initial heartbeat immediately
@@ -343,7 +343,7 @@ namespace MCPForUnity.Editor
                     listener?.Stop();
                     listener = null;
                     EditorApplication.update -= ProcessCommands;
-                    Debug.Log("<b><color=#2EA3FF>UNITY-MCP</color></b>: UnityMcpBridge stopped.");
+                    Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMcpBridge stopped.");
                 }
                 catch (Exception ex)
                 {

--- a/UnityMcpBridge/Editor/UnityMcpBridge.cs
+++ b/UnityMcpBridge/Editor/UnityMcpBridge.cs
@@ -39,7 +39,7 @@ namespace MCPForUnity.Editor
         // Debug helpers
         private static bool IsDebugEnabled()
         {
-            try { return EditorPrefs.GetBool("UnityMCP.DebugLogs", false); } catch { return false; }
+            try { return EditorPrefs.GetBool("MCPForUnity.DebugLogs", false); } catch { return false; }
         }
         
         private static void LogBreadcrumb(string stage)

--- a/UnityMcpBridge/Editor/UnityMcpBridge.cs
+++ b/UnityMcpBridge/Editor/UnityMcpBridge.cs
@@ -10,11 +10,11 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Helpers;
-using UnityMcpBridge.Editor.Models;
-using UnityMcpBridge.Editor.Tools;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Models;
+using MCPForUnity.Editor.Tools;
 
-namespace UnityMcpBridge.Editor
+namespace MCPForUnity.Editor
 {
     [InitializeOnLoad]
     public static partial class UnityMcpBridge

--- a/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -817,7 +817,7 @@ namespace MCPForUnity.Editor.Windows
 				if (claudeAvailable)
 				{
 					bool isConfigured = mcpClient.status == McpStatus.Configured;
-					string buttonText = isConfigured ? "Unregister UnityMCP with Claude Code" : "Register with Claude Code";
+					string buttonText = isConfigured ? "Unregister MCP for Unity with Claude Code" : "Register with Claude Code";
 					if (GUILayout.Button(buttonText, GUILayout.Height(32)))
 					{
 						if (isConfigured)
@@ -1623,7 +1623,7 @@ namespace MCPForUnity.Editor.Windows
                     var existingClient = mcpClients.clients.FirstOrDefault(c => c.mcpType == McpTypes.ClaudeCode);
                     if (existingClient != null) CheckClaudeCodeConfiguration(existingClient);
                     Repaint();
-                    UnityEngine.Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMCP already registered with Claude Code.");
+                    UnityEngine.Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: MCP for Unity already registered with Claude Code.");
                 }
                 else
                 {
@@ -1653,7 +1653,7 @@ namespace MCPForUnity.Editor.Windows
                 ? "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
                 : null; // On Windows, don't modify PATH - use system PATH as-is
 
-			// Determine if Claude has a UnityMCP server registered by using exit codes from `claude mcp get <name>`
+			// Determine if Claude has a "UnityMCP" server registered by using exit codes from `claude mcp get <name>`
 			string[] candidateNamesForGet = { "UnityMCP", "unityMCP", "unity-mcp", "UnityMcpServer" };
 			List<string> existingNames = new List<string>();
 			foreach (var candidate in candidateNamesForGet)
@@ -1732,7 +1732,7 @@ namespace MCPForUnity.Editor.Windows
             {
                 UnityEngine.Debug.Log($"Claude MCP servers (text): {listStdout}");
                 
-                // Check if output indicates no servers or contains UnityMCP variants
+                // Check if output indicates no servers or contains "UnityMCP" variants
                 if (listStdout.Contains("No MCP servers configured") || 
                     listStdout.Contains("no servers") ||
                     listStdout.Contains("No servers") ||
@@ -1742,7 +1742,7 @@ namespace MCPForUnity.Editor.Windows
                     return false;
                 }
                 
-                // Look for UnityMCP variants in the output
+                // Look for "UnityMCP" variants in the output
                 return listStdout.Contains("UnityMCP") || 
                        listStdout.Contains("unityMCP") || 
                        listStdout.Contains("unity-mcp");
@@ -2148,13 +2148,13 @@ namespace MCPForUnity.Editor.Windows
                 string configJson = File.ReadAllText(configPath);
                 dynamic claudeConfig = JsonConvert.DeserializeObject(configJson);
                 
-                // Check for UnityMCP server in the mcpServers section (current format)
+                // Check for "UnityMCP" server in the mcpServers section (current format)
                 if (claudeConfig?.mcpServers != null)
                 {
                     var servers = claudeConfig.mcpServers;
                     if (servers.UnityMCP != null || servers.unityMCP != null)
                     {
-                        // Found UnityMCP configured
+                        // Found MCP for Unity configured
                         mcpClient.SetStatus(McpStatus.Configured);
                         return;
                     }
@@ -2174,11 +2174,11 @@ namespace MCPForUnity.Editor.Windows
                         
                         if (string.Equals(normalizedProjectPath, normalizedProjectDir, StringComparison.OrdinalIgnoreCase) && project.Value?.mcpServers != null)
                         {
-                            // Check for UnityMCP (case variations)
+                            // Check for "UnityMCP" (case variations)
                             var servers = project.Value.mcpServers;
                             if (servers.UnityMCP != null || servers.unityMCP != null)
                             {
-                                // Found UnityMCP configured for this project
+                                // Found MCP for Unity configured for this project
                                 mcpClient.SetStatus(McpStatus.Configured);
                                 return;
                             }

--- a/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -17,7 +17,7 @@ using MCPForUnity.Editor.Models;
 
 namespace MCPForUnity.Editor.Windows
 {
-    public class UnityMcpEditorWindow : EditorWindow
+    public class MCPForUnityEditorWindow : EditorWindow
     {
         private bool isUnityBridgeRunning = false;
         private Vector2 scrollPosition;
@@ -47,7 +47,7 @@ namespace MCPForUnity.Editor.Windows
         [MenuItem("Window/MCP for Unity")]
         public static void ShowWindow()
         {
-            GetWindow<UnityMcpEditorWindow>("MCP for Unity");
+            GetWindow<MCPForUnityEditorWindow>("MCP for Unity");
         }
 
         private void OnEnable()
@@ -55,7 +55,7 @@ namespace MCPForUnity.Editor.Windows
             UpdatePythonServerInstallationStatus();
 
             // Refresh bridge status
-            isUnityBridgeRunning = UnityMcpBridge.IsRunning;
+            isUnityBridgeRunning = MCPForUnityBridge.IsRunning;
             autoRegisterEnabled = EditorPrefs.GetBool("MCPForUnity.AutoRegisterEnabled", true);
             debugLogsEnabled = EditorPrefs.GetBool("MCPForUnity.DebugLogs", false);
             foreach (McpClient mcpClient in mcpClients.clients)
@@ -76,7 +76,7 @@ namespace MCPForUnity.Editor.Windows
         private void OnFocus()
         {
             // Refresh bridge running state on focus in case initialization completed after domain reload
-            isUnityBridgeRunning = UnityMcpBridge.IsRunning;
+            isUnityBridgeRunning = MCPForUnityBridge.IsRunning;
             if (mcpClients.clients.Count > 0 && selectedClientIndex < mcpClients.clients.Count)
             {
                 McpClient selectedClient = mcpClients.clients[selectedClientIndex];
@@ -272,13 +272,13 @@ namespace MCPForUnity.Editor.Windows
             EditorGUILayout.Space(5);
             
             EditorGUILayout.BeginHorizontal();
-            bool isAutoMode = UnityMcpBridge.IsAutoConnectMode();
+            bool isAutoMode = MCPForUnityBridge.IsAutoConnectMode();
             GUIStyle modeStyle = new GUIStyle(EditorStyles.miniLabel) { fontSize = 11 };
             EditorGUILayout.LabelField($"Mode: {(isAutoMode ? "Auto" : "Standard")}", modeStyle);
             GUILayout.FlexibleSpace();
             EditorGUILayout.EndHorizontal();
             
-            int currentUnityPort = UnityMcpBridge.GetCurrentPort();
+            int currentUnityPort = MCPForUnityBridge.GetCurrentPort();
             GUIStyle portStyle = new GUIStyle(EditorStyles.miniLabel)
             {
                 fontSize = 11
@@ -369,7 +369,7 @@ namespace MCPForUnity.Editor.Windows
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
             
             // Always reflect the live state each repaint to avoid stale UI after recompiles
-            isUnityBridgeRunning = UnityMcpBridge.IsRunning;
+            isUnityBridgeRunning = MCPForUnityBridge.IsRunning;
 
             GUIStyle sectionTitleStyle = new GUIStyle(EditorStyles.boldLabel)
             {
@@ -511,12 +511,12 @@ namespace MCPForUnity.Editor.Windows
                 }
 
                 // Ensure the bridge is listening and has a fresh saved port
-                if (!UnityMcpBridge.IsRunning)
+                if (!MCPForUnityBridge.IsRunning)
                 {
                     try
                     {
-                        UnityMcpBridge.StartAutoConnect();
-                        isUnityBridgeRunning = UnityMcpBridge.IsRunning;
+                        MCPForUnityBridge.StartAutoConnect();
+                        isUnityBridgeRunning = MCPForUnityBridge.IsRunning;
                         Repaint();
                     }
                     catch (Exception ex)
@@ -526,7 +526,7 @@ namespace MCPForUnity.Editor.Windows
                 }
 
                 // Verify bridge with a quick ping
-                lastBridgeVerifiedOk = VerifyBridgePing(UnityMcpBridge.GetCurrentPort());
+                lastBridgeVerifiedOk = VerifyBridgePing(MCPForUnityBridge.GetCurrentPort());
 
                 EditorPrefs.SetBool(key, true);
             }
@@ -599,11 +599,11 @@ namespace MCPForUnity.Editor.Windows
                 lastClientRegisteredOk = anyRegistered || IsCursorConfigured(pythonDir) || IsClaudeConfigured();
 
                 // Restart/ensure bridge
-                UnityMcpBridge.StartAutoConnect();
-                isUnityBridgeRunning = UnityMcpBridge.IsRunning;
+                MCPForUnityBridge.StartAutoConnect();
+                isUnityBridgeRunning = MCPForUnityBridge.IsRunning;
 
                 // Verify
-                lastBridgeVerifiedOk = VerifyBridgePing(UnityMcpBridge.GetCurrentPort());
+                lastBridgeVerifiedOk = VerifyBridgePing(MCPForUnityBridge.GetCurrentPort());
                 Repaint();
             }
             catch (Exception e)
@@ -934,14 +934,14 @@ namespace MCPForUnity.Editor.Windows
         {
             if (isUnityBridgeRunning)
             {
-                UnityMcpBridge.Stop();
+                MCPForUnityBridge.Stop();
             }
             else
             {
-                UnityMcpBridge.Start();
+                MCPForUnityBridge.Start();
             }
             // Reflect the actual state post-operation (avoid optimistic toggle)
-            isUnityBridgeRunning = UnityMcpBridge.IsRunning;
+            isUnityBridgeRunning = MCPForUnityBridge.IsRunning;
             Repaint();
         }
 
@@ -1424,7 +1424,7 @@ namespace MCPForUnity.Editor.Windows
 
         private void LoadValidationLevelSetting()
         {
-            string savedLevel = EditorPrefs.GetString("UnityMCP_ScriptValidationLevel", "standard");
+            string savedLevel = EditorPrefs.GetString("MCPForUnity_ScriptValidationLevel", "standard");
             validationLevelIndex = savedLevel.ToLower() switch
             {
                 "basic" => 0,
@@ -1445,7 +1445,7 @@ namespace MCPForUnity.Editor.Windows
                 3 => "strict",
                 _ => "standard"
             };
-            EditorPrefs.SetString("UnityMCP_ScriptValidationLevel", levelString);
+            EditorPrefs.SetString("MCPForUnity_ScriptValidationLevel", levelString);
         }
 
         private string GetValidationLevelDescription(int index)
@@ -1462,7 +1462,7 @@ namespace MCPForUnity.Editor.Windows
 
         public static string GetCurrentValidationLevel()
         {
-            string savedLevel = EditorPrefs.GetString("UnityMCP_ScriptValidationLevel", "standard");
+            string savedLevel = EditorPrefs.GetString("MCPForUnity_ScriptValidationLevel", "standard");
             return savedLevel;
         }
 

--- a/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs.meta
+++ b/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4283e255b343c4546b843cd22214ac93
+guid: 4f740bec3a8d04716adeab35c412a15f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
@@ -1,9 +1,9 @@
 using System.Runtime.InteropServices;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Models;
+using MCPForUnity.Editor.Models;
 
-namespace UnityMcpBridge.Editor.Windows
+namespace MCPForUnity.Editor.Windows
 {
     // Editor window to display manual configuration instructions
     public class ManualConfigEditorWindow : EditorWindow

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -1623,7 +1623,7 @@ namespace MCPForUnity.Editor.Windows
                     var existingClient = mcpClients.clients.FirstOrDefault(c => c.mcpType == McpTypes.ClaudeCode);
                     if (existingClient != null) CheckClaudeCodeConfiguration(existingClient);
                     Repaint();
-                    UnityEngine.Debug.Log("<b><color=#2EA3FF>UNITY-MCP</color></b>: UnityMCP already registered with Claude Code.");
+                    UnityEngine.Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: UnityMCP already registered with Claude Code.");
                 }
                 else
                 {
@@ -1636,7 +1636,7 @@ namespace MCPForUnity.Editor.Windows
             var claudeClient = mcpClients.clients.FirstOrDefault(c => c.mcpType == McpTypes.ClaudeCode);
             if (claudeClient != null) CheckClaudeCodeConfiguration(claudeClient);
             Repaint();
-            UnityEngine.Debug.Log("<b><color=#2EA3FF>UNITY-MCP</color></b>: Registered with Claude Code.");
+            UnityEngine.Debug.Log("<b><color=#2EA3FF>MCP-FOR-UNITY</color></b>: Registered with Claude Code.");
         }
 
         private void UnregisterWithClaudeCode()

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -44,7 +44,7 @@ namespace MCPForUnity.Editor.Windows
         // UI state
         private int selectedClientIndex = 0;
 
-        [MenuItem("Window/Unity MCP")]
+        [MenuItem("Window/MCP for Unity")]
         public static void ShowWindow()
         {
             GetWindow<UnityMcpEditorWindow>("MCP Editor");
@@ -230,7 +230,7 @@ namespace MCPForUnity.Editor.Windows
             
             GUI.Label(
                 new Rect(titleRect.x + 15, titleRect.y + 8, titleRect.width - 30, titleRect.height),
-                "Unity MCP Editor",
+                "MCP for Unity Editor",
                 titleStyle
             );
 
@@ -307,12 +307,12 @@ namespace MCPForUnity.Editor.Windows
                     bool ok = global::MCPForUnity.Editor.Helpers.ServerInstaller.RepairPythonEnvironment();
                     if (ok)
                     {
-                        EditorUtility.DisplayDialog("Unity MCP", "Python environment repaired.", "OK");
+                        EditorUtility.DisplayDialog("MCP for Unity", "Python environment repaired.", "OK");
                         UpdatePythonServerInstallationStatus();
                     }
                     else
                     {
-                        EditorUtility.DisplayDialog("Unity MCP", "Repair failed. Please check Console for details.", "OK");
+                        EditorUtility.DisplayDialog("MCP for Unity", "Repair failed. Please check Console for details.", "OK");
                     }
                 }
             }
@@ -532,7 +532,7 @@ namespace MCPForUnity.Editor.Windows
             }
             catch (Exception e)
             {
-                UnityEngine.Debug.LogWarning($"Unity MCP auto-setup skipped: {e.Message}");
+                UnityEngine.Debug.LogWarning($"MCP for Unity auto-setup skipped: {e.Message}");
             }
         }
 

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -1558,7 +1558,7 @@ namespace MCPForUnity.Editor.Windows
                             {
                                 if (debugLogsEnabled)
                                 {
-                                    UnityEngine.Debug.Log($"MCP For Unity: Auto-updated MCP config for '{mcpClient.name}' to new path: {pythonDir}");
+                                    UnityEngine.Debug.Log($"MCP for Unity: Auto-updated MCP config for '{mcpClient.name}' to new path: {pythonDir}");
                                 }
                                 mcpClient.SetStatus(McpStatus.Configured);
                             }
@@ -1572,7 +1572,7 @@ namespace MCPForUnity.Editor.Windows
                             mcpClient.SetStatus(McpStatus.IncorrectPath);
                             if (debugLogsEnabled)
                             {
-                                UnityEngine.Debug.LogWarning($"MCP For Unity: Auto-config rewrite failed for '{mcpClient.name}': {ex.Message}");
+                                UnityEngine.Debug.LogWarning($"MCP for Unity: Auto-config rewrite failed for '{mcpClient.name}': {ex.Message}");
                             }
                         }
                     }
@@ -1594,7 +1594,7 @@ namespace MCPForUnity.Editor.Windows
             string claudePath = ExecPath.ResolveClaude();
             if (string.IsNullOrEmpty(claudePath))
             {
-                UnityEngine.Debug.LogError("MCP For Unity: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
+                UnityEngine.Debug.LogError("MCP for Unity: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
                 return;
             }
             string uvPath = ExecPath.ResolveUv() ?? "uv";
@@ -1627,7 +1627,7 @@ namespace MCPForUnity.Editor.Windows
                 }
                 else
                 {
-                    UnityEngine.Debug.LogError($"MCP For Unity: Failed to start Claude CLI.\n{stderr}\n{stdout}");
+                    UnityEngine.Debug.LogError($"MCP for Unity: Failed to start Claude CLI.\n{stderr}\n{stdout}");
                 }
                 return;
             }
@@ -1644,7 +1644,7 @@ namespace MCPForUnity.Editor.Windows
             string claudePath = ExecPath.ResolveClaude();
             if (string.IsNullOrEmpty(claudePath))
             {
-                UnityEngine.Debug.LogError("MCP For Unity: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
+                UnityEngine.Debug.LogError("MCP for Unity: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
                 return;
             }
 
@@ -1672,7 +1672,7 @@ namespace MCPForUnity.Editor.Windows
 				if (claudeClient != null)
 				{
 					claudeClient.SetStatus(McpStatus.NotConfigured);
-					UnityEngine.Debug.Log("Claude CLI reports no MCP For Unity server via 'mcp get' - setting status to NotConfigured and aborting unregister.");
+					UnityEngine.Debug.Log("Claude CLI reports no MCP for Unity server via 'mcp get' - setting status to NotConfigured and aborting unregister.");
 					Repaint();
 				}
 				return;
@@ -1687,7 +1687,7 @@ namespace MCPForUnity.Editor.Windows
                 if (ExecPath.TryRun(claudePath, $"mcp remove {serverName}", projectDir, out var stdout, out var stderr, 10000, pathPrepend))
                 {
                     success = true;
-                    UnityEngine.Debug.Log($"MCP For Unity: Successfully removed MCP server: {serverName}");
+                    UnityEngine.Debug.Log($"MCP for Unity: Successfully removed MCP server: {serverName}");
                     break;
                 }
                 else if (!string.IsNullOrEmpty(stderr) &&
@@ -1709,7 +1709,7 @@ namespace MCPForUnity.Editor.Windows
                     CheckClaudeCodeConfiguration(claudeClient);
                 }
                 Repaint();
-                UnityEngine.Debug.Log("MCP For Unity: MCP server successfully unregistered from Claude Code.");
+                UnityEngine.Debug.Log("MCP for Unity: MCP server successfully unregistered from Claude Code.");
             }
             else
             {

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -1558,7 +1558,7 @@ namespace MCPForUnity.Editor.Windows
                             {
                                 if (debugLogsEnabled)
                                 {
-                                    UnityEngine.Debug.Log($"UnityMCP: Auto-updated MCP config for '{mcpClient.name}' to new path: {pythonDir}");
+                                    UnityEngine.Debug.Log($"MCP For Unity: Auto-updated MCP config for '{mcpClient.name}' to new path: {pythonDir}");
                                 }
                                 mcpClient.SetStatus(McpStatus.Configured);
                             }
@@ -1572,7 +1572,7 @@ namespace MCPForUnity.Editor.Windows
                             mcpClient.SetStatus(McpStatus.IncorrectPath);
                             if (debugLogsEnabled)
                             {
-                                UnityEngine.Debug.LogWarning($"UnityMCP: Auto-config rewrite failed for '{mcpClient.name}': {ex.Message}");
+                                UnityEngine.Debug.LogWarning($"MCP For Unity: Auto-config rewrite failed for '{mcpClient.name}': {ex.Message}");
                             }
                         }
                     }
@@ -1594,7 +1594,7 @@ namespace MCPForUnity.Editor.Windows
             string claudePath = ExecPath.ResolveClaude();
             if (string.IsNullOrEmpty(claudePath))
             {
-                UnityEngine.Debug.LogError("UnityMCP: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
+                UnityEngine.Debug.LogError("MCP For Unity: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
                 return;
             }
             string uvPath = ExecPath.ResolveUv() ?? "uv";
@@ -1627,7 +1627,7 @@ namespace MCPForUnity.Editor.Windows
                 }
                 else
                 {
-                    UnityEngine.Debug.LogError($"UnityMCP: Failed to start Claude CLI.\n{stderr}\n{stdout}");
+                    UnityEngine.Debug.LogError($"MCP For Unity: Failed to start Claude CLI.\n{stderr}\n{stdout}");
                 }
                 return;
             }
@@ -1644,7 +1644,7 @@ namespace MCPForUnity.Editor.Windows
             string claudePath = ExecPath.ResolveClaude();
             if (string.IsNullOrEmpty(claudePath))
             {
-                UnityEngine.Debug.LogError("UnityMCP: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
+                UnityEngine.Debug.LogError("MCP For Unity: Claude CLI not found. Set a path in this window or install the CLI, then try again.");
                 return;
             }
 
@@ -1672,7 +1672,7 @@ namespace MCPForUnity.Editor.Windows
 				if (claudeClient != null)
 				{
 					claudeClient.SetStatus(McpStatus.NotConfigured);
-					UnityEngine.Debug.Log("Claude CLI reports no UnityMCP server via 'mcp get' – setting status to NotConfigured and aborting unregister.");
+					UnityEngine.Debug.Log("Claude CLI reports no MCP For Unity server via 'mcp get' - setting status to NotConfigured and aborting unregister.");
 					Repaint();
 				}
 				return;
@@ -1687,7 +1687,7 @@ namespace MCPForUnity.Editor.Windows
                 if (ExecPath.TryRun(claudePath, $"mcp remove {serverName}", projectDir, out var stdout, out var stderr, 10000, pathPrepend))
                 {
                     success = true;
-                    UnityEngine.Debug.Log($"Successfully removed MCP server: {serverName}");
+                    UnityEngine.Debug.Log($"MCP For Unity: Successfully removed MCP server: {serverName}");
                     break;
                 }
                 else if (!string.IsNullOrEmpty(stderr) &&
@@ -1709,7 +1709,7 @@ namespace MCPForUnity.Editor.Windows
                     CheckClaudeCodeConfiguration(claudeClient);
                 }
                 Repaint();
-                UnityEngine.Debug.Log("UnityMCP server successfully unregistered from Claude Code.");
+                UnityEngine.Debug.Log("MCP For Unity: MCP server successfully unregistered from Claude Code.");
             }
             else
             {

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -47,7 +47,7 @@ namespace MCPForUnity.Editor.Windows
         [MenuItem("Window/MCP for Unity")]
         public static void ShowWindow()
         {
-            GetWindow<UnityMcpEditorWindow>("MCP Editor");
+            GetWindow<UnityMcpEditorWindow>("MCP for Unity");
         }
 
         private void OnEnable()

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -328,7 +328,7 @@ namespace MCPForUnity.Editor.Windows
                 EditorGUILayout.LabelField("<color=#cc3333><b>Warning:</b></color> No Python installation found.", warnStyle);
                 using (new EditorGUILayout.HorizontalScope())
                 {
-                    if (GUILayout.Button("Open install instructions", GUILayout.Width(200)))
+                    if (GUILayout.Button("Open Install Instructions", GUILayout.Width(200)))
                     {
                         Application.OpenURL("https://www.python.org/downloads/");
                     }
@@ -786,7 +786,7 @@ namespace MCPForUnity.Editor.Windows
 
 				EditorGUILayout.Space(8);
 				EditorGUILayout.BeginHorizontal();
-				if (GUILayout.Button("Choose UV Install Location", GUILayout.Width(260), GUILayout.Height(22)))
+				if (GUILayout.Button("Choose uv Install Location", GUILayout.Width(260), GUILayout.Height(22)))
 				{
 					string suggested = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "/opt/homebrew/bin" : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 					string picked = EditorUtility.OpenFilePanel("Select 'uv' binary", suggested, "");

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -11,11 +11,11 @@ using System.Runtime.InteropServices;
 using Newtonsoft.Json;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Data;
-using UnityMcpBridge.Editor.Helpers;
-using UnityMcpBridge.Editor.Models;
+using MCPForUnity.Editor.Data;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Models;
 
-namespace UnityMcpBridge.Editor.Windows
+namespace MCPForUnity.Editor.Windows
 {
     public class UnityMcpEditorWindow : EditorWindow
     {
@@ -304,7 +304,7 @@ namespace UnityMcpBridge.Editor.Windows
                 );
                 if (GUILayout.Button(repairLabel, GUILayout.Width(160), GUILayout.Height(22)))
                 {
-                    bool ok = global::UnityMcpBridge.Editor.Helpers.ServerInstaller.RepairPythonEnvironment();
+                    bool ok = global::MCPForUnity.Editor.Helpers.ServerInstaller.RepairPythonEnvironment();
                     if (ok)
                     {
                         EditorUtility.DisplayDialog("Unity MCP", "Python environment repaired.", "OK");

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -56,8 +56,8 @@ namespace MCPForUnity.Editor.Windows
 
             // Refresh bridge status
             isUnityBridgeRunning = UnityMcpBridge.IsRunning;
-            autoRegisterEnabled = EditorPrefs.GetBool("UnityMCP.AutoRegisterEnabled", true);
-            debugLogsEnabled = EditorPrefs.GetBool("UnityMCP.DebugLogs", false);
+            autoRegisterEnabled = EditorPrefs.GetBool("MCPForUnity.AutoRegisterEnabled", true);
+            debugLogsEnabled = EditorPrefs.GetBool("MCPForUnity.DebugLogs", false);
             foreach (McpClient mcpClient in mcpClients.clients)
             {
                 CheckMcpConfiguration(mcpClient);
@@ -241,7 +241,7 @@ namespace MCPForUnity.Editor.Windows
             if (newDebug != debugLogsEnabled)
             {
                 debugLogsEnabled = newDebug;
-                EditorPrefs.SetBool("UnityMCP.DebugLogs", debugLogsEnabled);
+                EditorPrefs.SetBool("MCPForUnity.DebugLogs", debugLogsEnabled);
             }
             EditorGUILayout.Space(15);
         }
@@ -347,7 +347,7 @@ namespace MCPForUnity.Editor.Windows
                         if (!string.IsNullOrEmpty(picked) && File.Exists(Path.Combine(picked, "server.py")))
                         {
                             pythonDirOverride = picked;
-                            EditorPrefs.SetString("UnityMCP.PythonDirOverride", pythonDirOverride);
+                            EditorPrefs.SetString("MCPForUnity.PythonDirOverride", pythonDirOverride);
                             UpdatePythonServerInstallationStatus();
                         }
                         else if (!string.IsNullOrEmpty(picked))
@@ -467,14 +467,14 @@ namespace MCPForUnity.Editor.Windows
             {
                 // Project-scoped one-time flag
                 string projectPath = Application.dataPath ?? string.Empty;
-                string key = $"UnityMCP.AutoRegistered.{ComputeSha1(projectPath)}";
+                string key = $"MCPForUnity.AutoRegistered.{ComputeSha1(projectPath)}";
                 if (EditorPrefs.GetBool(key, false))
                 {
                     return;
                 }
 
                 // Attempt client registration using discovered Python server dir
-                pythonDirOverride ??= EditorPrefs.GetString("UnityMCP.PythonDirOverride", null);
+                pythonDirOverride ??= EditorPrefs.GetString("MCPForUnity.PythonDirOverride", null);
                 string pythonDir = !string.IsNullOrEmpty(pythonDirOverride) ? pythonDirOverride : FindPackagePythonDirectory();
                 if (!string.IsNullOrEmpty(pythonDir) && File.Exists(Path.Combine(pythonDir, "server.py")))
                 {
@@ -561,7 +561,7 @@ namespace MCPForUnity.Editor.Windows
             // Force a one-shot setup regardless of first-run flag
             try
             {
-                pythonDirOverride ??= EditorPrefs.GetString("UnityMCP.PythonDirOverride", null);
+                pythonDirOverride ??= EditorPrefs.GetString("MCPForUnity.PythonDirOverride", null);
                 string pythonDir = !string.IsNullOrEmpty(pythonDirOverride) ? pythonDirOverride : FindPackagePythonDirectory();
                 if (string.IsNullOrEmpty(pythonDir) || !File.Exists(Path.Combine(pythonDir, "server.py")))
                 {
@@ -792,7 +792,7 @@ namespace MCPForUnity.Editor.Windows
 					string picked = EditorUtility.OpenFilePanel("Select 'uv' binary", suggested, "");
 					if (!string.IsNullOrEmpty(picked))
 					{
-						EditorPrefs.SetString("UnityMCP.UvPath", picked);
+						EditorPrefs.SetString("MCPForUnity.UvPath", picked);
 						ConfigureMcpClient(mcpClient);
 						Repaint();
 					}
@@ -1003,7 +1003,7 @@ namespace MCPForUnity.Editor.Windows
 		private string WriteToConfig(string pythonDir, string configPath, McpClient mcpClient = null)
         {
 			// 0) Respect explicit lock (hidden pref or UI toggle)
-			try { if (UnityEditor.EditorPrefs.GetBool("UnityMCP.LockCursorConfig", false)) return "Skipped (locked)"; } catch { }
+			try { if (UnityEditor.EditorPrefs.GetBool("MCPForUnity.LockCursorConfig", false)) return "Skipped (locked)"; } catch { }
 
             JsonSerializerSettings jsonSettings = new() { Formatting = Formatting.Indented };
 
@@ -1078,7 +1078,7 @@ namespace MCPForUnity.Editor.Windows
 			// Hard-block PackageCache on Windows unless dev override is set
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 				&& serverSrc.IndexOf(@"\Library\PackageCache\", StringComparison.OrdinalIgnoreCase) >= 0
-				&& !UnityEditor.EditorPrefs.GetBool("UnityMCP.UseEmbeddedServer", false))
+				&& !UnityEditor.EditorPrefs.GetBool("MCPForUnity.UseEmbeddedServer", false))
 			{
 				serverSrc = ServerInstaller.GetServerPath();
 			}
@@ -1120,8 +1120,8 @@ namespace MCPForUnity.Editor.Windows
 				System.IO.File.Move(tmp, configPath);
 			try
 			{
-				if (IsValidUv(uvPath)) UnityEditor.EditorPrefs.SetString("UnityMCP.UvPath", uvPath);
-				UnityEditor.EditorPrefs.SetString("UnityMCP.ServerSrc", serverSrc);
+				if (IsValidUv(uvPath)) UnityEditor.EditorPrefs.SetString("MCPForUnity.UvPath", uvPath);
+				UnityEditor.EditorPrefs.SetString("MCPForUnity.ServerSrc", serverSrc);
 			}
 			catch { }
 
@@ -1206,7 +1206,7 @@ namespace MCPForUnity.Editor.Windows
 		{
 			try
 			{
-				string remembered = UnityEditor.EditorPrefs.GetString("UnityMCP.ServerSrc", string.Empty);
+				string remembered = UnityEditor.EditorPrefs.GetString("MCPForUnity.ServerSrc", string.Empty);
 				if (!string.IsNullOrEmpty(remembered) && File.Exists(Path.Combine(remembered, "server.py")))
 				{
 					return remembered;
@@ -1219,7 +1219,7 @@ namespace MCPForUnity.Editor.Windows
 					return installed;
 				}
 
-				bool useEmbedded = UnityEditor.EditorPrefs.GetBool("UnityMCP.UseEmbeddedServer", false);
+				bool useEmbedded = UnityEditor.EditorPrefs.GetBool("MCPForUnity.UseEmbeddedServer", false);
 				if (useEmbedded && ServerPathResolver.TryFindEmbeddedServerSource(out string embedded)
 					&& File.Exists(Path.Combine(embedded, "server.py")))
 				{
@@ -1261,7 +1261,7 @@ namespace MCPForUnity.Editor.Windows
                 }
 
 				// Resolve via shared helper (handles local registry and older fallback) only if dev override on
-				if (UnityEditor.EditorPrefs.GetBool("UnityMCP.UseEmbeddedServer", false))
+				if (UnityEditor.EditorPrefs.GetBool("MCPForUnity.UseEmbeddedServer", false))
 				{
 					if (ServerPathResolver.TryFindEmbeddedServerSource(out string embedded))
 					{

--- a/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
@@ -1,9 +1,9 @@
 using System.Runtime.InteropServices;
 using UnityEditor;
 using UnityEngine;
-using UnityMcpBridge.Editor.Models;
+using MCPForUnity.Editor.Models;
 
-namespace UnityMcpBridge.Editor.Windows
+namespace MCPForUnity.Editor.Windows
 {
     public class VSCodeManualSetupWindow : ManualConfigEditorWindow
     {

--- a/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/VSCodeManualSetupWindow.cs
@@ -57,7 +57,7 @@ namespace MCPForUnity.Editor.Windows
                     headerRect.width - 16,
                     headerRect.height
                 ),
-                "Setting up GitHub Copilot in VSCode with Unity MCP",
+                "Setting up GitHub Copilot in VSCode with MCP for Unity",
                 EditorStyles.boldLabel
             );
             EditorGUILayout.Space(10);
@@ -265,7 +265,7 @@ namespace MCPForUnity.Editor.Windows
                 instructionStyle
             );
             EditorGUILayout.LabelField(
-                "• Remember to have the Unity MCP Bridge running in Unity Editor",
+                "• Remember to have the MCP for Unity Bridge running in Unity Editor",
                 instructionStyle
             );
 

--- a/UnityMcpBridge/README.md
+++ b/UnityMcpBridge/README.md
@@ -13,7 +13,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
 1. Open Window > MCP for Unity.
 2. Click “Auto-Setup”.
 3. If prompted:
-   - Select the server folder that contains `server.py` (UnityMcpServer/src).
+   - Select the server folder that contains `server.py` (UnityMcpServer~/src).
    - Install Python and/or uv if missing.
    - For Claude Code, ensure the `claude` CLI is installed.
 4. Click “Start Bridge” if the Unity Bridge shows “Stopped”.
@@ -32,7 +32,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
   - Repair Python Env: Rebuilds a clean Python environment (deletes `.venv`, runs `uv sync`).
   - Select server folder…: Choose the folder containing `server.py`.
   - Verify again: Re-checks server presence.
-  - If Python isn’t detected, use “Open install instructions”.
+  - If Python isn’t detected, use “Open Install Instructions”.
 
 ---
 
@@ -51,7 +51,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
       - Command: uv
       - Args: run --directory <pythonDir> server.py
     - Manual Setup: Opens a window with a pre-filled JSON snippet to copy/paste into your client config.
-    - Choose UV Install Location: If uv isn’t on PATH, select the uv binary.
+    - Choose `uv` Install Location: If uv isn’t on PATH, select the uv binary.
     - A compact “Config:” line shows the resolved config file name once uv/server are detected.
   - Claude Code:
     - Register with Claude Code / Unregister UnityMCP with Claude Code.
@@ -76,9 +76,9 @@ Notes:
 
 ## Troubleshooting
 - Python or `uv` not found:
-  - Help: https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf
+  - Help: [Fix MCP for Unity with Cursor, VS Code & Windsurf](https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf)
 - Claude CLI not found:
-  - Help: https://github.com/CoplayDev/unity-mcp/wiki/2.-Fix-Unity-MCP-and-Claude-Code
+  - Help: [Fix MCP for Unity with Claude Code](https://github.com/CoplayDev/unity-mcp/wiki/2.-Fix-Unity-MCP-and-Claude-Code)
 
 ---
 

--- a/UnityMcpBridge/README.md
+++ b/UnityMcpBridge/README.md
@@ -54,7 +54,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
     - Choose `uv` Install Location: If uv isn’t on PATH, select the uv binary.
     - A compact “Config:” line shows the resolved config file name once uv/server are detected.
   - Claude Code:
-    - Register with Claude Code / Unregister UnityMCP with Claude Code.
+    - Register with Claude Code / Unregister MCP for Unity with Claude Code.
     - If the CLI isn’t found, click “Choose Claude Install Location”.
     - The window displays the resolved Claude CLI path when detected.
 

--- a/UnityMcpBridge/README.md
+++ b/UnityMcpBridge/README.md
@@ -1,0 +1,88 @@
+# MCP for Unity — Editor Plugin Guide
+
+Use this guide to configure and run MCP for Unity inside the Unity Editor. Installation is covered elsewhere; this document focuses on the Editor window, client configuration, and troubleshooting.
+
+## Open the window
+- Unity menu: Window > MCP for Unity
+
+The window has four areas: Server Status, Unity Bridge, MCP Client Configuration, and Script Validation.
+
+---
+
+## Quick start
+1. Open Window > MCP for Unity.
+2. Click “Auto-Setup”.
+3. If prompted:
+   - Select the server folder that contains `server.py` (UnityMcpServer/src).
+   - Install Python and/or uv if missing.
+   - For Claude Code, ensure the `claude` CLI is installed.
+4. Click “Start Bridge” if the Unity Bridge shows “Stopped”.
+5. Use your MCP client (Cursor, VS Code, Windsurf, Claude Code) to connect.
+
+---
+
+## Server Status
+- Status dot and label:
+  - Installed / Installed (Embedded) / Not Installed.
+- Mode and ports:
+  - Mode: Auto or Standard.
+  - Ports: Unity 6400, MCP Server 6500.
+- Actions:
+  - Auto-Setup: Registers/updates your selected MCP client(s), ensures bridge connectivity. Shows “Connected ✓” after success.
+  - Repair Python Env: Rebuilds a clean Python environment (deletes `.venv`, runs `uv sync`).
+  - Select server folder…: Choose the folder containing `server.py`.
+  - Verify again: Re-checks server presence.
+  - If Python isn’t detected, use “Open install instructions”.
+
+---
+
+## Unity Bridge
+- Shows Running or Stopped with a status dot.
+- Start/Stop Bridge button toggles the Unity bridge process used by MCP clients to talk to Unity.
+- Tip: After Auto-Setup, the bridge may auto-start in Auto mode.
+
+---
+
+## MCP Client Configuration
+- Select Client: Choose your target MCP client (e.g., Cursor, VS Code, Windsurf, Claude Code).
+- Per-client actions:
+  - Cursor / VS Code / Windsurf:
+    - Auto Configure: Writes/updates your config to launch the server via uv:
+      - Command: uv
+      - Args: run --directory <pythonDir> server.py
+    - Manual Setup: Opens a window with a pre-filled JSON snippet to copy/paste into your client config.
+    - Choose UV Install Location: If uv isn’t on PATH, select the uv binary.
+    - A compact “Config:” line shows the resolved config file name once uv/server are detected.
+  - Claude Code:
+    - Register with Claude Code / Unregister UnityMCP with Claude Code.
+    - If the CLI isn’t found, click “Choose Claude Install Location”.
+    - The window displays the resolved Claude CLI path when detected.
+
+Notes:
+- The UI shows a status dot and a short status text (e.g., “Configured”, “uv Not Found”, “Claude Not Found”).
+- Use “Auto Configure” for one-click setup; use “Manual Setup” when you prefer to review/copy config.
+
+---
+
+## Script Validation
+- Validation Level options:
+  - Basic — Only syntax checks
+  - Standard — Syntax + Unity practices
+  - Comprehensive — All checks + semantic analysis
+  - Strict — Full semantic validation (requires Roslyn)
+- Pick a level based on your project’s needs. A description is shown under the dropdown.
+
+---
+
+## Troubleshooting
+- Python or `uv` not:
+  - Help: https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf
+- Claude CLI not found:
+  - Help: https://github.com/CoplayDev/unity-mcp/wiki/2.-Fix-Unity-MCP-and-Claude-Code
+
+---
+
+## Tips
+- Enable “Show Debug Logs” in the header for more details in the Console when diagnosing issues.
+
+---

--- a/UnityMcpBridge/README.md
+++ b/UnityMcpBridge/README.md
@@ -26,7 +26,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
   - Installed / Installed (Embedded) / Not Installed.
 - Mode and ports:
   - Mode: Auto or Standard.
-  - Ports: Unity 6400, MCP Server 6500.
+  - Ports: Unity (varies; shown in UI), MCP 6500.
 - Actions:
   - Auto-Setup: Registers/updates your selected MCP client(s), ensures bridge connectivity. Shows “Connected ✓” after success.
   - Repair Python Env: Rebuilds a clean Python environment (deletes `.venv`, runs `uv sync`).
@@ -75,7 +75,7 @@ Notes:
 ---
 
 ## Troubleshooting
-- Python or `uv` not:
+- Python or `uv` not found:
   - Help: https://github.com/CoplayDev/unity-mcp/wiki/1.-Fix-Unity-MCP-and-Cursor,-VSCode-&-Windsurf
 - Claude CLI not found:
   - Help: https://github.com/CoplayDev/unity-mcp/wiki/2.-Fix-Unity-MCP-and-Claude-Code

--- a/UnityMcpBridge/Runtime/MCPForUnity.Runtime.asmdef
+++ b/UnityMcpBridge/Runtime/MCPForUnity.Runtime.asmdef
@@ -1,6 +1,6 @@
 {
-    "name": "UnityMcpBridge.Runtime",
-    "rootNamespace": "UnityMcpBridge.Runtime",
+    "name": "MCPForUnity.Runtime",
+    "rootNamespace": "MCPForUnity.Runtime",
     "references": [
         "GUID:560b04d1a97f54a46a2660c3cc343a6f" 
     ],

--- a/UnityMcpBridge/Runtime/MCPForUnity.Runtime.asmdef.meta
+++ b/UnityMcpBridge/Runtime/MCPForUnity.Runtime.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7d76fa93cbc5144028727fd2dbac5655
+guid: 562a750ff18ee4193928e885c708fee1
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/UnityMcpBridge/Runtime/Serialization/UnityTypeConverters.cs
+++ b/UnityMcpBridge/Runtime/Serialization/UnityTypeConverters.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 using UnityEditor; // Required for AssetDatabase and EditorUtility
 #endif
 
-namespace UnityMcpBridge.Runtime.Serialization
+namespace MCPForUnity.Runtime.Serialization
 {
     public class Vector3Converter : JsonConverter<Vector3>
     {

--- a/UnityMcpBridge/UnityMcpServer~/src/__init__.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/__init__.py
@@ -1,3 +1,3 @@
 """
-Unity MCP Server package.
+MCP for Unity Server package.
 """ 

--- a/UnityMcpBridge/UnityMcpServer~/src/config.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/config.py
@@ -1,5 +1,5 @@
 """
-Configuration settings for the Unity MCP Server.
+Configuration settings for the MCP for Unity Server.
 This file contains all configurable parameters for the server.
 """
 

--- a/UnityMcpBridge/UnityMcpServer~/src/port_discovery.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/port_discovery.py
@@ -19,7 +19,7 @@ from typing import Optional, List
 import glob
 import socket
 
-logger = logging.getLogger("unity-mcp-server")
+logger = logging.getLogger("mcp-for-unity-server")
 
 class PortDiscovery:
     """Handles port discovery from Unity Bridge registry"""

--- a/UnityMcpBridge/UnityMcpServer~/src/port_discovery.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/port_discovery.py
@@ -1,5 +1,5 @@
 """
-Port discovery utility for Unity MCP Server.
+Port discovery utility for MCP for Unity Server.
 
 What changed and why:
 - Unity now writes a per-project port file named like
@@ -7,7 +7,7 @@ What changed and why:
   each other's saved port. The legacy file `unity-mcp-port.json` may still
   exist.
 - This module now scans for both patterns, prefers the most recently
-  modified file, and verifies that the port is actually a Unity MCP listener
+  modified file, and verifies that the port is actually a MCP for Unity listener
   (quick socket connect + ping) before choosing it.
 """
 
@@ -55,7 +55,7 @@ class PortDiscovery:
     
     @staticmethod
     def _try_probe_unity_mcp(port: int) -> bool:
-        """Quickly check if a Unity MCP listener is on this port.
+        """Quickly check if a MCP for Unity listener is on this port.
         Tries a short TCP connect, sends 'ping', expects a JSON 'pong'.
         """
         try:

--- a/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
+++ b/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "UnityMcpServer"
+name = "MCPForUnityServer"
 version = "2.1.2"
-description = "Unity MCP Server: A Unity package for Unity Editor integration via the Model Context Protocol (MCP)."
+description = "MCP for Unity Server: A Unity package for Unity Editor integration via the Model Context Protocol (MCP)."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = ["httpx>=0.27.2", "mcp[cli]>=1.4.1"]

--- a/UnityMcpBridge/UnityMcpServer~/src/server.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/server.py
@@ -21,7 +21,7 @@ _unity_connection: UnityConnection = None
 async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
     """Handle server startup and shutdown."""
     global _unity_connection
-    logger.info("Unity MCP Server starting up")
+    logger.info("MCP for Unity Server starting up")
     try:
         _unity_connection = get_unity_connection()
         logger.info("Connected to Unity on startup")
@@ -36,7 +36,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
         if _unity_connection:
             _unity_connection.disconnect()
             _unity_connection = None
-        logger.info("Unity MCP Server shut down")
+        logger.info("MCP for Unity Server shut down")
 
 # Initialize MCP server
 mcp = FastMCP(
@@ -52,9 +52,9 @@ register_all_tools(mcp)
 
 @mcp.prompt()
 def asset_creation_strategy() -> str:
-    """Guide for discovering and using Unity MCP tools effectively."""
+    """Guide for discovering and using MCP for Unity tools effectively."""
     return (
-        "Available Unity MCP Server Tools:\\n\\n"
+        "Available MCP for Unity Server Tools:\\n\\n"
         "- `manage_editor`: Controls editor state and queries info.\\n"
         "- `execute_menu_item`: Executes Unity Editor menu items by path.\\n"
         "- `read_console`: Reads or clears Unity console messages, with filtering options.\\n"

--- a/UnityMcpBridge/UnityMcpServer~/src/server.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/server.py
@@ -12,7 +12,7 @@ logging.basicConfig(
     level=getattr(logging, config.log_level),
     format=config.log_format
 )
-logger = logging.getLogger("unity-mcp-server")
+logger = logging.getLogger("mcp-for-unity-server")
 
 # Global connection state
 _unity_connection: UnityConnection = None
@@ -40,7 +40,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 
 # Initialize MCP server
 mcp = FastMCP(
-    "unity-mcp-server",
+    "mcp-for-unity-server",
     description="Unity Editor integration via Model Context Protocol",
     lifespan=server_lifespan
 )

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/__init__.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/__init__.py
@@ -9,7 +9,7 @@ from .execute_menu_item import register_execute_menu_item_tools
 
 def register_all_tools(mcp):
     """Register all refactored tools with the MCP server."""
-    print("Registering Unity MCP Server refactored tools...")
+    print("Registering MCP for Unity Server refactored tools...")
     register_manage_script_tools(mcp)
     register_manage_scene_tools(mcp)
     register_manage_editor_tools(mcp)
@@ -18,4 +18,4 @@ def register_all_tools(mcp):
     register_manage_shader_tools(mcp)
     register_read_console_tools(mcp)
     register_execute_menu_item_tools(mcp)
-    print("Unity MCP Server tool registration complete.")
+    print("MCP for Unity Server tool registration complete.")

--- a/UnityMcpBridge/UnityMcpServer~/src/unity_connection.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/unity_connection.py
@@ -15,7 +15,7 @@ logging.basicConfig(
     level=getattr(logging, config.log_level),
     format=config.log_format
 )
-logger = logging.getLogger("unity-mcp-server")
+logger = logging.getLogger("mcp-for-unity-server")
 
 @dataclass
 class UnityConnection:

--- a/UnityMcpBridge/UnityMcpServer~/src/uv.lock
+++ b/UnityMcpBridge/UnityMcpServer~/src/uv.lock
@@ -371,8 +371,8 @@ wheels = [
 ]
 
 [[package]]
-name = "unitymcpserver"
-version = "2.0.0"
+name = "mcpforunityserver"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/UnityMcpBridge/package.json
+++ b/UnityMcpBridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.coplaydev.unity-mcp",
   "version": "2.1.2",
-  "displayName": "Unity MCP",
+  "displayName": "MCP for Unity",
   "description": "A bridge that connects an LLM to Unity via the MCP (Model Context Protocol). This allows MCP Clients like Claude Desktop or Cursor to directly control your Unity Editor.\n\nJoin Our Discord: https://discord.gg/y4p8KfzrN4",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/CoplayDev/unity-mcp",

--- a/claude-chunk.md
+++ b/claude-chunk.md
@@ -1,7 +1,7 @@
 ### macOS: Claude CLI fails to start (dyld ICU library not loaded)
 
 - Symptoms
-  - Unity MCP error: “Failed to start Claude CLI. dyld: Library not loaded: /usr/local/opt/icu4c/lib/libicui18n.71.dylib …”
+  - MCP For Unity error: “Failed to start Claude CLI. dyld: Library not loaded: /usr/local/opt/icu4c/lib/libicui18n.71.dylib …”
   - Running `claude` in Terminal fails with missing `libicui18n.xx.dylib`.
 
 - Cause
@@ -20,32 +20,32 @@
     nvm install --lts
     nvm use --lts
     npm install -g @anthropic-ai/claude-code
-    # Unity MCP → Claude Code → Choose Claude Location → ~/.nvm/versions/node/<ver>/bin/claude
+    # MCP For Unity → Claude Code → Choose Claude Location → ~/.nvm/versions/node/<ver>/bin/claude
     ```
   - Use the native installer (puts claude in a stable path):
     ```bash
     # macOS/Linux
     curl -fsSL https://claude.ai/install.sh | bash
-    # Unity MCP → Claude Code → Choose Claude Location → /opt/homebrew/bin/claude or ~/.local/bin/claude
+    # MCP For Unity → Claude Code → Choose Claude Location → /opt/homebrew/bin/claude or ~/.local/bin/claude
     ```
 
 - After fixing
-  - In Unity MCP (Claude Code), click “Choose Claude Location” and select the working `claude` binary, then Register again.
+  - In MCP For Unity (Claude Code), click “Choose Claude Location” and select the working `claude` binary, then Register again.
 
 - More details
-  - See: Troubleshooting Unity MCP and Claude Code
+  - See: Troubleshooting MCP For Unity and Claude Code
 
 ---
 
 ### FAQ (Claude Code)
 
 - Q: Unity can’t find `claude` even though Terminal can.
-  - A: macOS apps launched from Finder/Hub don’t inherit your shell PATH. In the Unity MCP window, click “Choose Claude Location” and select the absolute path (e.g., `/opt/homebrew/bin/claude` or `~/.nvm/versions/node/<ver>/bin/claude`).
+  - A: macOS apps launched from Finder/Hub don’t inherit your shell PATH. In the MCP For Unity window, click “Choose Claude Location” and select the absolute path (e.g., `/opt/homebrew/bin/claude` or `~/.nvm/versions/node/<ver>/bin/claude`).
 
 - Q: I installed via NVM; where is `claude`?
   - A: Typically `~/.nvm/versions/node/<ver>/bin/claude`. Our UI also scans NVM versions and you can browse to it via “Choose Claude Location”.
 
 - Q: The Register button says “Claude Not Found”.
-  - A: Install the CLI or set the path. Click the orange “[HELP]” link in the Unity MCP window for step‑by‑step install instructions, then choose the binary location.
+  - A: Install the CLI or set the path. Click the orange “[HELP]” link in the MCP For Unity window for step‑by‑step install instructions, then choose the binary location.
 
 

--- a/claude-chunk.md
+++ b/claude-chunk.md
@@ -1,7 +1,7 @@
 ### macOS: Claude CLI fails to start (dyld ICU library not loaded)
 
 - Symptoms
-  - MCP For Unity error: “Failed to start Claude CLI. dyld: Library not loaded: /usr/local/opt/icu4c/lib/libicui18n.71.dylib …”
+  - MCP for Unity error: “Failed to start Claude CLI. dyld: Library not loaded: /usr/local/opt/icu4c/lib/libicui18n.71.dylib …”
   - Running `claude` in Terminal fails with missing `libicui18n.xx.dylib`.
 
 - Cause
@@ -20,32 +20,32 @@
     nvm install --lts
     nvm use --lts
     npm install -g @anthropic-ai/claude-code
-    # MCP For Unity → Claude Code → Choose Claude Location → ~/.nvm/versions/node/<ver>/bin/claude
+    # MCP for Unity → Claude Code → Choose Claude Location → ~/.nvm/versions/node/<ver>/bin/claude
     ```
   - Use the native installer (puts claude in a stable path):
     ```bash
     # macOS/Linux
     curl -fsSL https://claude.ai/install.sh | bash
-    # MCP For Unity → Claude Code → Choose Claude Location → /opt/homebrew/bin/claude or ~/.local/bin/claude
+    # MCP for Unity → Claude Code → Choose Claude Location → /opt/homebrew/bin/claude or ~/.local/bin/claude
     ```
 
 - After fixing
-  - In MCP For Unity (Claude Code), click “Choose Claude Location” and select the working `claude` binary, then Register again.
+  - In MCP for Unity (Claude Code), click “Choose Claude Location” and select the working `claude` binary, then Register again.
 
 - More details
-  - See: Troubleshooting MCP For Unity and Claude Code
+  - See: Troubleshooting MCP for Unity and Claude Code
 
 ---
 
 ### FAQ (Claude Code)
 
 - Q: Unity can’t find `claude` even though Terminal can.
-  - A: macOS apps launched from Finder/Hub don’t inherit your shell PATH. In the MCP For Unity window, click “Choose Claude Location” and select the absolute path (e.g., `/opt/homebrew/bin/claude` or `~/.nvm/versions/node/<ver>/bin/claude`).
+  - A: macOS apps launched from Finder/Hub don’t inherit your shell PATH. In the MCP for Unity window, click “Choose Claude Location” and select the absolute path (e.g., `/opt/homebrew/bin/claude` or `~/.nvm/versions/node/<ver>/bin/claude`).
 
 - Q: I installed via NVM; where is `claude`?
   - A: Typically `~/.nvm/versions/node/<ver>/bin/claude`. Our UI also scans NVM versions and you can browse to it via “Choose Claude Location”.
 
 - Q: The Register button says “Claude Not Found”.
-  - A: Install the CLI or set the path. Click the orange “[HELP]” link in the MCP For Unity window for step‑by‑step install instructions, then choose the binary location.
+  - A: Install the CLI or set the path. Click the orange “[HELP]” link in the MCP for Unity window for step‑by‑step install instructions, then choose the binary location.
 
 

--- a/deploy-dev.bat
+++ b/deploy-dev.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 echo ===============================================
-echo MCP For Unity Development Deployment Script
+echo MCP for Unity Development Deployment Script
 echo ===============================================
 echo.
 

--- a/deploy-dev.bat
+++ b/deploy-dev.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 echo ===============================================
-echo Unity MCP Development Deployment Script
+echo MCP For Unity Development Deployment Script
 echo ===============================================
 echo.
 

--- a/mcp_source.py
+++ b/mcp_source.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Generic helper to switch the Unity MCP package source in a Unity project's
+Generic helper to switch the MCP for Unity package source in a Unity project's
 Packages/manifest.json.  This is useful for switching between upstream and local repos while working on the MCP.
 
 Usage:
@@ -109,7 +109,7 @@ def build_options(repo_root: pathlib.Path, branch: str, origin_https: str):
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Switch Unity MCP package source")
+    p = argparse.ArgumentParser(description="Switch MCP for Unity package source")
     p.add_argument("--manifest", help="Path to Packages/manifest.json")
     p.add_argument("--repo", help="Path to unity-mcp repo root (for local file option)")
     p.add_argument("--choice", choices=["1", "2", "3"], help="Pick option non-interactively")

--- a/restore-dev.bat
+++ b/restore-dev.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 echo ===============================================
-echo Unity MCP Development Restore Script
+echo MCP For Unity Development Restore Script
 echo ===============================================
 echo.
 echo Note: The Python server is bundled under UnityMcpBridge\UnityMcpServer~ in the package.

--- a/restore-dev.bat
+++ b/restore-dev.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 echo ===============================================
-echo MCP For Unity Development Restore Script
+echo MCP for Unity Development Restore Script
 echo ===============================================
 echo.
 echo Note: The Python server is bundled under UnityMcpBridge\UnityMcpServer~ in the package.


### PR DESCRIPTION
We can use Unity MCP because it's too affiliated. I think "MCP For Unity" is good because:

- It passes basic asset store validations
- It's similar to the current name
- Good SEO as @dsarno pointed out
- Isn't too heavy hand on the branding (don't want to rub people the wrong way, or have them jump to conclusions about who we are at Coplay)

Aside from the namespace, I changed user facing references of "Unity MCP" to "MCP for Unity".

Once merged in, we should do a major version update and explain the name change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Rebranded “Unity MCP” to “MCP for Unity” across UI, menus (Window > MCP for Unity), logs, and messages.
  - Editor window and bridge renamed; preference keys migrated to MCPForUnity.*.
  - Startup and port handling improved: safer server startup with graceful Unity-connection fallback and port selection now prioritizes stored ports.

- Documentation
  - All docs updated to new branding; added an Editor Plugin Guide with setup and troubleshooting.

- Chores
  - Package/display names and assembly metadata updated to MCP for Unity; no functional API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->