### PR TITLE
fix: Port Discovery Protocol Mismatch

### DIFF
--- a/MCPForUnity/UnityMcpServer~/src/port_discovery.py
+++ b/MCPForUnity/UnityMcpServer~/src/port_discovery.py
@@ -56,7 +56,7 @@ class PortDiscovery:
     @staticmethod
     def _try_probe_unity_mcp(port: int) -> bool:
         """Quickly check if a MCP for Unity listener is on this port.
-        Tries a short TCP connect, sends 'ping', expects a JSON 'pong'.
+        Tries a short TCP connect, sends 'ping', expects Unity bridge welcome message.
         """
         try:
             with socket.create_connection(("127.0.0.1", port), PortDiscovery.CONNECT_TIMEOUT) as s:
@@ -64,8 +64,8 @@ class PortDiscovery:
                 try:
                     s.sendall(b"ping")
                     data = s.recv(512)
-                    # Minimal validation: look for a success pong response
-                    if data and b'"message":"pong"' in data:
+                    # Check for Unity bridge welcome message format
+                    if data and (b"WELCOME UNITY-MCP" in data or b'"message":"pong"' in data):
                         return True
                 except Exception:
                     return False


### PR DESCRIPTION

**Problem:** The MCP server's port discovery was failing to connect to Unity Editor because of a protocol mismatch. The Python server's `_try_probe_unity_mcp()` method was sending a "ping" and expecting a JSON response with `"message":"pong"`, but the Unity MCP bridge actually responds with a welcome message format: `"WELCOME UNITY-MCP 1 FRAMING=1"`.

This caused the port discovery to fall back to the default port (6400) instead of finding the actual Unity port (6402), resulting in connection failures and the error "Could not connect to Unity. Ensure the Unity Editor and MCP Bridge are running."

**Solution:** Updated the port discovery probe to recognize both the Unity bridge's actual welcome message format and maintain backward compatibility with the original JSON pong format. The fix allows the MCP server to successfully discover and connect to Unity Editor on the correct port.

**Impact:** MCP tools now properly connect to Unity Editor, enabling all MCP functionality including asset management, console reading, and GameObject operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced port validation during discovery to recognize multiple valid response formats, improving connection reliability and compatibility across different server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->