### PR TITLE
Fix test failures by invalidating EditorConfigurationCache

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/WriteToConfigTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/WriteToConfigTests.cs
@@ -66,6 +66,7 @@ namespace MCPForUnityTests.Editor.Helpers
             // Force HTTP transport defaults so expectations match current behavior
             EditorPrefs.SetBool(UseHttpTransportPrefKey, true);
             EditorPrefs.SetString(HttpUrlPrefKey, "http://localhost:8080");
+            EditorConfigCache.Instance.Refresh();
         }
 
         [TearDown]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Characterization/ServerManagementServiceCharacterizationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Characterization/ServerManagementServiceCharacterizationTests.cs
@@ -215,6 +215,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
             // Arrange
             EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
             EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://remote.server.com:8080");
+            EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
             // Act

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/ServerCommandBuilderTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/ServerCommandBuilderTests.cs
@@ -237,6 +237,7 @@ namespace MCPForUnityTests.Editor.Services.Server
             // Arrange
             EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
             EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://remote.server.com:8080");
+            EditorConfigurationCache.Instance.Refresh();
 
             // Act
             bool result = _builder.TryBuildCommand(out string fileName, out string arguments, out string displayCommand, out string error);
@@ -253,6 +254,7 @@ namespace MCPForUnityTests.Editor.Services.Server
             // Arrange
             EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
             EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.Refresh();
 
             // Act
             bool result = _builder.TryBuildCommand(out string fileName, out string arguments, out string displayCommand, out string error);


### PR DESCRIPTION
## Summary
Fixes test failures caused by EditorConfigurationCache returning stale cached values. Several tests were setting EditorPrefs directly without refreshing the singleton cache.

## Changes
- Added `EditorConfigurationCache.Instance.Refresh()` calls after setting EditorPrefs in:
  - `ServerCommandBuilderTests.TryBuildCommand_RemoteUrl_ReturnsFalse()`
  - `ServerCommandBuilderTests.TryBuildCommand_LocalUrl_ReturnsCommandOrError()`
  - `ServerManagementServiceCharacterizationTests.TryGetLocalHttpServerCommand_RemoteUrl_ReturnsFalseWithError()`
  - `WriteToConfigTests.SetUp()`

## Test Plan
- [x] Tests now properly read the updated EditorPrefs values
- [x] ServerCommandBuilderTests errors now match expected patterns
- [x] WriteToConfigTests HTTP configuration assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure editor configuration-dependent tests use refreshed cached preferences after mutating EditorPrefs.

Tests:
- Refresh the editor configuration cache in server command builder and server management service tests after modifying EditorPrefs to prevent stale values.
- Update WriteToConfigTests setup to refresh the editor config cache after setting HTTP-related EditorPrefs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated test files to ensure proper cache refresh behavior during test execution across multiple test suites, verifying that configuration changes are correctly propagated before service evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->