### PR TITLE
Fix issue #525: Save dirty scenes for all test modes

### DIFF
--- a/MCPForUnity/Editor/Services/TestRunnerService.cs
+++ b/MCPForUnity/Editor/Services/TestRunnerService.cs
@@ -106,10 +106,9 @@ namespace MCPForUnity.Editor.Services
                 };
                 var settings = new ExecutionSettings(filter);
 
-                if (mode == TestMode.PlayMode)
-                {
-                    SaveDirtyScenesIfNeeded();
-                }
+                // Save dirty scenes for all test modes to prevent modal dialogs blocking MCP
+                // (Issue #525: EditMode tests were blocked by save dialog)
+                SaveDirtyScenesIfNeeded();
 
                 _testRunnerApi.Execute(settings);
 


### PR DESCRIPTION
## Summary
- Moved `SaveDirtyScenesIfNeeded()` call outside the PlayMode conditional so EditMode tests don't get blocked by Unity's "Save Scene" modal dialog

## Problem
When running EditMode tests through MCP with unsaved scene changes, Unity displays a "Save Scene" modal dialog that blocks the editor, causing MCP to timeout without receiving a response.

## Solution
The `SaveDirtyScenesIfNeeded()` method was only being called for PlayMode tests. This one-line change ensures dirty scenes are saved before ALL test runs, not just PlayMode.

## Testing
- Verified EditMode tests no longer block on save dialogs
- 1165 tests run successfully with this fix

Fixes #525

## Summary by Sourcery

Bug Fixes:
- Prevent EditMode test runs from being blocked by Unity's save scene modal dialog by saving dirty scenes for all test modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where EditMode tests were blocked by save dialogs. Dirty scenes are now automatically saved before running any test mode, ensuring smooth test execution across all test types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->