### PR TITLE
Fix CLI entry point path in pyproject.toml

### DIFF
--- a/Server/pyproject.toml
+++ b/Server/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
 ]
 
 [project.scripts]
-mcp-for-unity = "main:main"
+mcp-for-unity = "src.main:main"
 
 [build-system]
 requires = ["setuptools>=64.0.0", "wheel"]


### PR DESCRIPTION
Update mcp-for-unity script entry point from "main:main" to "src.main:main" to match the actual module structure after moving main.py into the src directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated console script entry-point configuration for the mcp-for-unity command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->