### PR TITLE
fix: Filter EditorApplication.isCompiling false positives in Play mode

### DIFF
--- a/MCPForUnity/Editor/Services/EditorStateCache.cs
+++ b/MCPForUnity/Editor/Services/EditorStateCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -265,7 +266,7 @@ namespace MCPForUnity.Editor.Services
             if (now - _lastUpdateTimeSinceStartup < MinUpdateIntervalSeconds)
             {
                 // Still update on compilation edge transitions to keep timestamps meaningful.
-                bool isCompiling = EditorApplication.isCompiling;
+                bool isCompiling = GetActualIsCompiling();
                 if (isCompiling == _lastIsCompiling)
                 {
                     return;
@@ -289,7 +290,7 @@ namespace MCPForUnity.Editor.Services
             _sequence++;
             _observedUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-            bool isCompiling = EditorApplication.isCompiling;
+            bool isCompiling = GetActualIsCompiling();
             if (isCompiling && !_lastIsCompiling)
             {
                 _lastCompileStartedUnixMs = _observedUnixMs;
@@ -426,6 +427,42 @@ namespace MCPForUnity.Editor.Services
                 }
                 return (JObject)_cached.DeepClone();
             }
+        }
+
+        /// <summary>
+        /// Returns the actual compilation state, working around a known Unity quirk where
+        /// EditorApplication.isCompiling can return false positives in Play mode.
+        /// See: https://github.com/CoplayDev/unity-mcp/issues/549
+        /// </summary>
+        private static bool GetActualIsCompiling()
+        {
+            // If EditorApplication.isCompiling is false, Unity is definitely not compiling
+            if (!EditorApplication.isCompiling)
+            {
+                return false;
+            }
+
+            // In Play mode, EditorApplication.isCompiling can have false positives.
+            // Double-check with CompilationPipeline.isCompiling via reflection.
+            if (EditorApplication.isPlaying)
+            {
+                try
+                {
+                    Type pipeline = Type.GetType("UnityEditor.Compilation.CompilationPipeline, UnityEditor");
+                    var prop = pipeline?.GetProperty("isCompiling", BindingFlags.Public | BindingFlags.Static);
+                    if (prop != null)
+                    {
+                        return (bool)prop.GetValue(null);
+                    }
+                }
+                catch
+                {
+                    // If reflection fails, fall back to EditorApplication.isCompiling
+                }
+            }
+
+            // Outside Play mode or if reflection failed, trust EditorApplication.isCompiling
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #549

`EditorApplication.isCompiling` can return `true` in Play mode even when Unity is not actually compiling. This causes MCP tools to incorrectly return `"error": "busy", "reason": "compiling"` errors intermittently.

### Changes

- Added `GetActualIsCompiling()` helper method in `EditorStateCache.cs` that:
  - Returns `false` immediately if `EditorApplication.isCompiling` is `false`
  - In Play mode, when `EditorApplication.isCompiling` is `true`, double-checks with `CompilationPipeline.isCompiling` via reflection
  - If `CompilationPipeline.isCompiling` returns `false`, treats it as a false positive
  - Falls back to `EditorApplication.isCompiling` outside Play mode or if reflection fails

- Updated both usages in `EditorStateCache.cs` to use the new helper

### Test plan

- [x] Enter Play mode in Unity Editor
- [x] Make repeated MCP tool calls (`find_gameobjects`, `manage_scene`, etc.)
- [x] Verify no spurious "busy/compiling" errors occur
- [x] Verify `editor_state` resource shows `is_compiling: false` when not actually compiling
- [x] Verify tools still work correctly in Play mode

## Summary by Sourcery

Bug Fixes:
- Correct is-compiling detection during Play mode by cross-checking EditorApplication.isCompiling with CompilationPipeline.isCompiling to avoid false positives in editor state reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of compilation state detection in Play mode to eliminate false positives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->