### PR TITLE
Fix: Unity Editor reload crash + debug-noise reduction

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -66,6 +66,38 @@ To find it reliably:
 
 Note: In recent builds, the Python server sources are also bundled inside the package under `UnityMcpServer~/src`. This is handy for local testing or pointing MCP clients directly at the packaged server.
 
+## MCP Bridge Stress Test
+
+An on-demand stress utility exercises the MCP bridge with multiple concurrent clients while triggering periodic asset refreshes and script reloads.
+
+### Script
+- `tools/stress_mcp.py`
+
+### What it does
+- Starts N TCP clients against the Unity MCP bridge (default port auto-discovered from `~/.unity-mcp/unity-mcp-status-*.json`).
+- Sends a mix of framed `ping`, `execute_menu_item` (e.g., `Assets/Refresh`), and small `manage_gameobject` requests.
+- In parallel, toggles a comment in a large C# file to encourage domain reloads, and triggers `Assets/Refresh` via MCP.
+
+### Usage (local)
+```bash
+python3 tools/stress_mcp.py --duration 60 --clients 8
+```
+
+Flags:
+- `--project` Unity project path (auto-detected to the included test project by default)
+- `--unity-file` C# file to toggle (defaults to the long test script)
+- `--clients` number of concurrent clients (default 10)
+- `--duration` seconds to run (default 60)
+
+Expected outcome:
+- No Unity Editor crashes during reload churn
+- Clients reconnect cleanly after reloads
+- Script prints a JSON summary of request counts and disconnects
+
+CI guidance:
+- Keep this out of default PR CI due to Unity/editor requirements and runtime variability.
+- Optionally run it as a manual workflow or nightly job on a Unity-capable runner.
+
 ## CI Test Workflow (GitHub Actions)
 
 We provide a CI job to run a Natural Language Editing mini-suite against the Unity test project. It spins up a headless Unity container and connects via the MCP bridge.

