### PR TITLE
Fix ULF detection in Claude licensing

### DIFF
--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -97,16 +97,20 @@ jobs:
             printf "%s" "$UNITY_LICENSE" > "$f"
           fi
           chmod 600 "$f" || true
-          # If someone pasted an entitlement XML into UNITY_LICENSE by mistake, re-home it:
-          if head -c 100 "$f" | grep -qi '<\?xml'; then
-            mkdir -p "$RUNNER_TEMP/unity-config/Unity/licenses"
-            mv "$f" "$RUNNER_TEMP/unity-config/Unity/licenses/UnityEntitlementLicense.xml"
-            echo "ok=false" >> "$GITHUB_OUTPUT"
-          elif grep -qi '<Signature>' "$f"; then
+          # Detect ULF first; it is XML and includes a <Signature> element.
+          if grep -qi '<Signature>' "$f"; then
             # provide it in the standard local-share path too
             cp -f "$f" "$RUNNER_TEMP/unity-local/Unity/Unity_lic.ulf"
+            echo "License source: ULF (Signature found)"
             echo "ok=true" >> "$GITHUB_OUTPUT"
+          # If someone pasted an entitlement XML into UNITY_LICENSE by mistake, re-home it:
+          elif grep -qi 'Entitlement|entitlement' "$f"; then
+            mkdir -p "$RUNNER_TEMP/unity-config/Unity/licenses"
+            mv "$f" "$RUNNER_TEMP/unity-config/Unity/licenses/UnityEntitlementLicense.xml"
+            echo "License source: Entitlement XML (re-homed)"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
           else
+            echo "License source: Unknown format (no ULF Signature or Entitlement markers)"
             echo "ok=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Detect ULF by Signature before entitlement XML and log license source for debugging.

## Summary by Sourcery

CI:
- Update GitHub Actions workflow license handling to detect ULF by signature before entitlement XML and to log the detected license source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced license file detection to recognize and properly handle multiple license format types.
  * Improved diagnostic logging for license source identification to aid in troubleshooting.
  * Added fallback handling for unrecognized license formats with informative messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->