### PR TITLE
Harden PlayMode test runs

### DIFF
--- a/MCPForUnity/Editor/Services/TestRunnerService.cs
+++ b/MCPForUnity/Editor/Services/TestRunnerService.cs
@@ -227,6 +227,11 @@ namespace MCPForUnity.Editor.Services
                 var scene = SceneManager.GetSceneAt(i);
                 if (scene.isDirty)
                 {
+                    if (string.IsNullOrEmpty(scene.path))
+                    {
+                        McpLog.Warn($"[TestRunnerService] Skipping unsaved scene '{scene.name}': save it manually before running PlayMode tests.");
+                        continue;
+                    }
                     try
                     {
                         EditorSceneManager.SaveScene(scene);


### PR DESCRIPTION
- Guard against starting tests while already in Play Mode.
- Pre-save dirty scenes before PlayMode runs to avoid SaveModifiedSceneTask failures.
- Temporarily disable domain reload during PlayMode tests to keep the MCP bridge alive; restore settings afterward.
- Avoid runSynchronously because it can freeze Unity

Should fix #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents test runs from starting while the Editor is (or entering) Play Mode to avoid conflicts.
  * Ensures Play Mode tests run with adjusted settings, preserving and restoring Editor play-mode options on error or completion.
  * Auto-saves dirty scenes before Play Mode tests to prevent save-time conflicts and data loss.
  * Improves overall test-run stability and reliability during Play Mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->