### PR TITLE
Fix: Rename UnityMCP to unityMCP in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ claude mcp add --scope user UnityMCP -- "C:/Users/USERNAME/AppData/Local/Microso
 ```json
 {
   "mcpServers": {
-    "UnityMCP": {
+    "unityMCP": {
       "url": "http://localhost:8080/mcp"
     }
   }
@@ -285,7 +285,7 @@ Switch the Unity transport dropdown to `Stdio`, then use one of the following `c
 ```json
 {
   "mcpServers": {
-    "UnityMCP": {
+    "unityMCP": {
       "command": "uv",
       "args": [
         "run",
@@ -305,7 +305,7 @@ Switch the Unity transport dropdown to `Stdio`, then use one of the following `c
 ```json
 {
   "mcpServers": {
-    "UnityMCP": {
+    "unityMCP": {
       "command": "C:/Users/YOUR_USERNAME/AppData/Local/Microsoft/WinGet/Links/uv.exe",
       "args": [
         "run",


### PR DESCRIPTION
## Description
Fixed a typo in the README where the MCP server name was incorrectly referenced as `UnityMCP` instead of `unityMCP`.

## Problem
When configuring Claude Desktop using the README instructions, the incorrect server name `UnityMCP` caused the following error:
```
Error reading or parsing claude_desktop_config.json file: [
{
  "code": "invalid_type",
  "expected": "string",
  "received": "undefined",
  "path": ["mcpServers", "UnityMCP", "command"],
  "message": "Required"
}
]
```

## Solution
Updated the README to use the correct server name `unityMCP` in the configuration example.

## Changes
- Changed `"UnityMCP"` to `"unityMCP"` in the claude_desktop_config.json example

## Testing
- ✅ Verified the corrected configuration works with Claude Desktop
- ✅ No more parsing errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples in the documentation for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->