### PR TITLE
feat: add Kilo Code configurator for AutoConfig support

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/KiloCodeConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/KiloCodeConfigurator.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MCPForUnity.Editor.Models;
+
+namespace MCPForUnity.Editor.Clients.Configurators
+{
+    public class KiloCodeConfigurator : JsonFileMcpConfigurator
+    {
+        public KiloCodeConfigurator() : base(new McpClient
+        {
+            name = "Kilo Code",
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+            IsVsCodeLayout = true
+        })
+        { }
+
+        public override IList<string> GetInstallationSteps() => new List<string>
+        {
+            "Install Kilo Code extension in VS Code",
+            "Open Kilo Code settings (gear icon in sidebar)",
+            "Navigate to MCP Servers section and click 'Edit Global MCP Settings'\nOR open the config file at the path above",
+            "Paste the configuration JSON into the mcpServers object",
+            "Save and restart VS Code"
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `KiloCodeConfigurator` to enable automatic MCP configuration for Kilo Code VS Code extension users
- Implements platform-specific config paths for Windows, macOS, and Linux
- Uses `IsVsCodeLayout = true` as Kilo Code stores settings in VS Code's globalStorage

## Config Paths
- **Windows**: `%APPDATA%/Code/User/globalStorage/kilocode.kilo-code/settings/mcp_settings.json`
- **macOS**: `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/settings/mcp_settings.json`
- **Linux**: `~/.config/Code/User/globalStorage/kilocode.kilo-code/settings/mcp_settings.json`

## Test Plan
- [ ] Open MCP for Unity window in Unity Editor
- [ ] Verify "Kilo Code" appears in the client list
- [ ] Test "Check Status" button with Kilo Code installed
- [ ] Test "Configure" button to auto-configure MCP settings

Closes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kilo Code editor integration for the Unity Editor with automatic platform detection and support for Windows, macOS, and Linux.
  * In-editor, step‑by‑step installation and configuration guidance to help set up the Kilo Code extension and MCP settings in VS Code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->