### PR TITLE
Avoid blocking Claude CLI status checks on focus

### DIFF
--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
@@ -293,7 +293,8 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
             if (selectedClientIndex >= 0 && selectedClientIndex < configurators.Count)
             {
                 var client = configurators[selectedClientIndex];
-                RefreshClientStatus(client, forceImmediate: true);
+                bool forceImmediate = client is not ClaudeCliMcpConfigurator;
+                RefreshClientStatus(client, forceImmediate);
                 UpdateManualConfiguration();
                 UpdateClaudeCliPathVisibility();
             }
@@ -318,14 +319,6 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
 
         private void RefreshClaudeCliStatus(IMcpClientConfigurator client, bool forceImmediate)
         {
-            if (forceImmediate)
-            {
-                MCPServiceLocator.Client.CheckClientStatus(client, attemptAutoRewrite: false);
-                lastStatusChecks[client] = DateTime.UtcNow;
-                ApplyStatusToUi(client);
-                return;
-            }
-
             bool hasStatus = lastStatusChecks.ContainsKey(client);
             bool needsRefresh = !hasStatus || ShouldRefreshClient(client);
 
@@ -338,7 +331,7 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
                 ApplyStatusToUi(client);
             }
 
-            if (needsRefresh && !statusRefreshInFlight.Contains(client))
+            if ((forceImmediate || needsRefresh) && !statusRefreshInFlight.Contains(client))
             {
                 statusRefreshInFlight.Add(client);
                 ApplyStatusToUi(client, showChecking: true);


### PR DESCRIPTION
### Motivation
- Prevent UI blocking when selecting a client that uses the Claude CLI by avoiding synchronous status checks.
- Ensure Claude CLI status checks run asynchronously even when an immediate refresh is requested.
- Keep existing immediate/synchronous checks for non-Claude clients intact.

### Description
- When refreshing the selected client, compute `forceImmediate` as `client is not ClaudeCliMcpConfigurator` so Claude CLI configurators are not forced to run synchronously.
- Remove the synchronous early-return in `RefreshClaudeCliStatus` that performed a blocking `CheckClientStatus` call.
- Update `RefreshClaudeCliStatus` to include `forceImmediate` in the condition that starts an asynchronous `Task.Run` for `MCPServiceLocator.Client.CheckClientStatus` and preserve `statusRefreshInFlight` tracking and UI updates.
- Leave `RefreshClientStatus` behavior for non-Claude clients unchanged, still performing immediate checks when `forceImmediate` is true.

### Testing
- No automated tests were run for this change.
- Basic local build/compile was not executed as part of this PR (no automated validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695348980234832780cf8e9ee90cebf5)

## Summary by Sourcery

Run Claude CLI client status checks asynchronously to avoid blocking the editor UI while preserving immediate checks for non-Claude clients.

Enhancements:
- Only force immediate status refreshes for non-Claude CLI clients when a client is selected.
- Always perform Claude CLI status checks via the asynchronous refresh path while keeping existing in-flight tracking and UI update behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status refresh logic for Claude CLI and other client configurators. Status updates now use conditional refresh strategies based on configurator type, with ClaudeCli utilizing asynchronous refresh flow while other configurators use immediate updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->