### PR TITLE
fix: add parameter validation to manage_gameobject tool

### DIFF
--- a/UnityMcpBridge/UnityMcpServer~/src/tools/manage_gameobject.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/manage_gameobject.py
@@ -9,11 +9,11 @@ from unity_connection import send_command_with_retry
 def register_manage_gameobject_tools(mcp: FastMCP):
     """Register all GameObject management tools with the MCP server."""
 
-    @mcp.tool(name="manage_gameobject", description="Manage GameObjects. Note: for 'get_components', the `data` field contains a dictionary of component names and their serialized properties.")
+    @mcp.tool(name="manage_gameobject", description="Manage GameObjects. Note: for 'get_components', the `data` field contains a dictionary of component names and their serialized properties. For 'get_component', specify 'component_name' to retrieve only that component's serialized data.")
     @telemetry_tool("manage_gameobject")
     def manage_gameobject(
         ctx: Context,
-        action: Annotated[Literal["create", "modify", "delete", "find", "add_component", "remove_component", "set_component_property", "get_components"], "Perform CRUD operations on GameObjects and components."],
+        action: Annotated[Literal["create", "modify", "delete", "find", "add_component", "remove_component", "set_component_property", "get_components", "get_component"], "Perform CRUD operations on GameObjects and components."],
         target: Annotated[str,
                           "GameObject identifier by name or path for modify/delete/component actions"] | None = None,
         search_method: Annotated[Literal["by_id", "by_name", "by_path", "by_tag", "by_layer", "by_component"],


### PR DESCRIPTION
Latest `manage_gameobject` had trouble with the "find" operation.  E.g. "`Find the "Player" object in the hierarchy`" returns "not found" even if object is there.  This fixes those issues.

- Prevent silent failures when using 'name' instead of 'search_term' for find action
- Add clear error messages guiding users to correct parameter usage
- Validate that 'search_term' is only used with 'find' action
- Update parameter annotations to clarify when each parameter should be used

Also added a `get_component` action to manage_gameobject, which returns data from a single component, rather than a full data dump of all serialized component data from `get_components` -- which should probably be deprecated come to think of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Constrained search method options for more predictable searches.
  - Runtime validation enforcing correct parameter combinations per action.

- Bug Fixes
  - Prevents using name for find actions; requires search_term when finding.
  - Blocks providing search_term for create/modify actions to avoid accidental misuse.

- Documentation
  - Clarified guidance: use name only for create/modify, and search_term only for find.
  - Improved help text for selecting a search method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->