### PR TITLE
fix: resolve Unknown pseudo class last-child USS warnings

### DIFF
--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
@@ -7,7 +7,6 @@
                 <ui:Label text="Client:" class="setting-label" />
                 <ui:DropdownField name="client-dropdown" class="setting-dropdown-inline" />
             </ui:VisualElement>
-            <ui:Button name="configure-all-button" text="Configure All Detected Clients" class="secondary-button" />
             <ui:VisualElement class="setting-row">
                 <ui:VisualElement class="status-container">
                     <ui:VisualElement name="client-status-indicator" class="status-dot" />
@@ -37,6 +36,7 @@
                     <ui:Label name="installation-steps" class="installation-steps" />
                 </ui:VisualElement>
             </ui:Foldout>
+            <ui:Button name="configure-all-button" text="Configure All Detected Clients" class="secondary-button" style="width: auto; padding-left: 12px; padding-right: 12px;" />
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/MCPForUnity/Editor/Windows/Components/Common.uss
+++ b/MCPForUnity/Editor/Windows/Components/Common.uss
@@ -26,7 +26,9 @@
 }
 
 /* Remove bottom margin from last section in a stack */
-.section-stack > .section:last-child {
+/* Note: Unity UI Toolkit doesn't support :last-child pseudo-class.
+   The .section-last class is applied programmatically instead. */
+.section-stack > .section.section-last {
     margin-bottom: 0px;
 }
 

--- a/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -278,6 +278,10 @@ namespace MCPForUnity.Editor.Windows
                 McpLog.Warn("Failed to load tools section UXML. Tool configuration will be unavailable.");
             }
 
+            // Apply .section-last class to last section in each stack
+            // (Unity UI Toolkit doesn't support :last-child pseudo-class)
+            ApplySectionLastClasses();
+
             guiCreated = true;
 
             // Initial updates
@@ -298,6 +302,29 @@ namespace MCPForUnity.Editor.Windows
 
             toolsLoaded = true;
             toolsSection.Refresh();
+        }
+
+        /// <summary>
+        /// Applies the .section-last class to the last .section element in each .section-stack container.
+        /// This is a workaround for Unity UI Toolkit not supporting the :last-child pseudo-class.
+        /// </summary>
+        private void ApplySectionLastClasses()
+        {
+            var sectionStacks = rootVisualElement.Query<VisualElement>(className: "section-stack").ToList();
+            foreach (var stack in sectionStacks)
+            {
+                var sections = stack.Children().Where(c => c.ClassListContains("section")).ToList();
+                if (sections.Count > 0)
+                {
+                    // Remove class from all sections first (in case of refresh)
+                    foreach (var section in sections)
+                    {
+                        section.RemoveFromClassList("section-last");
+                    }
+                    // Add class to the last section
+                    sections[sections.Count - 1].AddToClassList("section-last");
+                }
+            }
         }
 
         // Throttle OnEditorUpdate to avoid per-frame overhead (GitHub issue #577).


### PR DESCRIPTION
Fixes https://github.com/CoplayDev/unity-mcp/issues/622

Unity UI Toolkit does not support the :last-child pseudo-class. Replace it with a .section-last class that is applied programmatically to the last section in each .section-stack container.

Also moves the Configure All Detected Clients button to the bottom of the Client Configuration section.

## Summary by Sourcery

Work around Unity UI Toolkit limitations by replacing the unsupported :last-child pseudo-class with a programmatically applied .section-last class on editor window sections, and adjust client configuration layout accordingly.

Enhancements:
- Add a utility that scans section stacks in the editor window UI and applies a .section-last class to the final section in each stack to emulate :last-child styling.
- Update client configuration UXML/USS layout to place the Configure All Detected Clients action at the bottom of the section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed styling selector compatibility with Unity UI Toolkit for proper section styling.

* **Refactor**
  * Repositioned the "Configure All Detected Clients" button in the client configuration interface.
  * Applied UI styling improvements for better layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->