### PR TITLE
Specify version for Microsoft.CodeAnalysis.CSharp package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ MCP for Unity connects your tools using two components:
         **Method 1: NuGet for Unity (Recommended)**
         1. Install [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity)
         2. Go to `Window > NuGet Package Manager`
-        3. Search for `Microsoft.CodeAnalysis.CSharp` and install the package
+        3. Search for `Microsoft.CodeAnalysis.CSharp`, select version 3.11.0 and install the package
         5. Go to `Player Settings > Scripting Define Symbols`
         6. Add `USE_ROSLYN`
         7. Restart Unity


### PR DESCRIPTION
As reported in issue #276 .

This pull request updates the installation instructions in the `README.md` to specify the required version of a dependency. The change clarifies that version 3.11.0 of the `Microsoft.CodeAnalysis.CSharp` package should be installed when using NuGet for Unity.

- Documentation update:
  * Updated the NuGet installation instructions to specify installing `Microsoft.CodeAnalysis.CSharp` version 3.11.0 in the `README.md`.