### PR TITLE
feat: Add Intelij Rider for Autoconfig support

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/RiderConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/RiderConfigurator.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using MCPForUnity.Editor.Models;
+
+namespace MCPForUnity.Editor.Clients.Configurators
+{
+    public class RiderConfigurator : JsonFileMcpConfigurator
+    {
+        public RiderConfigurator() : base(new McpClient
+        {
+            name = "Rider GitHub Copilot",
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "JetBrains", "Rider", "mcp.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "JetBrains", "Rider", "mcp.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "JetBrains", "Rider", "mcp.json"),
+            IsVsCodeLayout = true
+        })
+        { }
+
+        public override IList<string> GetInstallationSteps() => new List<string>
+        {
+            "Install GitHub Copilot plugin in Rider",
+            "Open or create mcp.json at the path above",
+            "Paste the configuration JSON",
+            "Save and restart Rider"
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary

* Adds `RiderConfigurator` to enable automatic MCP configuration for JetBrains Rider with GitHub Copilot users
* Implements platform-specific config paths for Windows, macOS, and Linux
* Uses `IsVsCodeLayout = true` as Rider stores settings in VS Code-compatible format

## Config Paths

* **Windows**: `%APPDATA%/JetBrains/Rider/mcp.json`
* **macOS**: `~/Library/Application Support/JetBrains/Rider/mcp.json`
* **Linux**: `~/.config/JetBrains/Rider/mcp.json`

## Test Plan

☐ Open MCP for Unity window in Unity Editor  
☐ Verify "Rider GitHub Copilot" appears in the client list  
☐ Test "Check Status" button with Rider installed  
☐ Test "Configure" button to auto-configure MCP settings  

## Summary by CodeRabbit

* **New Features**
  * Rider GitHub Copilot integration for the Unity Editor with automatic platform detection and support for Windows, macOS, and Linux.
  * In-editor, step-by-step installation and configuration guidance to help set up the GitHub Copilot plugin and MCP settings in Rider.

✏️ Tip: You can customize this high-level summary in your review settings.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring GitHub Copilot in Rider IDE with platform-specific setup paths
  * Includes a detailed step-by-step installation guide for Rider users

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->