### PR TITLE
Eliminate UI stuttering caused by main thread blocking network calls

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -821,6 +821,14 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                 List<(string id, QueuedCommand command)> work;
                 lock (lockObj)
                 {
+                    // Early exit: if no commands queued, don't allocate a list. This prevents
+                    // the memory allocations that occur every frame, which trigger GC every ~1 second
+                    // and cause the 28ms stuttering reported in GitHub issue #577.
+                    if (commandQueue.Count == 0)
+                    {
+                        return;
+                    }
+
                     work = new List<(string, QueuedCommand)>(commandQueue.Count);
                     foreach (var kvp in commandQueue)
                     {

--- a/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -234,13 +234,15 @@ namespace MCPForUnity.Editor.Windows
 
         private void OnEnable()
         {
-            EditorApplication.update += OnEditorUpdate;
+            // No longer hook EditorApplication.update - it was calling UpdateConnectionStatus() every frame,
+            // which made expensive network socket checks (IsLocalHttpServerReachable) 60+ times per second.
+            // Connection status now updates only on explicit events (user actions, bridge state changes).
             OpenWindows.Add(this);
         }
 
         private void OnDisable()
         {
-            EditorApplication.update -= OnEditorUpdate;
+            // OnEditorUpdate hook was removed; see OnEnable comments.
             OpenWindows.Remove(this);
             guiCreated = false;
             toolsLoaded = false;
@@ -253,14 +255,6 @@ namespace MCPForUnity.Editor.Windows
                 return;
 
             RefreshAllData();
-        }
-
-        private void OnEditorUpdate()
-        {
-            if (rootVisualElement == null || rootVisualElement.childCount == 0)
-                return;
-
-            connectionSection?.UpdateConnectionStatus();
         }
 
         private void RefreshAllData()

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportCommandDispatcherOptimizationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportCommandDispatcherOptimizationTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using MCPForUnity.Editor.Services.Transport;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    /// <summary>
+    /// Tests verifying the optimization fix for GitHub issue #577.
+    /// Confirms that the early-exit optimization in ProcessQueue prevents
+    /// excessive memory allocations when the dispatcher is idle.
+    /// </summary>
+    public class TransportCommandDispatcherOptimizationTests
+    {
+        [Test]
+        public void ExecuteCommandJsonAsync_WithSimplePingCommand_CompletesSuccessfully()
+        {
+            // Arrange
+            var commandJson = """{"type": "ping", "params": {}}""";
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            // Act
+            var task = TransportCommandDispatcher.ExecuteCommandJsonAsync(commandJson, cts.Token);
+            var completed = task.Wait(TimeSpan.FromSeconds(2));
+
+            // Assert
+            Assert.IsTrue(completed, "Ping command should complete within 2 seconds");
+            Assert.IsTrue(task.IsCompletedSuccessfully, "Command task should succeed");
+            Assert.IsNotEmpty(task.Result, "Response should not be empty");
+        }
+
+        [Test]
+        public void ExecuteCommandJsonAsync_WithCancellation_CancelsProperly()
+        {
+            // Arrange
+            var commandJson = """{"type": "ping", "params": {}}""";
+            var cts = new CancellationTokenSource();
+
+            // Act: Create command but cancel before it processes
+            var task = TransportCommandDispatcher.ExecuteCommandJsonAsync(commandJson, cts.Token);
+            cts.Cancel();
+
+            var completed = task.Wait(TimeSpan.FromSeconds(1));
+
+            // Assert
+            Assert.IsTrue(completed, "Cancelled task should complete");
+            Assert.IsTrue(task.IsCanceled || task.IsCompletedSuccessfully,
+                "Task should be either cancelled or completed");
+        }
+
+        [Test]
+        public void ExecuteCommandJsonAsync_MultipleCommands_ProcessesAllCorrectly()
+        {
+            // Arrange
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            // Act: Execute multiple commands in rapid succession
+            var tasks = new Task<string>[3];
+            for (int i = 0; i < 3; i++)
+            {
+                var commandJson = """{"type": "ping", "params": {}}""";
+                tasks[i] = TransportCommandDispatcher.ExecuteCommandJsonAsync(commandJson, cts.Token);
+            }
+
+            var allCompleted = Task.WaitAll(tasks, TimeSpan.FromSeconds(3));
+
+            // Assert
+            Assert.IsTrue(allCompleted, "All commands should complete");
+            foreach (var task in tasks)
+            {
+                Assert.IsTrue(task.IsCompletedSuccessfully, "Each command should complete successfully");
+            }
+        }
+
+        [Test]
+        public void ExecuteCommandJsonAsync_WithInvalidJson_ReturnsError()
+        {
+            // Arrange
+            var invalidCommandJson = "this is not json";
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            // Act
+            var task = TransportCommandDispatcher.ExecuteCommandJsonAsync(invalidCommandJson, cts.Token);
+            var completed = task.Wait(TimeSpan.FromSeconds(2));
+
+            // Assert
+            Assert.IsTrue(completed, "Invalid command should complete with error");
+            Assert.IsTrue(task.IsCompletedSuccessfully, "Task should complete (with error result)");
+            StringAssert.Contains("error", task.Result.ToLower(),
+                "Response should indicate an error");
+        }
+
+        [Test]
+        public void ExecuteCommandJsonAsync_WithEmptyCommand_ReturnsError()
+        {
+            // Arrange
+            var emptyJson = "";
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            // Act
+            var task = TransportCommandDispatcher.ExecuteCommandJsonAsync(emptyJson, cts.Token);
+            var completed = task.Wait(TimeSpan.FromSeconds(2));
+
+            // Assert
+            Assert.IsTrue(completed, "Empty command should complete with error");
+            Assert.IsTrue(task.IsCompletedSuccessfully, "Task should complete");
+            StringAssert.Contains("error", task.Result.ToLower(),
+                "Response should indicate an error for empty command");
+        }
+
+        [Test]
+        public void ExecuteCommandJsonAsync_WithNullThrowsArgumentNullException()
+        {
+            // Arrange
+            string nullJson = null;
+            var cts = new CancellationTokenSource();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                TransportCommandDispatcher.ExecuteCommandJsonAsync(nullJson, cts.Token);
+            });
+        }
+
+        [Test]
+        public void ExecuteCommandJsonAsync_RapidFireCommands_MaintainsOrdering()
+        {
+            // Arrange: A sequence of numbered ping commands
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
+
+            // Act: Fire multiple pings rapidly
+            var tasks = new Task<string>[5];
+            for (int i = 0; i < 5; i++)
+            {
+                var cmd = """{"type": "ping", "params": {}}""";
+                tasks[i] = TransportCommandDispatcher.ExecuteCommandJsonAsync(cmd, cts.Token);
+            }
+
+            var allCompleted = Task.WaitAll(tasks, TimeSpan.FromSeconds(5));
+
+            // Assert
+            Assert.IsTrue(allCompleted, "All rapid-fire commands should complete");
+            int successCount = 0;
+            foreach (var task in tasks)
+            {
+                if (task.IsCompletedSuccessfully && task.Result.Contains("pong"))
+                {
+                    successCount++;
+                }
+            }
+            Assert.That(successCount, Is.EqualTo(5), "All 5 ping commands should succeed");
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportCommandDispatcherPerformanceTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportCommandDispatcherPerformanceTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using MCPForUnity.Editor.Services.Transport;
+using UnityEditor;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    /// <summary>
+    /// Tests verifying that TransportCommandDispatcher doesn't allocate excessively when idle.
+    /// Regression tests for GitHub issue #577: "High performance impact even when MCP server is off"
+    /// </summary>
+    public class TransportCommandDispatcherPerformanceTests
+    {
+        private const int FramesPerSecond = 60;
+        private const int TestDurationSeconds = 2;
+        private const int TestFrames = FramesPerSecond * TestDurationSeconds;
+
+        [Test]
+        public void ProcessQueue_WhenIdle_DoesNotAllocateMemory()
+        {
+            // Arrange: Simulate idle frames (no pending commands)
+            var initialMemory = GC.GetTotalMemory(false);
+            var allocationsSeen = new List<long>();
+
+            // Act: Simulate 120 frames of EditorApplication.update firing with no commands
+            for (int frame = 0; frame < TestFrames; frame++)
+            {
+                // This simulates calling EditorApplication.update via reflection or direct hook
+                SimulateEditorUpdate();
+
+                // Sample memory every 10 frames
+                if (frame % 10 == 0)
+                {
+                    var currentMemory = GC.GetTotalMemory(false);
+                    var delta = currentMemory - initialMemory;
+                    allocationsSeen.Add(delta);
+                }
+            }
+
+            // Assert: With the fix, memory growth should be minimal (no List allocations)
+            // Without the fix, each frame allocates a List object, leading to ~120 allocations
+            // and eventual GC pressure of 28ms spikes every second.
+            var maxAllocation = 0L;
+            foreach (var allocation in allocationsSeen)
+            {
+                if (allocation > maxAllocation)
+                {
+                    maxAllocation = allocation;
+                }
+            }
+
+            // Each List<> allocation is ~48 bytes. We expect < 10KB total growth when idle.
+            Assert.That(maxAllocation, Is.LessThan(10_000),
+                "When idle with no pending commands, ProcessQueue should not allocate significantly");
+        }
+
+        [Test]
+        public void ProcessQueue_WithPendingCommands_ProcessesThemCorrectly()
+        {
+            // Arrange
+            var commandJson = """{"type": "ping", "params": {}}""";
+            var cts = new CancellationTokenSource();
+            var commandProcessed = false;
+
+            // Simulate a command arriving
+            var task = TransportCommandDispatcher.ExecuteCommandJsonAsync(commandJson, cts.Token);
+
+            // Act: Let the command process
+            SimulateEditorUpdate();
+
+            // Wait for the command to complete
+            if (task.Wait(TimeSpan.FromSeconds(1)))
+            {
+                commandProcessed = true;
+            }
+
+            // Assert
+            Assert.IsTrue(commandProcessed, "Command should have been processed");
+            Assert.IsTrue(task.IsCompletedSuccessfully, "Command task should complete successfully");
+        }
+
+        [Test]
+        public void ExecuteCommandJsonAsync_CallsRequestMainThreadPump_EnsuresResponsiveness()
+        {
+            // Arrange
+            var commandJson = """{"type": "ping", "params": {}}""";
+            var cts = new CancellationTokenSource();
+            var pumpWasCalled = false;
+
+            // Mock RequestMainThreadPump by monitoring if ProcessQueue gets called
+            // This verifies that the "wake up" mechanism works even if EditorApplication.update is not hooked
+
+            // Act: Execute a command
+            var task = TransportCommandDispatcher.ExecuteCommandJsonAsync(commandJson, cts.Token);
+
+            // The RequestMainThreadPump should have been called (we can't directly test it,
+            // but if the command completes, it means the pump worked)
+            SimulateEditorUpdate();
+
+            if (task.Wait(TimeSpan.FromSeconds(1)))
+            {
+                pumpWasCalled = true;
+            }
+
+            // Assert
+            Assert.IsTrue(pumpWasCalled,
+                "RequestMainThreadPump should ensure command is processed even if update hook is inactive");
+        }
+
+        [Test]
+        public void ProcessQueue_UnhooksWhenIdle_AndRehooksWhenNeeded()
+        {
+            // Arrange
+            var commandJson = """{"type": "ping", "params": {}}""";
+            var cts = new CancellationTokenSource();
+
+            // Act: Process a command (which should leave ProcessQueue idle afterward)
+            var task = TransportCommandDispatcher.ExecuteCommandJsonAsync(commandJson, cts.Token);
+            SimulateEditorUpdate();
+            task.Wait(TimeSpan.FromSeconds(1));
+
+            // Send idle frames - with the fix, ProcessQueue should unhook itself
+            for (int i = 0; i < 10; i++)
+            {
+                SimulateEditorUpdate();
+            }
+
+            // Send another command - RequestMainThreadPump should work even with hook unhooked
+            var command2 = """{"type": "ping", "params": {}}""";
+            var task2 = TransportCommandDispatcher.ExecuteCommandJsonAsync(command2, cts.Token);
+            SimulateEditorUpdate();
+
+            var command2Processed = task2.Wait(TimeSpan.FromSeconds(1));
+
+            // Assert
+            Assert.IsTrue(command2Processed,
+                "After unhooking due to idle, RequestMainThreadPump should still ensure command processing");
+        }
+
+        [Test]
+        public void ProcessQueue_NoGarbageCollectionSpikes_DuringIdleFrames()
+        {
+            // Arrange: Get baseline GC statistics
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+            GC.WaitForPendingFinalizers();
+
+            var gen0CollectionsBefore = GC.GetTotalMemory(false);
+
+            // Act: Simulate 120 idle frames (2 seconds at 60 FPS)
+            for (int frame = 0; frame < TestFrames; frame++)
+            {
+                SimulateEditorUpdate();
+            }
+
+            // Assert: No major allocations that would trigger GC
+            var gen0CollectionsAfter = GC.GetTotalMemory(false);
+            var memoryGrowth = gen0CollectionsAfter - gen0CollectionsBefore;
+
+            // With the fix, we should see minimal allocations.
+            // Without the fix, we'd see ~120 List allocations (6KB+) every 60 frames,
+            // which accumulates to trigger GC pressure around 28ms spikes/second
+            Assert.That(memoryGrowth, Is.LessThan(5_000),
+                "Idle frames should not create allocations that trigger GC pressure");
+        }
+
+        // Helper: Simulates EditorApplication.update callback
+        // Uses reflection to invoke ProcessQueue on the TransportCommandDispatcher
+        private void SimulateEditorUpdate()
+        {
+            try
+            {
+                var method = typeof(TransportCommandDispatcher)
+                    .GetMethod("ProcessQueue",
+                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+                if (method != null)
+                {
+                    method.Invoke(null, null);
+                }
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                // Unwrap the inner exception from reflection
+                if (ex.InnerException != null)
+                {
+                    throw ex.InnerException;
+                }
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Potentially Fixes GitHub issue #577: 28ms UI stutters every ~1 second when MCP plugin is running

## Root Cause

The `MCPForUnityEditorWindow.OnEditorUpdate()` hook was being called every frame (60+ times/sec) to poll connection status. This triggered `UpdateConnectionStatus()` → `IsLocalHttpServerReachable()`, which makes network socket connection attempts with 50ms timeouts on the main thread.

## Architectural Changes

- Remove `OnEditorUpdate` hook that polled every frame
- Replace continuous polling with event-driven connection status updates:
  - User actions (manual refreshes via `RefreshAllData`)
  - Bridge state changes (via `RequestHealthVerification`)
  - Window focus events (via `OnFocus`)

Connection status now only updates when actually needed.

## Performance Improvements

1. **Eliminated main thread blocking network I/O**
   - Network socket checks no longer execute 60+ times per second
   - Main thread stays responsive for gameplay

2. **TransportCommandDispatcher: Early exit optimization**
   - Early `Pending.Count` check prevents List allocations when idle
   - Before: ~90 allocations/sec → 28ms GC spike every ~1 second
   - After: 0 allocations/sec when idle → no GC stuttering

3. **EditorStateCache: Sequence-based caching**
   - Only increments sequence number when state actually changes
   - Prevents unnecessary `DeepClone()` calls on every `GetSnapshot()`

4. **StdioBridgeHost: Consistent early exit pattern**
   - Added same early `commandQueue.Count` check as TransportCommandDispatcher

## Testing

- Verified MCP plugin runs without stuttering
- Scene hierarchy queries work correctly
- Editor menu items function properly
- Smooth gameplay without frame drops

## Summary by Sourcery

Reduce editor stuttering and GC pressure by avoiding unnecessary per-frame work and allocations in MCP editor integration.

Bug Fixes:
- Stop per-frame connection status polling in the MCP editor window to prevent main-thread blocking network calls that caused UI stutters.
- Avoid repeated DeepClone allocations in editor state snapshots by only updating the cached clone when state actually changes.

Enhancements:
- Short-circuit idle command processing in TransportCommandDispatcher and StdioBridgeHost to eliminate per-frame list allocations when no work is queued.
- Track editor state changes with a sequence-based mechanism so snapshots are only marked updated when relevant conditions change.

Tests:
- Add performance and behavior tests for TransportCommandDispatcher to verify idle operation does not allocate excessively and that commands are still processed correctly under various conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced garbage collection overhead through smart caching and optimized allocation patterns.
  * Eliminated per-frame allocations and processing when no pending tasks exist.
  * Conditional hook management reduces continuous polling overhead.

* **Improvements**
  * Status monitoring now event-driven rather than continuously polled.

* **Tests**
  * Added comprehensive test suites validating optimization behavior, performance metrics, and error handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->