--- a/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
+++ b/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
@@ -27,7 +27,7 @@ namespace MCPForUnity.Editor.Tools
         /// </summary>
         public static object HandleCommand(JObject @params)
         {
-            string action = @params["action"]?.ToString().ToLower() ?? "execute"; // Default action
+            string action = (@params["action"]?.ToString())?.ToLowerInvariant() ?? "execute"; // Default action
 
             try
             {

--- a/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
+++ b/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
@@ -96,14 +96,15 @@ namespace MCPForUnity.Editor.Tools
 
             try
             {
-                // Trace incoming execute requests
-                Debug.Log($"[ExecuteMenuItem] Request to execute menu: '{menuPath}'");
+                // Trace incoming execute requests (debug-gated)
+                McpLog.Info($"[ExecuteMenuItem] Request to execute menu: '{menuPath}'", always: false);
 
                 // Execute synchronously. This code runs on the Editor main thread in our bridge path.
                 bool executed = EditorApplication.ExecuteMenuItem(menuPath);
                 if (executed)
                 {
-                    Debug.Log($"[ExecuteMenuItem] Executed successfully: '{menuPath}'");
+                    // Success trace (debug-gated)
+                    McpLog.Info($"[ExecuteMenuItem] Executed successfully: '{menuPath}'", always: false);
                     return Response.Success(
                         $"Executed menu item: '{menuPath}'",
                         new { executed = true, menuPath }

--- a/tools/stress_mcp.py
+++ b/tools/stress_mcp.py
@@ -6,6 +6,17 @@ import os
 import struct
 import time
 from pathlib import Path
+import random
+import sys
+
+
+TIMEOUT = float(os.environ.get("MCP_STRESS_TIMEOUT", "2.0"))
+DEBUG = os.environ.get("MCP_STRESS_DEBUG", "").lower() in ("1", "true", "yes")
+
+
+def dlog(*args):
+    if DEBUG:
+        print(*args, file=sys.stderr)
 
 
 def find_status_files() -> list[Path]:
@@ -60,7 +71,7 @@ async def write_frame(writer: asyncio.StreamWriter, payload: bytes) -> None:
     header = struct.pack(">Q", len(payload))
     writer.write(header)
     writer.write(payload)
-    await writer.drain()
+    await asyncio.wait_for(writer.drain(), timeout=TIMEOUT)
 
 
 async def do_handshake(reader: asyncio.StreamReader) -> None:
@@ -83,152 +94,203 @@ def make_execute_menu_item(menu_path: str) -> bytes:
 async def client_loop(idx: int, host: str, port: int, stop_time: float, stats: dict):
     reconnect_delay = 0.2
     while time.time() < stop_time:
+        writer = None
         try:
-            reader, writer = await asyncio.open_connection(host, port)
-            await do_handshake(reader)
+            # slight stagger to prevent burst synchronization across clients
+            await asyncio.sleep(0.003 * (idx % 11))
+            reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=TIMEOUT)
+            await asyncio.wait_for(do_handshake(reader), timeout=TIMEOUT)
             # Send a quick ping first
             await write_frame(writer, make_ping_frame())
-            _ = await read_frame(reader)  # ignore content
+            _ = await asyncio.wait_for(read_frame(reader), timeout=TIMEOUT)  # ignore content
 
             # Main activity loop (keep-alive + light load). Edit spam handled by reload_churn_task.
             while time.time() < stop_time:
                 # Ping-only; edits are sent via reload_churn_task to avoid console spam
                 await write_frame(writer, make_ping_frame())
-                _ = await read_frame(reader)
+                _ = await asyncio.wait_for(read_frame(reader), timeout=TIMEOUT)
                 stats["pings"] += 1
-                await asyncio.sleep(0.02)
+                await asyncio.sleep(0.02 + random.uniform(-0.003, 0.003))
 
-        except (ConnectionError, OSError, asyncio.IncompleteReadError):
+        except (ConnectionError, OSError, asyncio.IncompleteReadError, asyncio.TimeoutError):
             stats["disconnects"] += 1
+            dlog(f"[client {idx}] disconnect/backoff {reconnect_delay}s")
             await asyncio.sleep(reconnect_delay)
             reconnect_delay = min(reconnect_delay * 1.5, 2.0)
             continue
         except Exception:
             stats["errors"] += 1
+            dlog(f"[client {idx}] unexpected error")
             await asyncio.sleep(0.2)
             continue
         finally:
-            try:
-                writer.close()  # type: ignore
-                await writer.wait_closed()  # type: ignore
-            except Exception:
-                pass
+            if writer is not None:
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except Exception:
+                    pass
 
 
-async def reload_churn_task(project_path: str, stop_time: float, unity_file: str | None, host: str, port: int, stats: dict):
+async def reload_churn_task(project_path: str, stop_time: float, unity_file: str | None, host: str, port: int, stats: dict, storm_count: int = 1):
     # Use script edit tool to touch a C# file, which triggers compilation reliably
     path = Path(unity_file) if unity_file else None
     seq = 0
     proj_root = Path(project_path).resolve() if project_path else None
+    # Build candidate list for storm mode
+    candidates: list[Path] = []
+    if proj_root:
+        try:
+            for p in (proj_root / "Assets").rglob("*.cs"):
+                candidates.append(p.resolve())
+        except Exception:
+            candidates = []
+    if path and path.exists():
+        rp = path.resolve()
+        if rp not in candidates:
+            candidates.append(rp)
     while time.time() < stop_time:
         try:
             if path and path.exists():
-                # Build a tiny ApplyTextEdits request that toggles a trailing comment
-                relative = None
-                try:
-                    # Derive Unity-relative path under Assets/ (cross-platform)
-                    resolved = path.resolve()
-                    parts = list(resolved.parts)
-                    if "Assets" in parts:
-                        i = parts.index("Assets")
-                        relative = Path(*parts[i:]).as_posix()
-                    elif proj_root and str(resolved).startswith(str(proj_root)):
-                        rel = resolved.relative_to(proj_root)
-                        parts2 = list(rel.parts)
-                        if "Assets" in parts2:
-                            i2 = parts2.index("Assets")
-                            relative = Path(*parts2[i2:]).as_posix()
-                except Exception:
+                # Determine files to touch this cycle
+                targets: list[Path]
+                if storm_count and storm_count > 1 and candidates:
+                    k = min(max(1, storm_count), len(candidates))
+                    targets = random.sample(candidates, k)
+                else:
+                    targets = [path]
+
+                for tpath in targets:
+                    # Build a tiny ApplyTextEdits request that toggles a trailing comment
                     relative = None
-
-                if relative:
-                    # Derive name and directory for ManageScript and compute precondition SHA + EOF position
-                    name_base = Path(relative).stem
-                    dir_path = str(Path(relative).parent).replace('\\', '/')
-
-                    # 1) Read current contents via manage_script.read to compute SHA and true EOF location
                     try:
-                        reader, writer = await asyncio.open_connection(host, port)
-                        await do_handshake(reader)
-                        read_payload = {
-                            "type": "manage_script",
-                            "params": {
-                                "action": "read",
-                                "name": name_base,
-                                "path": dir_path
-                            }
-                        }
-                        await write_frame(writer, json.dumps(read_payload).encode("utf-8"))
-                        resp = await read_frame(reader)
-                        writer.close()
-                        await writer.wait_closed()
+                        # Derive Unity-relative path under Assets/ (cross-platform)
+                        resolved = tpath.resolve()
+                        parts = list(resolved.parts)
+                        if "Assets" in parts:
+                            i = parts.index("Assets")
+                            relative = Path(*parts[i:]).as_posix()
+                        elif proj_root and str(resolved).startswith(str(proj_root)):
+                            rel = resolved.relative_to(proj_root)
+                            parts2 = list(rel.parts)
+                            if "Assets" in parts2:
+                                i2 = parts2.index("Assets")
+                                relative = Path(*parts2[i2:]).as_posix()
+                    except Exception:
+                        relative = None
 
-                        read_obj = json.loads(resp.decode("utf-8", errors="ignore"))
-                        result = read_obj.get("result", read_obj) if isinstance(read_obj, dict) else {}
-                        if not result.get("success"):
+                    if relative:
+                        # Derive name and directory for ManageScript and compute precondition SHA + EOF position
+                        name_base = Path(relative).stem
+                        dir_path = str(Path(relative).parent).replace('\\', '/')
+
+                        # 1) Read current contents via manage_script.read to compute SHA and true EOF location
+                        contents = None
+                        read_success = False
+                        for attempt in range(3):
+                            writer = None
+                            try:
+                                reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=TIMEOUT)
+                                await asyncio.wait_for(do_handshake(reader), timeout=TIMEOUT)
+                                read_payload = {
+                                    "type": "manage_script",
+                                    "params": {
+                                        "action": "read",
+                                        "name": name_base,
+                                        "path": dir_path
+                                    }
+                                }
+                                await write_frame(writer, json.dumps(read_payload).encode("utf-8"))
+                                resp = await asyncio.wait_for(read_frame(reader), timeout=TIMEOUT)
+
+                                read_obj = json.loads(resp.decode("utf-8", errors="ignore"))
+                                result = read_obj.get("result", read_obj) if isinstance(read_obj, dict) else {}
+                                if result.get("success"):
+                                    data_obj = result.get("data", {})
+                                    contents = data_obj.get("contents") or ""
+                                    read_success = True
+                                    break
+                            except Exception:
+                                # retry with backoff
+                                await asyncio.sleep(0.2 * (2 ** attempt) + random.uniform(0.0, 0.1))
+                            finally:
+                                if 'writer' in locals() and writer is not None:
+                                    try:
+                                        writer.close()
+                                        await writer.wait_closed()
+                                    except Exception:
+                                        pass
+
+                        if not read_success or contents is None:
                             stats["apply_errors"] = stats.get("apply_errors", 0) + 1
                             await asyncio.sleep(0.5)
                             continue
-                        data_obj = result.get("data", {})
-                        contents = data_obj.get("contents") or ""
-                    except Exception:
-                        stats["apply_errors"] = stats.get("apply_errors", 0) + 1
-                        await asyncio.sleep(0.5)
-                        continue
 
-                    # Compute SHA and EOF insertion point
-                    import hashlib
-                    sha = hashlib.sha256(contents.encode("utf-8")).hexdigest()
-                    lines = contents.splitlines(keepends=True)
-                    # Insert at true EOF (safe against header guards)
-                    end_line = len(lines) + 1  # 1-based exclusive end
-                    end_col = 1
+                        # Compute SHA and EOF insertion point
+                        import hashlib
+                        sha = hashlib.sha256(contents.encode("utf-8")).hexdigest()
+                        lines = contents.splitlines(keepends=True)
+                        # Insert at true EOF (safe against header guards)
+                        end_line = len(lines) + 1  # 1-based exclusive end
+                        end_col = 1
 
-                    # Build a unique marker append; ensure it begins with a newline if needed
-                    marker = f"// MCP_STRESS seq={seq} time={int(time.time())}"
-                    seq += 1
-                    insert_text = ("\n" if not contents.endswith("\n") else "") + marker + "\n"
+                        # Build a unique marker append; ensure it begins with a newline if needed
+                        marker = f"// MCP_STRESS seq={seq} time={int(time.time())}"
+                        seq += 1
+                        insert_text = ("\n" if not contents.endswith("\n") else "") + marker + "\n"
 
-                    # 2) Apply text edits with immediate refresh and precondition
-                    apply_payload = {
-                        "type": "manage_script",
-                        "params": {
-                            "action": "apply_text_edits",
-                            "name": name_base,
-                            "path": dir_path,
-                            "edits": [
-                                {
-                                    "startLine": end_line,
-                                    "startCol": end_col,
-                                    "endLine": end_line,
-                                    "endCol": end_col,
-                                    "newText": insert_text
-                                }
-                            ],
-                            "precondition_sha256": sha,
-                            "options": {"refresh": "immediate", "validate": "standard"}
+                        # 2) Apply text edits with immediate refresh and precondition
+                        apply_payload = {
+                            "type": "manage_script",
+                            "params": {
+                                "action": "apply_text_edits",
+                                "name": name_base,
+                                "path": dir_path,
+                                "edits": [
+                                    {
+                                        "startLine": end_line,
+                                        "startCol": end_col,
+                                        "endLine": end_line,
+                                        "endCol": end_col,
+                                        "newText": insert_text
+                                    }
+                                ],
+                                "precondition_sha256": sha,
+                                "options": {"refresh": "immediate", "validate": "standard"}
+                            }
                         }
-                    }
 
-                    try:
-                        reader, writer = await asyncio.open_connection(host, port)
-                        await do_handshake(reader)
-                        await write_frame(writer, json.dumps(apply_payload).encode("utf-8"))
-                        resp = await read_frame(reader)
-                        try:
-                            data = json.loads(resp.decode("utf-8", errors="ignore"))
-                            result = data.get("result", data) if isinstance(data, dict) else {}
-                            ok = bool(result.get("success", False))
-                            if ok:
-                                stats["applies"] = stats.get("applies", 0) + 1
-                            else:
-                                stats["apply_errors"] = stats.get("apply_errors", 0) + 1
-                        except Exception:
+                        apply_success = False
+                        for attempt in range(3):
+                            writer = None
+                            try:
+                                reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=TIMEOUT)
+                                await asyncio.wait_for(do_handshake(reader), timeout=TIMEOUT)
+                                await write_frame(writer, json.dumps(apply_payload).encode("utf-8"))
+                                resp = await asyncio.wait_for(read_frame(reader), timeout=TIMEOUT)
+                                try:
+                                    data = json.loads(resp.decode("utf-8", errors="ignore"))
+                                    result = data.get("result", data) if isinstance(data, dict) else {}
+                                    ok = bool(result.get("success", False))
+                                    if ok:
+                                        stats["applies"] = stats.get("applies", 0) + 1
+                                        apply_success = True
+                                        break
+                                except Exception:
+                                    # fall through to retry
+                                    pass
+                            except Exception:
+                                # retry with backoff
+                                await asyncio.sleep(0.2 * (2 ** attempt) + random.uniform(0.0, 0.1))
+                            finally:
+                                if 'writer' in locals() and writer is not None:
+                                    try:
+                                        writer.close()
+                                        await writer.wait_closed()
+                                    except Exception:
+                                        pass
+                        if not apply_success:
                             stats["apply_errors"] = stats.get("apply_errors", 0) + 1
-                        writer.close()
-                        await writer.wait_closed()
-                    except Exception:
-                        stats["apply_errors"] = stats.get("apply_errors", 0) + 1
 
         except Exception:
             pass
@@ -242,6 +304,7 @@ async def main():
     ap.add_argument("--unity-file", default=str(Path(__file__).resolve().parents[1] / "TestProjects" / "UnityMCPTests" / "Assets" / "Scripts" / "LongUnityScriptClaudeTest.cs"))
     ap.add_argument("--clients", type=int, default=10)
     ap.add_argument("--duration", type=int, default=60)
+    ap.add_argument("--storm-count", type=int, default=1, help="Number of scripts to touch each cycle")
     args = ap.parse_args()
 
     port = discover_port(args.project)
@@ -255,7 +318,7 @@ async def main():
         tasks.append(asyncio.create_task(client_loop(i, args.host, port, stop_time, stats)))
 
     # Spawn reload churn task
-    tasks.append(asyncio.create_task(reload_churn_task(args.project, stop_time, args.unity_file, args.host, port, stats)))
+    tasks.append(asyncio.create_task(reload_churn_task(args.project, stop_time, args.unity_file, args.host, port, stats, storm_count=args.storm_count)))
 
     await asyncio.gather(*tasks, return_exceptions=True)
     print(json.dumps({"port": port, "stats": stats}, indent=2))

--- a/tools/stress_mcp.py
+++ b/tools/stress_mcp.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+import asyncio
+import argparse
+import json
+import os
+import random
+import socket
+import struct
+import sys
+import time
+from pathlib import Path
+
+
+def find_status_files() -> list[Path]:
+    home = Path.home()
+    status_dir = Path(os.environ.get("UNITY_MCP_STATUS_DIR", home / ".unity-mcp"))
+    if not status_dir.exists():
+        return []
+    return sorted(status_dir.glob("unity-mcp-status-*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+
+
+def discover_port(project_path: str | None) -> int:
+    # Default bridge port if nothing found
+    default_port = 6400
+    files = find_status_files()
+    for f in files:
+        try:
+            data = json.loads(f.read_text())
+            port = int(data.get("unity_port", 0) or 0)
+            proj = data.get("project_path") or ""
+            if project_path:
+                # Match status for the given project if possible
+                if proj and project_path in proj:
+                    if 0 < port < 65536:
+                        return port
+            else:
+                if 0 < port < 65536:
+                    return port
+        except Exception:
+            pass
+    return default_port
+
+
+async def read_exact(reader: asyncio.StreamReader, n: int) -> bytes:
+    buf = b""
+    while len(buf) < n:
+        chunk = await reader.read(n - len(buf))
+        if not chunk:
+            raise ConnectionError("Connection closed while reading")
+        buf += chunk
+    return buf
+
+
+async def read_frame(reader: asyncio.StreamReader) -> bytes:
+    header = await read_exact(reader, 8)
+    (length,) = struct.unpack(">Q", header)
+    if length <= 0 or length > (64 * 1024 * 1024):
+        raise ValueError(f"Invalid frame length: {length}")
+    return await read_exact(reader, length)
+
+
+async def write_frame(writer: asyncio.StreamWriter, payload: bytes) -> None:
+    header = struct.pack(">Q", len(payload))
+    writer.write(header)
+    writer.write(payload)
+    await writer.drain()
+
+
+async def do_handshake(reader: asyncio.StreamReader) -> None:
+    # Server sends a single line handshake: "WELCOME UNITY-MCP 1 FRAMING=1\n"
+    line = await reader.readline()
+    if not line or b"WELCOME UNITY-MCP" not in line:
+        raise ConnectionError(f"Unexpected handshake from server: {line!r}")
+
+
+def make_ping_frame() -> bytes:
+    return b"ping"
+
+
+def make_execute_menu_item(menu_path: str) -> bytes:
+    payload = {
+        "type": "execute_menu_item",
+        "params": {"action": "execute", "menu_path": menu_path},
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+def make_manage_gameobject_modify_dummy(target_name: str) -> bytes:
+    payload = {
+        "type": "manage_gameobject",
+        "params": {
+            "action": "modify",
+            "target": target_name,
+            "search_method": "by_name",
+            # Intentionally small and sometimes invalid to exercise error paths safely
+            "componentProperties": {
+                "Transform": {"localScale": {"x": 1.0, "y": 1.0, "z": 1.0}},
+                "Rigidbody": {"velocity": "invalid_type"},
+            },
+        },
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+async def client_loop(idx: int, host: str, port: int, stop_time: float, stats: dict):
+    reconnect_delay = 0.2
+    while time.time() < stop_time:
+        try:
+            reader, writer = await asyncio.open_connection(host, port)
+            await do_handshake(reader)
+            # Send a quick ping first
+            await write_frame(writer, make_ping_frame())
+            _ = await read_frame(reader)  # ignore content
+
+            # Main activity loop
+            while time.time() < stop_time:
+                r = random.random()
+                if r < 0.70:
+                    # Ping
+                    await write_frame(writer, make_ping_frame())
+                    _ = await read_frame(reader)
+                    stats["pings"] += 1
+                elif r < 0.90:
+                    # Lightweight menu execute: Assets/Refresh
+                    await write_frame(writer, make_execute_menu_item("Assets/Refresh"))
+                    _ = await read_frame(reader)
+                    stats["menus"] += 1
+                else:
+                    # Small manage_gameobject request (may legitimately error if target not found)
+                    await write_frame(writer, make_manage_gameobject_modify_dummy("__MCP_Stress_Object__"))
+                    _ = await read_frame(reader)
+                    stats["mods"] += 1
+
+                await asyncio.sleep(0.01)
+
+        except (ConnectionError, OSError, asyncio.IncompleteReadError):
+            stats["disconnects"] += 1
+            await asyncio.sleep(reconnect_delay)
+            reconnect_delay = min(reconnect_delay * 1.5, 2.0)
+            continue
+        except Exception:
+            stats["errors"] += 1
+            await asyncio.sleep(0.2)
+            continue
+        finally:
+            try:
+                writer.close()  # type: ignore
+                await writer.wait_closed()  # type: ignore
+            except Exception:
+                pass
+
+
+async def reload_churn_task(project_path: str, stop_time: float, unity_file: str | None, host: str, port: int):
+    # Toggle a comment in a large .cs file to force a recompilation; then request Assets/Refresh
+    path = Path(unity_file) if unity_file else None
+    toggle = True
+    while time.time() < stop_time:
+        try:
+            if path and path.exists():
+                s = path.read_text(encoding="utf-8", errors="ignore")
+                marker_on = "// MCP_STRESS_ON"
+                marker_off = "// MCP_STRESS_OFF"
+                if toggle:
+                    if marker_on not in s:
+                        path.write_text(s + ("\n" if not s.endswith("\n") else "") + marker_on + "\n", encoding="utf-8")
+                else:
+                    if marker_off not in s:
+                        path.write_text(s + ("\n" if not s.endswith("\n") else "") + marker_off + "\n", encoding="utf-8")
+                toggle = not toggle
+
+            # Ask Unity to refresh assets (safe, Editor main thread)
+            try:
+                reader, writer = await asyncio.open_connection(host, port)
+                await do_handshake(reader)
+                await write_frame(writer, make_execute_menu_item("Assets/Refresh"))
+                _ = await read_frame(reader)
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+        except Exception:
+            pass
+        await asyncio.sleep(10.0)
+
+
+async def main():
+    ap = argparse.ArgumentParser(description="Stress test the Unity MCP bridge with concurrent clients and reload churn")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--project", default=str(Path(__file__).resolve().parents[1] / "TestProjects" / "UnityMCPTests"))
+    ap.add_argument("--unity-file", default=str(Path(__file__).resolve().parents[1] / "TestProjects" / "UnityMCPTests" / "Assets" / "Scripts" / "LongUnityScriptClaudeTest.cs"))
+    ap.add_argument("--clients", type=int, default=10)
+    ap.add_argument("--duration", type=int, default=60)
+    args = ap.parse_args()
+
+    port = discover_port(args.project)
+    stop_time = time.time() + max(10, args.duration)
+
+    stats = {"pings": 0, "menus": 0, "mods": 0, "disconnects": 0, "errors": 0}
+    tasks = []
+
+    # Spawn clients
+    for i in range(max(1, args.clients)):
+        tasks.append(asyncio.create_task(client_loop(i, args.host, port, stop_time, stats)))
+
+    # Spawn reload churn task
+    tasks.append(asyncio.create_task(reload_churn_task(args.project, stop_time, args.unity_file, args.host, port)))
+
+    await asyncio.gather(*tasks, return_exceptions=True)
+    print(json.dumps({"port": port, "stats": stats}, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass
+
+


### PR DESCRIPTION
This PR hardens the Unity bridge to survive assembly reloads without native/mono crashes and reduces console noise during stress:

- Cooperative cancellation and safe shutdown in `MCPForUnityBridge`:
  - Cancel listener/clients, brief join, then unhook editor events
  - Reentrancy guard on `ProcessCommands`
  - No file I/O in `beforeAssemblyReload`
- Gate noisy ExecuteMenuItem logs behind the “Show Debug Logs” toggle
- Add `tools/stress_mcp.py` and docs to run an on-demand multi-client/reload churn stress

Why it matters:
- Eliminates common reload-time races that caused instability/crashes
- Keeps the console clean under heavy automated usage
- Provides a simple stress harness to validate stability locally or in nightly CI

Notes:
- No changes needed to the Python server for this issue
- Validated via Unity EditMode tests and 60s multi-client stress (no crashes)

Aimed at fixing https://github.com/CoplayDev/unity-mcp/issues/238, maybe helps with #257 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an on-demand MCP bridge stress-test utility to simulate many clients, induce rapid script reloads, and output a JSON summary.

- Improvements
  - More robust bridge lifecycle (graceful start/stop, cancellation, timeouts, framed I/O), reentrancy protection, safer command handling, and reduced nonessential logging.

- Documentation
  - Detailed stress-test usage, flags, examples, expected outcomes, CI workflow added in two locations.

- Tests
  - Enhanced tests to assert structured error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->