### PR TITLE
Fix read_console includeStacktrace parameter behavior

### DIFF
--- a/UnityMcpBridge/Editor/Tools/ReadConsole.cs
+++ b/UnityMcpBridge/Editor/Tools/ReadConsole.cs
@@ -303,14 +303,18 @@ namespace MCPForUnity.Editor.Tools
 
                     // --- Formatting ---
                     string stackTrace = includeStacktrace ? ExtractStackTrace(message) : null;
-                    // Get first line if stack is present and requested, otherwise use full message
-                    string messageOnly =
-                        (includeStacktrace && !string.IsNullOrEmpty(stackTrace))
-                            ? message.Split(
-                                new[] { '\n', '\r' },
-                                StringSplitOptions.RemoveEmptyEntries
-                            )[0]
-                            : message;
+                    // Always get first line for the message, use full message only if no stack trace exists
+                    string[] messageLines = message.Split(
+                        new[] { '\n', '\r' },
+                        StringSplitOptions.RemoveEmptyEntries
+                    );
+                    string messageOnly = messageLines.Length > 0 ? messageLines[0] : message;
+
+                    // If not including stacktrace, ensure we only show the first line
+                    if (!includeStacktrace)
+                    {
+                        stackTrace = null;
+                    }
 
                     object formattedEntry = null;
                     switch (format)


### PR DESCRIPTION
The includeStacktrace parameter was working backwards - when false, it would return the full message with embedded stack traces, and when true, it would extract the stack trace but the logic was inverted.

Changes:
- Always extract the first line as the message text
- Only populate stackTrace field when includeStacktrace is true
- Ensures clean, summary-only messages when includeStacktrace is false
- Properly separates stack traces into their own field when requested

This matches the expected Unity console behavior where the summary is shown by default, and stack traces are only shown when expanded.

Should help with https://github.com/CoplayDev/unity-mcp/issues/302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures stack traces are never shown when disabled, preventing unintended noise in console output.
  - Displays the first line of each log consistently, improving readability across messages.

- Refactor
  - Streamlined log formatting to use a single, consistent parsing path for messages and stack traces.

- Documentation
  - Clarified behavior of message display and stack trace inclusion in console output to set correct expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->