### PR TITLE
fix: search inactive objects when setActive=true in modify

### DIFF
--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectModify.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectModify.cs
@@ -14,7 +14,15 @@ namespace MCPForUnity.Editor.Tools.GameObjects
     {
         internal static object Handle(JObject @params, JToken targetToken, string searchMethod)
         {
-            GameObject targetGo = ManageGameObjectCommon.FindObjectInternal(targetToken, searchMethod);
+            // When setActive=true is specified, we need to search for inactive objects
+            // otherwise we can't find an inactive object to activate it
+            JObject findParams = null;
+            if (@params["setActive"]?.ToObject<bool?>() == true)
+            {
+                findParams = new JObject { ["searchInactive"] = true };
+            }
+            
+            GameObject targetGo = ManageGameObjectCommon.FindObjectInternal(targetToken, searchMethod, findParams);
             if (targetGo == null)
             {
                 return new ErrorResponse($"Target GameObject ('{targetToken}') not found using method '{searchMethod ?? "default"}'.");


### PR DESCRIPTION
## Summary
- Fixes test `Modify_SetActive_ActivatesObject` which was failing after the Prefab Stage PR
- When trying to activate an inactive GameObject via `manage_gameobject` modify with `setActive=true`, the lookup would fail because inactive objects were not included in the search by default

## Changes
- `GameObjectModify.cs`: Automatically sets `searchInactive=true` when `setActive=true` is specified, allowing inactive objects to be found and activated

## Test plan
- [x] `Modify_SetActive_ActivatesObject` test passes
- [x] All 20 `ManageGameObjectModifyTests` pass
- [x] Full EditMode test suite (262 tests) passes with no regressions

## Summary by Sourcery

Ensure GameObject modify operations can activate inactive objects by including them in lookup when setActive is requested.

Bug Fixes:
- Fix failure to locate inactive GameObjects when performing a modify operation with setActive=true, allowing them to be activated as intended.

Tests:
- Verify Modify_SetActive_ActivatesObject and the full ManageGameObjectModify test suite pass, along with the broader EditMode tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game object search functionality to properly detect and modify inactive objects when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->