### PR TITLE
fix: restrict fastmcp version to avoid potential KeyError

### DIFF
--- a/Server/pyproject.toml
+++ b/Server/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
  "httpx>=0.27.2",
- "fastmcp>=2.13.0",
+ "fastmcp>=2.13.0,<2.13.2",
  "mcp>=1.16.0",
  "pydantic>=2.12.0",
  "tomli>=2.3.0",


### PR DESCRIPTION
This pull request introduces a minor update to the dependency specification for `fastmcp` in the `Server/pyproject.toml` file. The change restricts the allowed versions of `fastmcp` to exclude versions beyond `2.13.1`, avoiding the ctx keyerror

* Restricted the `fastmcp` dependency to versions `>=2.13.0,<2.13.2` in `Server/pyproject.toml` to prevent use of potentially incompatible newer versions.