### PR TITLE
Use localhost to ping server if server binds to 0.0.0.0

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/WebSocketTransportClient.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/WebSocketTransportClient.cs
@@ -682,16 +682,18 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                 throw new InvalidOperationException($"Invalid MCP base URL: {baseUrl}");
             }
 
-            string scheme = httpUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws";
-            string builder = $"{scheme}://{httpUri.Authority}";
-            if (!string.IsNullOrEmpty(httpUri.AbsolutePath) && httpUri.AbsolutePath != "/")
+            // Replace 0.0.0.0 with localhost for client connections
+            // 0.0.0.0 is only valid for server binding, not client connections
+            string host = httpUri.Host == "0.0.0.0" ? "localhost" : httpUri.Host;
+
+            var builder = new UriBuilder(httpUri)
             {
-                builder += httpUri.AbsolutePath.TrimEnd('/');
-            }
+                Scheme = httpUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws",
+                Host = host,
+                Path = httpUri.AbsolutePath.TrimEnd('/') + "/hub/plugin"
+            };
 
-            builder += "/hub/plugin";
-
-            return new Uri(builder);
+            return builder.Uri;
         }
     }
 }


### PR DESCRIPTION
Problem: When the MCP server is configured to bind to 0.0.0.0:8080 (I am doing it locally to be able to access MCP from my local windows and from WSL), the WebSocket client would attempt to connect to 0.0.0.0, which fails because 0.0.0.0 is only valid for server binding, not client connections.

Solution: Added automatic URL translation that replaces 0.0.0.0 with localhost before establishing the WebSocket connection. This allows the server to bind on all interfaces while ensuring the client connects to the correct loopback address.

## Summary by Sourcery

Bug Fixes:
- Translate 0.0.0.0 to localhost in the constructed WebSocket endpoint URL to prevent client connection failures when the server listens on all interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket endpoint construction and host normalization to handle edge host addresses (e.g., 0.0.0.0 → localhost).
  * Ensures the correct WebSocket scheme (wss/ws) is selected based on the connection protocol.
  * Consistently appends the required hub path segment so connections use a well-formed endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->