### PR TITLE
Update URL for v9

### DIFF
--- a/tools/prepare_unity_asset_store_release.py
+++ b/tools/prepare_unity_asset_store_release.py
@@ -129,7 +129,7 @@ def main() -> int:
         replace_once(
             http_util,
             r'private const string DefaultBaseUrl = "http://localhost:8080";',
-            'private const string DefaultBaseUrl = "https://mc-f51b526566384d86b44b59eb81097218.ecs.us-east-2.on.aws";',
+            'private const string DefaultBaseUrl = "https://mc-0cb5e1039f6b4499b473670f70662d29.ecs.us-east-2.on.aws/";',
         )
 
         # Default transport to HTTP Remote and persist inferred scope when missing


### PR DESCRIPTION
I'll change the URL every major version change so things don't break for users on old versions on the Asset Store

## Summary by Sourcery

Enhancements:
- Change the default base URL constant used in generated Unity code to the new version-specific HTTPS endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default server endpoint configuration to use production HTTPS endpoint instead of local HTTP.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->