### PR TITLE
Added AssetDatabase.Refresh() to all command tool calls

### DIFF
--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -8,6 +8,7 @@ using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Resources;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using UnityEditor;
 
 namespace MCPForUnity.Editor.Tools
 {
@@ -232,6 +233,7 @@ namespace MCPForUnity.Editor.Tools
         /// <returns>The result for synchronous commands, or null for async commands (TCS will be completed later)</returns>
         public static object ExecuteCommand(string commandName, JObject @params, TaskCompletionSource<string> tcs)
         {
+            AssetDatabase.Refresh();
             var handlerInfo = GetHandlerInfo(commandName);
 
             if (handlerInfo.IsAsync)
@@ -256,6 +258,7 @@ namespace MCPForUnity.Editor.Tools
         /// <param name="params">Parameters to pass to the command (optional).</param>
         public static Task<object> InvokeCommandAsync(string commandName, JObject @params)
         {
+            AssetDatabase.Refresh();
             var handlerInfo = GetHandlerInfo(commandName);
             var payload = @params ?? new JObject();
 


### PR DESCRIPTION
Per issue: https://github.com/CoplayDev/unity-mcp/issues/474
Added AssetDatabase.Refresh() to all command tool calls to ensure that the tools are working with the latest version of the editor assets. This should allow the editor to recompile and update assets in the background without manual intervention.

## Summary by Sourcery

Bug Fixes:
- Force an AssetDatabase refresh before executing registered editor commands to avoid operating on stale assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution reliability by ensuring the asset database is automatically synchronized before executing all registered commands, both synchronously and asynchronously, to maintain consistency and prevent potential asset-related synchronization issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->