### PR TITLE
Feat: Add test filtering options to run_tests tool

### DIFF
--- a/MCPForUnity/Editor/Services/ITestRunnerService.cs
+++ b/MCPForUnity/Editor/Services/ITestRunnerService.cs
@@ -5,6 +5,33 @@ using UnityEditor.TestTools.TestRunner.Api;
 namespace MCPForUnity.Editor.Services
 {
     /// <summary>
+    /// Options for filtering which tests to run.
+    /// All properties are optional - null or empty arrays are ignored.
+    /// </summary>
+    public class TestFilterOptions
+    {
+        /// <summary>
+        /// Full names of specific tests to run (e.g., "MyNamespace.MyTests.TestMethod").
+        /// </summary>
+        public string[] TestNames { get; set; }
+
+        /// <summary>
+        /// Same as TestNames, except it allows for Regex.
+        /// </summary>
+        public string[] GroupNames { get; set; }
+
+        /// <summary>
+        /// NUnit category names to filter by (tests marked with [Category] attribute).
+        /// </summary>
+        public string[] CategoryNames { get; set; }
+
+        /// <summary>
+        /// Assembly names to filter tests by.
+        /// </summary>
+        public string[] AssemblyNames { get; set; }
+    }
+
+    /// <summary>
     /// Provides access to Unity Test Runner data and execution.
     /// </summary>
     public interface ITestRunnerService
@@ -16,8 +43,10 @@ namespace MCPForUnity.Editor.Services
         Task<IReadOnlyList<Dictionary<string, string>>> GetTestsAsync(TestMode? mode);
 
         /// <summary>
-        /// Execute tests for the supplied mode.
+        /// Execute tests for the supplied mode with optional filtering.
         /// </summary>
-        Task<TestRunResult> RunTestsAsync(TestMode mode);
+        /// <param name="mode">The test mode (EditMode or PlayMode).</param>
+        /// <param name="filterOptions">Optional filter options to run specific tests. Pass null to run all tests.</param>
+        Task<TestRunResult> RunTestsAsync(TestMode mode, TestFilterOptions filterOptions = null);
     }
 }

--- a/MCPForUnity/Editor/Services/TestRunnerService.cs
+++ b/MCPForUnity/Editor/Services/TestRunnerService.cs
@@ -58,7 +58,7 @@ namespace MCPForUnity.Editor.Services
             }
         }
 
-        public async Task<TestRunResult> RunTestsAsync(TestMode mode)
+        public async Task<TestRunResult> RunTestsAsync(TestMode mode, TestFilterOptions filterOptions = null)
         {
             await _operationLock.WaitAsync().ConfigureAwait(true);
             Task<TestRunResult> runTask;
@@ -94,7 +94,14 @@ namespace MCPForUnity.Editor.Services
                 _leafResults.Clear();
                 _runCompletionSource = new TaskCompletionSource<TestRunResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                var filter = new Filter { testMode = mode };
+                var filter = new Filter
+                {
+                    testMode = mode,
+                    testNames = filterOptions?.TestNames,
+                    groupNames = filterOptions?.GroupNames,
+                    categoryNames = filterOptions?.CategoryNames,
+                    assemblyNames = filterOptions?.AssemblyNames
+                };
                 var settings = new ExecutionSettings(filter);
 
                 if (mode == TestMode.PlayMode)

--- a/Server/src/services/tools/run_tests.py
+++ b/Server/src/services/tools/run_tests.py
@@ -45,10 +45,12 @@ class RunTestsResponse(MCPResponse):
 )
 async def run_tests(
     ctx: Context,
-    mode: Annotated[Literal["EditMode", "PlayMode"], Field(
-        description="Unity test mode to run")] = "EditMode",
-    timeout_seconds: Annotated[int | str, Field(
-        description="Optional timeout in seconds for the Unity test run (string, e.g. '30')")] | None = None,
+    mode: Annotated[Literal["EditMode", "PlayMode"], "Unity test mode to run"] = "EditMode",
+    timeout_seconds: Annotated[int | str, "Optional timeout in seconds for the test run"] | None = None,
+    test_names: Annotated[list[str] | str, "Full names of specific tests to run (e.g., 'MyNamespace.MyTests.TestMethod')"] | None = None,
+    group_names: Annotated[list[str] | str, "Same as test_names, except it allows for Regex"] | None = None,
+    category_names: Annotated[list[str] | str, "NUnit category names to filter by (tests marked with [Category] attribute)"] | None = None,
+    assembly_names: Annotated[list[str] | str, "Assembly names to filter tests by"] | None = None,
 ) -> RunTestsResponse:
     unity_instance = get_unity_instance_from_context(ctx)
 
@@ -68,10 +70,38 @@ async def run_tests(
         except Exception:
             return default
 
+    # Coerce string or list to list of strings
+    def _coerce_string_list(value) -> list[str] | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return [value] if value.strip() else None
+        if isinstance(value, list):
+            result = [str(v).strip() for v in value if v and str(v).strip()]
+            return result if result else None
+        return None
+
     params: dict[str, Any] = {"mode": mode}
     ts = _coerce_int(timeout_seconds)
     if ts is not None:
         params["timeoutSeconds"] = ts
+
+    # Add filter parameters if provided
+    test_names_list = _coerce_string_list(test_names)
+    if test_names_list:
+        params["testNames"] = test_names_list
+
+    group_names_list = _coerce_string_list(group_names)
+    if group_names_list:
+        params["groupNames"] = group_names_list
+
+    category_names_list = _coerce_string_list(category_names)
+    if category_names_list:
+        params["categoryNames"] = category_names_list
+
+    assembly_names_list = _coerce_string_list(assembly_names)
+    if assembly_names_list:
+        params["assemblyNames"] = assembly_names_list
 
     response = await send_with_unity_instance(async_send_command_with_retry, unity_instance, "run_tests", params)
     await ctx.info(f'Response {response}')


### PR DESCRIPTION
Adds optional filter parameters to the `run_tests` MCP tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test filtering capabilities to run specific tests by name, group, category, or assembly. Multiple filter criteria can be applied simultaneously for more efficient and targeted test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->