### PR TITLE
Fix read_console default to include 'log' messages

### DIFF
--- a/Server/src/services/tools/read_console.py
+++ b/Server/src/services/tools/read_console.py
@@ -44,7 +44,7 @@ async def read_console(
     unity_instance = get_unity_instance_from_context(ctx)
     # Set defaults if values are None
     action = action if action is not None else 'get'
-    types = types if types is not None else ['error', 'warning']
+    types = types if types is not None else ['error', 'warning', 'log']
     format = format if format is not None else 'plain'
     # Coerce booleans defensively (strings like 'true'/'false')
 


### PR DESCRIPTION
### Motivation
- The `read_console` tool previously defaulted to only `['error', 'warning']`, which omitted ordinary `Debug.Log` messages.
- This led to cases where the console appeared empty even when many log entries existed.

### Description
- Changed the default `types` in `Server/src/services/tools/read_console.py` from `['error', 'warning']` to `['error', 'warning', 'log']` so `Debug.Log` output is returned without explicit filters.
- No other behavior or paging logic in `read_console` was modified and explicit `types` parameters remain respected.

### Testing
- No automated tests were executed for this change.
- Existing integration tests that exercise `read_console` (for example `Server/tests/integration/test_read_console_truncate.py`) were not run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b6521677c83279987c3b84c03274e)

## Summary by Sourcery

Bug Fixes:
- Ensure read_console returns Debug.Log output by default by including 'log' in the default console types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Console message output now includes log messages by default, in addition to errors and warnings, providing more comprehensive visibility into system activity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->