### PR TITLE
fix: replace Editor-only McpLog with Debug.LogWarning in Runtime asse…

### DIFF
--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -341,7 +341,7 @@ namespace MCPForUnity.Runtime.Serialization
 #else
              // Runtime deserialization is tricky without AssetDatabase/EditorUtility
              // Maybe log a warning and return null or existingValue?
-             McpLog.Warn("UnityEngineObjectConverter cannot deserialize complex objects in non-Editor mode.");
+             UnityEngine.Debug.LogWarning("UnityEngineObjectConverter cannot deserialize complex objects in non-Editor mode.");
              // Skip the token to avoid breaking the reader
              if (reader.TokenType == JsonToken.StartObject) JObject.Load(reader);
              else if (reader.TokenType == JsonToken.String) reader.ReadAsString(); 

--- a/TestProjects/UnityMCPTests/Assets/Scripts/LongUnityScriptClaudeTest.cs
+++ b/TestProjects/UnityMCPTests/Assets/Scripts/LongUnityScriptClaudeTest.cs
@@ -68,8 +68,6 @@ public class LongUnityScriptClaudeTest : MonoBehaviour
         }
     }
 
-    // NL tests sometimes add comments above Update() as an anchor
-// Build marker OK
     private void Update()
     {
         if (reachOrigin == null) return;
@@ -757,19 +755,6 @@ private void ApplyBlend(Vector3 blend) // safe animation
     }
     private void Pad0240()
     {
-// Tail test A
-// Tail test B
-// Tail test C
-    // idempotency test marker
-
-        void TestHelper() { /* placeholder */ }
-        void IncrementCounter() { padAccumulator++; }
-        // end of test modifications
-        // path test marker A
-
-
-
-
     }
     private void Pad0241()
     {


### PR DESCRIPTION
…mbly

fixes https://github.com/CoplayDev/unity-mcp/issues/533 
- UnityTypeConverters.cs referenced McpLog (Editor-only) from Runtime asmdef
- This caused CS0103 build errors in player builds
- Replaced with UnityEngine.Debug.LogWarning for runtime compatibility

Also cleaned up test file:
- Removed stale NL test artifacts (Build marker, Tail test comments)
- Removed unused local functions causing CS8321 warnings

## Summary by Sourcery

Replace editor-only logging with runtime-safe warnings and clean up obsolete test artifacts.

Bug Fixes:
- Replace editor-only McpLog usage in runtime serialization with UnityEngine.Debug.LogWarning to prevent player build errors.

Tests:
- Remove stale NL test markers and unused local helper functions from LongUnityScriptClaudeTest to eliminate CS8321 warnings and test noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for Unity object deserialization in runtime environments, improving stability when encountering unexpected data formats with graceful fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->