### PR TITLE
refactor: use Tommy TOML library directly for config file manipulation

### DIFF
--- a/MCPForUnity/Editor/Helpers/McpConfigurationHelper.cs
+++ b/MCPForUnity/Editor/Helpers/McpConfigurationHelper.cs
@@ -205,8 +205,7 @@ namespace MCPForUnity.Editor.Helpers
                 return "Configured successfully";
             }
 
-            string codexBlock = CodexConfigHelper.BuildCodexServerBlock(uvPath, serverSrc);
-            string updatedToml = CodexConfigHelper.UpsertCodexServerBlock(existingToml, codexBlock);
+            string updatedToml = CodexConfigHelper.UpsertCodexServerBlock(existingToml, uvPath, serverSrc);
 
             McpConfigFileHelper.WriteAtomicFile(configPath, updatedToml);
 


### PR DESCRIPTION
Before discovering the Tommy library I tried to parse TOML files directly. Some of the methods lingered from that time, which were messing up configuration on Windows.

Now we use Tommy more, it should work. Also consolodiated some code with fresh eyes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration handling for MCP server setup with enhanced validation and more robust processing logic to ensure more reliable configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->