### PR TITLE
Refactor ClaudeCodeConfigurator to use JsonFileMcpConfigurator

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/ClaudeCodeConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/ClaudeCodeConfigurator.cs
@@ -1,24 +1,30 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using MCPForUnity.Editor.Models;
 
 namespace MCPForUnity.Editor.Clients.Configurators
 {
-    public class ClaudeCodeConfigurator : ClaudeCliMcpConfigurator
+    public class ClaudeCodeConfigurator : JsonFileMcpConfigurator
     {
         public ClaudeCodeConfigurator() : base(new McpClient
         {
             name = "Claude Code",
-            windowsConfigPath = string.Empty,
-            macConfigPath = string.Empty,
-            linuxConfigPath = string.Empty,
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude.json"),
+            SupportsHttpTransport = true,
+            HttpUrlProperty = "url", // Claude Code uses "url" for HTTP servers
+            IsVsCodeLayout = false,  // Claude Code uses standard mcpServers layout
         })
         { }
 
         public override IList<string> GetInstallationSteps() => new List<string>
         {
-            "Ensure Claude CLI is installed",
-            "Use the Register button to register automatically\nOR manually run: claude mcp add UnityMCP",
-            "Restart Claude Code"
+            "Open your project in Claude Code",
+            "Click Configure in MCP for Unity (or manually edit ~/.claude.json)",
+            "The MCP server will be added to the global mcpServers section",
+            "Restart Claude Code to apply changes"
         };
     }
 }


### PR DESCRIPTION
The old CLI file map does not seem to work for the latest CC(V2.1.4), with errors that cannot recognize any symbols after uvx.exe, whether it be --no-cache, --refresh, or --from. I did not find any documentation change of why this cannot use. I temporarily revert the current Claude Code registration to the old JSON way, which still works. Will look for a fix that could retain the CLI command usage.

## Summary by Sourcery

Refactor Claude Code MCP client configuration to use the JSON file-based configurator instead of the CLI-based configurator, updating platform config paths and installation steps accordingly.

Enhancements:
- Switch ClaudeCodeConfigurator to use JsonFileMcpConfigurator with a shared ~/.claude.json configuration path across platforms.
- Enable HTTP transport configuration for Claude Code using the standard mcpServers layout and url property.
- Update installation instructions to describe configuration via the global ~/.claude.json file rather than CLI registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Claude Code configuration to use JSON file-based approach
  * Simplified installation flow with UI-oriented setup guidance through Claude Code instead of command-line steps
  * Added cross-platform support with consistent configuration file location (Windows, macOS, Linux)
  * Enabled HTTP transport for improved connectivity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->