### PR TITLE
Guard refresh wait nudge during compile

### DIFF
--- a/MCPForUnity/Editor/Tools/RefreshUnity.cs
+++ b/MCPForUnity/Editor/Tools/RefreshUnity.cs
@@ -94,7 +94,9 @@ namespace MCPForUnity.Editor.Tools
             {
                 try
                 {
-                    await WaitForUnityReadyAsync(TimeSpan.FromSeconds(DefaultWaitTimeoutSeconds)).ConfigureAwait(true);
+                    await WaitForUnityReadyAsync(
+                        TimeSpan.FromSeconds(DefaultWaitTimeoutSeconds),
+                        allowNudge: !compileRequested).ConfigureAwait(true);
                 }
                 catch (TimeoutException)
                 {
@@ -126,7 +128,7 @@ namespace MCPForUnity.Editor.Tools
             });
         }
 
-        private static Task WaitForUnityReadyAsync(TimeSpan timeout)
+        private static Task WaitForUnityReadyAsync(TimeSpan timeout, bool allowNudge)
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var start = DateTime.UtcNow;
@@ -165,8 +167,11 @@ namespace MCPForUnity.Editor.Tools
             }
 
             EditorApplication.update += Tick;
-            // Nudge Unity to pump once in case update is throttled.
-            try { EditorApplication.QueuePlayerLoopUpdate(); } catch { }
+            if (allowNudge)
+            {
+                // Nudge Unity to pump once in case update is throttled.
+                try { EditorApplication.QueuePlayerLoopUpdate(); } catch { }
+            }
             return tcs.Task;
         }
     }


### PR DESCRIPTION
## Summary
- skip QueuePlayerLoopUpdate nudge when refresh_unity also requested compilation
- keep wait_for_ready polling behavior unchanged otherwise

## Testing
- Unity EditMode tests (UnityMCPTests) — pass
- Unity PlayMode tests (UnityMCPTests) — pass
- Server pytest suite — pass

## Summary by Sourcery

Enhancements:
- Add an allow-nudge guard to Unity readiness polling to avoid QueuePlayerLoopUpdate when a compilation is in progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved Unity refresh responsiveness by making the refresh nudge conditional based on compilation status. The refresh mechanism now adapts its behavior depending on whether a compilation was requested, optimizing the readiness check process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->