### PR TITLE
fix: Remove redundant single quotes in Linux terminal command

### DIFF
--- a/MCPForUnity/Editor/Services/ServerManagementService.cs
+++ b/MCPForUnity/Editor/Services/ServerManagementService.cs
@@ -435,8 +435,8 @@ namespace MCPForUnity.Editor.Services
             // We use bash -c to execute the command, so we must properly quote/escape for bash
             // Escape single quotes for the inner bash string
             string escapedCommandLinux = command.Replace("'", "'\\''");
-            // Wrap the command in single quotes for bash -c
-            string script = $"'{escapedCommandLinux}; exec bash'";
+            // Build the script
+            string script = $"{escapedCommandLinux}; exec bash";
             // Escape double quotes for the outer Process argument string
             string escapedScriptForArg = script.Replace("\"", "\\\"");
             string bashCmdArgs = $"bash -c \"{escapedScriptForArg}\"";


### PR DESCRIPTION
## Description

Fixes a bug where the "Start Server" button fails to execute the command correctly on Linux systems.

## Problem

In `ServerManagementService.cs`, the Linux terminal command construction wraps the script in redundant single quotes when building the `bash -c` argument:

```csharp
// Before (broken)
string script = $"'{escapedCommandLinux}; exec bash'";
string bashCmdArgs = $"bash -c \"{escapedScriptForArg}\"";
// Results in: bash -c "'command; exec bash'"
```

The extra single quotes cause bash to interpret the entire command as a literal string rather than executing it.

## Solution

Remove the redundant single quotes since the double quotes already properly delimit the argument for `bash -c`:

```csharp
// After (fixed)
string script = $"{escapedCommandLinux}; exec bash";
string bashCmdArgs = $"bash -c \"{escapedScriptForArg}\"";
// Results in: bash -c "command; exec bash"
```

## Testing

- Tested on Linux (Ubuntu) with various terminal emulators (gnome-terminal, xterm)
- Verified the server starts correctly after the fix

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are minimal and focused on the specific bug fix
- [x] Tested on Linux platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal process execution on Linux by correcting how shell commands are formatted in the server management system, improving command interpretation and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->