### PR TITLE
Fix test teardown to avoid dropping MCP bridge

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/CodexConfigHelperTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/CodexConfigHelperTests.cs
@@ -32,6 +32,7 @@ namespace MCPForUnityTests.Editor.Helpers
         private string _originalGitOverride;
         private bool _hadHttpTransport;
         private bool _originalHttpTransport;
+        private IPlatformService _originalPlatformService;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -40,6 +41,7 @@ namespace MCPForUnityTests.Editor.Helpers
             _originalGitOverride = EditorPrefs.GetString(EditorPrefKeys.GitUrlOverride, string.Empty);
             _hadHttpTransport = EditorPrefs.HasKey(EditorPrefKeys.UseHttpTransport);
             _originalHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
+            _originalPlatformService = MCPServiceLocator.Platform;
         }
 
         [SetUp]
@@ -58,7 +60,12 @@ namespace MCPForUnityTests.Editor.Helpers
             // These tests can be executed while an MCP session is active (e.g., when running tests via MCP).
             // MCPServiceLocator.Reset() disposes the bridge + transport manager, which can kill the MCP connection
             // mid-run. Instead, restore only what this fixture mutates.
-            MCPServiceLocator.Register<IPlatformService>(new PlatformService());
+            // To avoid leaking global state to other tests/fixtures, restore the original platform service
+            // instance captured before this fixture started running.
+            if (_originalPlatformService != null)
+            {
+                MCPServiceLocator.Register<IPlatformService>(_originalPlatformService);
+            }
         }
 
         [OneTimeTearDown]


### PR DESCRIPTION
CodexConfigHelperTests was calling MCPServiceLocator.Reset() in TearDown, which disposes the active bridge/transport during MCP-driven test runs -- kills bridge connection.  Replace with restoring only the mutated service (IPlatformService). Now TestProject test runs complete successfully without killing connection.

## Summary by Sourcery

Adjust test teardown behavior to avoid disrupting active MCP sessions during test runs.

Bug Fixes:
- Prevent CodexConfigHelperTests teardown from disposing the active MCP bridge and transport, which previously could kill the MCP connection mid-run.

Tests:
- Update CodexConfigHelperTests teardown to only restore the mutated IPlatformService instead of resetting the entire MCPServiceLocator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup: tests now restore the original platform service instead of performing a full reset, preventing disposal of active session resources and limiting restoration to the changed platform service for safer, more targeted test teardown.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->