### PR TITLE
Improve legacy configuration migration error handling and cleanup

### DIFF
--- a/MCPForUnity/Editor/Migrations/LegacyServerSrcMigration.cs
+++ b/MCPForUnity/Editor/Migrations/LegacyServerSrcMigration.cs
@@ -42,18 +42,21 @@ namespace MCPForUnity.Editor.Migrations
 
                 var summary = MCPServiceLocator.Client.ConfigureAllDetectedClients();
 
-                if (summary.FailureCount > 0 || summary.SuccessCount == 0)
+                if (summary.FailureCount > 0)
                 {
-                    if (summary.Messages != null && summary.Messages.Count > 0)
+                    McpLog.Warn($"Legacy configuration migration finished with errors ({summary.GetSummaryMessage()}). details:");
+                    if (summary.Messages != null)
                     {
-                        McpLog.Debug("Legacy configuration migration details:");
                         foreach (var message in summary.Messages)
                         {
-                            McpLog.Debug($"  {message}");
+                            McpLog.Warn($"  {message}");
                         }
                     }
-                    McpLog.Warn($"Legacy configuration migration incomplete ({summary.GetSummaryMessage()}). Will retry next session.");
-                    return;
+                    McpLog.Warn("Legacy keys will be removed to prevent migration loop. Please configure failing clients manually.");
+                }
+                else
+                {
+                    McpLog.Info($"Legacy configuration migration complete ({summary.GetSummaryMessage()})");
                 }
 
                 if (hasServerSrc)
@@ -67,8 +70,6 @@ namespace MCPForUnity.Editor.Migrations
                     EditorPrefs.DeleteKey(UseEmbeddedKey);
                     McpLog.Info("  ✓ Removed legacy key: MCPForUnity.UseEmbeddedServer");
                 }
-
-                McpLog.Info($"Legacy configuration migration complete ({summary.GetSummaryMessage()})");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Change migration to always clean up legacy keys, even on partial failures
- Upgrade migration messages from Debug to Warn/Info for better visibility
- Add explicit warning when failures occur that manual configuration is needed
- Remove early return on failures to ensure legacy keys are always deleted
- Prevents migration retry loops when some clients fail to configure

Partly addresses #464.

## Summary by Sourcery

Improve handling of legacy configuration migration outcomes while ensuring legacy keys are always cleaned up.

Enhancements:
- Always log legacy migration failures and details at warning level for better visibility.
- Log a clear informational message when legacy migration completes successfully.
- Add an explicit warning that legacy keys will still be removed after migration errors and that failing clients require manual configuration.
- Ensure legacy configuration keys are removed even when some client configurations fail, avoiding repeated migration attempts.