### PR TITLE
Add missing Unity .meta file for PrefabUtilityHelper

### DIFF
--- a/MCPForUnity/Editor/Helpers/PrefabUtilityHelper.cs.meta
+++ b/MCPForUnity/Editor/Helpers/PrefabUtilityHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebe2be77e64f4d4f811614b198210017
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Prevent Unity from ignoring the `PrefabUtilityHelper.cs` asset by adding its missing `.meta` file in the immutable assets folder.

### Description
- Add `MCPForUnity/Editor/Helpers/PrefabUtilityHelper.cs.meta` containing `fileFormatVersion: 2`, a generated `guid: ebe2be77e64f4d4f811614b198210017`, and default `MonoImporter` settings.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976dff06be08327bd659f0719710b16)

## Summary by Sourcery

Chores:
- Check in the PrefabUtilityHelper.cs.meta file under MCPForUnity/Editor/Helpers to track the asset in version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added metadata configuration file for internal Unity editor tooling support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->