### PR TITLE
Replace asmdef GUID references

### DIFF
--- a/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
+++ b/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
@@ -3,7 +3,7 @@
     "rootNamespace": "MCPForUnity.Editor",
     "references": [
         "MCPForUnity.Runtime",
-        "GUID:560b04d1a97f54a46a2660c3cc343a6f"
+        "Newtonsoft.Json"
     ],
     "includePlatforms": [
         "Editor"

--- a/MCPForUnity/Runtime/MCPForUnity.Runtime.asmdef
+++ b/MCPForUnity/Runtime/MCPForUnity.Runtime.asmdef
@@ -2,7 +2,7 @@
     "name": "MCPForUnity.Runtime",
     "rootNamespace": "MCPForUnity.Runtime",
     "references": [
-        "GUID:560b04d1a97f54a46a2660c3cc343a6f" 
+        "Newtonsoft.Json"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## Summary
- replace GUID-based asmdef references with assembly names
- avoid missing GUID resolution when importing as a Git package

Fixes #563

## Testing
- Unity EditMode tests (UnityMCPTests) — pass (second run; first failed due to console logs disabled)
- Unity PlayMode tests (UnityMCPTests) — pass
- Server pytest suite — pass

## Summary by Sourcery

Enhancements:
- Update MCPForUnity Editor and Runtime asmdef files to reference other assemblies by name instead of GUIDs to avoid GUID resolution issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated assembly dependencies to use explicit package references instead of GUID-based references for improved clarity and maintainability. The Newtonsoft.Json library is now directly referenced by name in both Editor and Runtime assembly configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->