### PR TITLE
fix / Add Windows legacy server cleanup fix

### DIFF
--- a/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
+++ b/UnityMcpBridge/Editor/Helpers/ServerInstaller.cs
@@ -314,6 +314,11 @@ namespace MCPForUnity.Editor.Helpers
                 string roaming = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) ?? string.Empty;
                 if (!string.IsNullOrEmpty(roaming))
                     roots.Add(Path.Combine(roaming, "UnityMCP", "UnityMcpServer"));
+                // Windows legacy: early installers/dev scripts used %LOCALAPPDATA%\Programs\UnityMCP\UnityMcpServer
+                // Detect this location so we can clean up older copies during install/update.
+                string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) ?? string.Empty;
+                if (!string.IsNullOrEmpty(localAppData))
+                    roots.Add(Path.Combine(localAppData, "Programs", "UnityMCP", "UnityMcpServer"));
             }
             catch { }
             return roots;


### PR DESCRIPTION
Legacy windows users were still being pointed to a server dir in the wrong place

- Detect and clean up legacy server installations in LocalApplicationData
- Prevents accumulation of old server copies during package updates
- Improves cleanup of Windows-specific legacy installation paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer behavior by detecting an additional legacy install location, ensuring older copies are properly removed during install or update.
  * Reduces duplicate installations, prevents potential conflicts, and frees disk space by cleaning up outdated server files automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->