### PR TITLE
扩展CodeBuddy MCP

### DIFF
--- a/MCPForUnity/Editor/Data/McpClients.cs
+++ b/MCPForUnity/Editor/Data/McpClients.cs
@@ -208,6 +208,31 @@ namespace MCPForUnity.Editor.Data
                 mcpType = McpTypes.Codex,
                 configStatus = "Not Configured",
             },
+            // CodeBuddy
+            new()
+            {
+                name = "CodeBuddy",
+                windowsConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".CodeBuddy",
+                    "settings",
+                    "mcp.json"
+                ),
+                macConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".CodeBuddy",
+                    "settings",
+                    "mcp.json"
+                ),
+                linuxConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".CodeBuddy",
+                    "settings",
+                    "mcp.json"
+                ),
+                mcpType = McpTypes.CodeBuddy,
+                configStatus = "Not Configured",
+            },
         };
 
         // Initialize status enums after construction

--- a/MCPForUnity/Editor/Models/McpTypes.cs
+++ b/MCPForUnity/Editor/Models/McpTypes.cs
@@ -10,5 +10,6 @@ namespace MCPForUnity.Editor.Models
         VSCode,
         Windsurf,
         Trae,
+        CodeBuddy,
     }
 }


### PR DESCRIPTION
扩展Unity MCP，使其支持CodeBuddy代码编辑器。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CodeBuddy support as a new MCP client option in the MCPForUnity editor. The client is now available for Windows, macOS, and Linux, with configuration settings accessible at ~/.CodeBuddy/settings/mcp.json. Users can configure CodeBuddy integration through the editor's MCP configuration interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->