### PR TITLE
fix: Replace missing TicTacToe3D with existing CustomComponent in Com…

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ComponentResolverTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ComponentResolverTests.cs
@@ -105,7 +105,7 @@ namespace MCPForUnityTests.Editor.Tools
         public void TryResolve_PrefersPlayerAssemblies()
         {
             // Test that custom user scripts (in Player assemblies) are found
-            bool result = ComponentResolver.TryResolve("TicTacToe3D", out Type type, out string error);
+            bool result = ComponentResolver.TryResolve("CustomComponent", out Type type, out string error);
             
             Assert.IsTrue(result, "Should resolve user script from Player assembly");
             Assert.IsNotNull(type, "Should return valid type");
@@ -114,6 +114,10 @@ namespace MCPForUnityTests.Editor.Tools
             string assemblyName = type.Assembly.GetName().Name;
             Assert.That(assemblyName, Does.Not.Contain("Editor"), 
                 "User script should come from Player assembly, not Editor assembly");
+            
+            // Verify it's from the TestAsmdef assembly (which is a Player assembly)
+            Assert.AreEqual("TestAsmdef", assemblyName, 
+                "CustomComponent should be resolved from TestAsmdef assembly");
         }
 
         [Test] 


### PR DESCRIPTION
…ponentResolver test

The TryResolve_PrefersPlayerAssemblies test was failing in CI because it referenced TicTacToe3D.cs which exists only locally and is not committed to the repository.

- Replace test reference from "TicTacToe3D" to "CustomComponent"
- CustomComponent exists in Assets/Scripts/TestAsmdef/ and is tracked in git
- CustomComponent is properly compiled into the TestAsmdef Player assembly
- Add explicit assertion to verify resolution from correct TestAsmdef assembly
- Test maintains same functionality: verifying ComponentResolver finds user scripts from Player assemblies

