### PR TITLE
feat: add beta release workflow for TestPyPI

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,68 @@
+name: Beta Release (TestPyPI)
+
+concurrency:
+  group: beta-release
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - beta
+    paths:
+      - "Server/**"
+
+jobs:
+  publish_testpypi:
+    name: Publish beta to TestPyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/mcpforunityserver
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "Server/uv.lock"
+
+      - name: Generate dev version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE_VERSION=$(grep -oP '(?<=version = ")[^"]+' Server/pyproject.toml)
+          # Use date + short SHA for unique dev version
+          DEV_SUFFIX="dev$(date +%Y%m%d%H%M).g$(git rev-parse --short HEAD)"
+          DEV_VERSION="${BASE_VERSION}.${DEV_SUFFIX}"
+          echo "Base version: $BASE_VERSION"
+          echo "Dev version: $DEV_VERSION"
+          echo "dev_version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update version for beta release
+        env:
+          DEV_VERSION: ${{ steps.version.outputs.dev_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" Server/pyproject.toml
+          echo "Updated pyproject.toml:"
+          grep "^version" Server/pyproject.toml
+
+      - name: Build a binary wheel and a source tarball
+        shell: bash
+        run: uv build
+        working-directory: ./Server
+
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: Server/dist/
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

Adds a workflow that publishes beta/dev versions of the Python MCP server to TestPyPI when changes are pushed to the `beta` branch.

- Only triggers when there are changes to `Server/**` (avoids wasted cycles)
- Generates unique dev versions like `9.2.0.dev202501251430.gabc1234`
- Publishes to TestPyPI, keeping production PyPI clean for stable releases

## Admin Setup Required

Before this workflow can run, an admin needs to:

### 1. Create the GitHub Environment

1. Go to **Settings → Environments → New environment**
2. Name it `testpypi`
3. (Optional) Add deployment protection rules if desired

### 2. Configure Trusted Publishing on TestPyPI

1. Log in to https://test.pypi.org
2. Go to **Account settings → Publishing → Add a new pending publisher**
3. Fill in:
   - **PyPI project name:** `mcpforunityserver`
   - **Owner:** `CoplayDev`
   - **Repository:** `unity-mcp`
   - **Workflow name:** `beta-release.yml`
   - **Environment name:** `testpypi`

## Usage

Once set up, users can install beta versions with:

```bash
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ mcpforunityserver --pre
```

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Build:
- Introduce a beta-release workflow that builds the Server package and publishes time- and commit-suffixed dev versions to TestPyPI using Trusted Publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated beta release pipeline for continuous integration and streamlined distribution of development versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->