### PR TITLE
fix: Rider config path and add MCP registry manifest

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/RiderConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/RiderConfigurator.cs
@@ -10,9 +10,9 @@ namespace MCPForUnity.Editor.Clients.Configurators
         public RiderConfigurator() : base(new McpClient
         {
             name = "Rider GitHub Copilot",
-            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "JetBrains", "Rider", "mcp.json"),
-            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "JetBrains", "Rider", "mcp.json"),
-            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "JetBrains", "Rider", "mcp.json"),
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "github-copilot", "intellij", "mcp.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "github-copilot", "intellij", "mcp.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "github-copilot", "intellij", "mcp.json"),
             IsVsCodeLayout = true
         })
         { }

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,13 @@
+﻿{
+  "mcpServers": {
+    "unity-mcp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "mcpforunityserver",
+        "mcp-for-unity"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description
Fix Rider/IntelliJ GitHub Copilot MCP configuration paths and add mcp.json manifest for GitHub MCP Registry support.  Fixes https://github.com/CoplayDev/unity-mcp/issues/599

## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Changes Made
- **Fix RiderConfigurator** to use correct GitHub Copilot config paths:
  - Windows: `%LOCALAPPDATA%\github-copilot\intellij\mcp.json`
  - macOS: `~/Library/Application Support/github-copilot/intellij/mcp.json`
  - Linux: `~/.config/github-copilot/intellij/mcp.json`
- **Add mcp.json** for GitHub MCP Registry support:
  - Enables users to install via `coplaydev/unity-mcp`
  - Uses `uvx` with `mcpforunityserver` from PyPI

## Testing/Screenshots/Recordings
- Tested on Windows with JetBrains Rider + GitHub Copilot
- Verified MCP connection works via Unity console logs showing successful WebSocket registration and tool discovery
- Confirmed `mcp.json` is written to correct path (`%LOCALAPPDATA%\github-copilot\intellij\mcp.json`)

## Related Issues
<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional Notes
- The previous Rider config paths were incorrect and prevented the MCP connection from being established
- Cross-platform paths verified for Windows, macOS, and Linux

## Summary by Sourcery

Fix GitHub Copilot MCP configuration for JetBrains Rider and add registry manifest support.

New Features:
- Add an mcp.json manifest to enable installation via the GitHub MCP Registry.

Bug Fixes:
- Correct JetBrains Rider GitHub Copilot MCP configuration paths on Windows, macOS, and Linux so the MCP connection can be established.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rider integration configuration file paths across Windows, macOS, and Linux platforms
  * Added MCP server configuration file for Unity MCP server connectivity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->