### PR TITLE
Fix CodexConfigHelperTests for new prerelease argument order

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/CodexConfigHelperTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/CodexConfigHelperTests.cs
@@ -241,15 +241,19 @@ namespace MCPForUnityTests.Editor.Helpers
 
             // Verify args contains the proper uvx command structure
             var args = argsNode as TomlArray;
-            Assert.IsTrue(args.ChildrenCount >= 3, "Args should contain --from, git URL, and package name");
-            
+            Assert.IsTrue(args.ChildrenCount >= 5, "Args should contain --prerelease, explicit, --from, PyPI package reference, and package name");
+
             var firstArg = (args[0] as TomlString).Value;
             var secondArg = (args[1] as TomlString).Value;
             var thirdArg = (args[2] as TomlString).Value;
-            
-            Assert.AreEqual("--from", firstArg, "First arg should be --from");
-            Assert.IsTrue(secondArg.Contains("mcpforunityserver"), "Second arg should be PyPI package reference");
-            Assert.AreEqual("mcp-for-unity", thirdArg, "Third arg should be mcp-for-unity");
+            var fourthArg = (args[3] as TomlString).Value;
+            var fifthArg = (args[4] as TomlString).Value;
+
+            Assert.AreEqual("--prerelease", firstArg, "First arg should be --prerelease");
+            Assert.AreEqual("explicit", secondArg, "Second arg should be explicit");
+            Assert.AreEqual("--from", thirdArg, "Third arg should be --from");
+            Assert.IsTrue(fourthArg.Contains("mcpforunityserver"), "Fourth arg should be PyPI package reference");
+            Assert.AreEqual("mcp-for-unity", fifthArg, "Fifth arg should be mcp-for-unity");
 
             // Verify env.SystemRoot is present on Windows
             bool hasEnv = unityMcp.TryGetNode("env", out var envNode);
@@ -306,15 +310,19 @@ namespace MCPForUnityTests.Editor.Helpers
 
             // Verify args contains the proper uvx command structure
             var args = argsNode as TomlArray;
-            Assert.IsTrue(args.ChildrenCount >= 3, "Args should contain --from, git URL, and package name");
-            
+            Assert.IsTrue(args.ChildrenCount >= 5, "Args should contain --prerelease, explicit, --from, PyPI package reference, and package name");
+
             var firstArg = (args[0] as TomlString).Value;
             var secondArg = (args[1] as TomlString).Value;
             var thirdArg = (args[2] as TomlString).Value;
-            
-            Assert.AreEqual("--from", firstArg, "First arg should be --from");
-            Assert.IsTrue(secondArg.Contains("mcpforunityserver"), "Second arg should be PyPI package reference");
-            Assert.AreEqual("mcp-for-unity", thirdArg, "Third arg should be mcp-for-unity");
+            var fourthArg = (args[3] as TomlString).Value;
+            var fifthArg = (args[4] as TomlString).Value;
+
+            Assert.AreEqual("--prerelease", firstArg, "First arg should be --prerelease");
+            Assert.AreEqual("explicit", secondArg, "Second arg should be explicit");
+            Assert.AreEqual("--from", thirdArg, "Third arg should be --from");
+            Assert.IsTrue(fourthArg.Contains("mcpforunityserver"), "Fourth arg should be PyPI package reference");
+            Assert.AreEqual("mcp-for-unity", fifthArg, "Fifth arg should be mcp-for-unity");
 
             // Verify env is NOT present on non-Windows platforms
             bool hasEnv = unityMcp.TryGetNode("env", out _);
@@ -373,15 +381,19 @@ namespace MCPForUnityTests.Editor.Helpers
 
             // Verify args contains the proper uvx command structure
             var args = argsNode as TomlArray;
-            Assert.IsTrue(args.ChildrenCount >= 3, "Args should contain --from, git URL, and package name");
-            
+            Assert.IsTrue(args.ChildrenCount >= 5, "Args should contain --prerelease, explicit, --from, PyPI package reference, and package name");
+
             var firstArg = (args[0] as TomlString).Value;
             var secondArg = (args[1] as TomlString).Value;
             var thirdArg = (args[2] as TomlString).Value;
-            
-            Assert.AreEqual("--from", firstArg, "First arg should be --from");
-            Assert.IsTrue(secondArg.Contains("mcpforunityserver"), "Second arg should be PyPI package reference");
-            Assert.AreEqual("mcp-for-unity", thirdArg, "Third arg should be mcp-for-unity");
+            var fourthArg = (args[3] as TomlString).Value;
+            var fifthArg = (args[4] as TomlString).Value;
+
+            Assert.AreEqual("--prerelease", firstArg, "First arg should be --prerelease");
+            Assert.AreEqual("explicit", secondArg, "Second arg should be explicit");
+            Assert.AreEqual("--from", thirdArg, "Third arg should be --from");
+            Assert.IsTrue(fourthArg.Contains("mcpforunityserver"), "Fourth arg should be PyPI package reference");
+            Assert.AreEqual("mcp-for-unity", fifthArg, "Fifth arg should be mcp-for-unity");
 
             // Verify env.SystemRoot is present on Windows
             bool hasEnv = unityMcp.TryGetNode("env", out var envNode);
@@ -447,15 +459,19 @@ namespace MCPForUnityTests.Editor.Helpers
 
             // Verify args contains the proper uvx command structure
             var args = argsNode as TomlArray;
-            Assert.IsTrue(args.ChildrenCount >= 3, "Args should contain --from, git URL, and package name");
-            
+            Assert.IsTrue(args.ChildrenCount >= 5, "Args should contain --prerelease, explicit, --from, PyPI package reference, and package name");
+
             var firstArg = (args[0] as TomlString).Value;
             var secondArg = (args[1] as TomlString).Value;
             var thirdArg = (args[2] as TomlString).Value;
-            
-            Assert.AreEqual("--from", firstArg, "First arg should be --from");
-            Assert.IsTrue(secondArg.Contains("mcpforunityserver"), "Second arg should be PyPI package reference");
-            Assert.AreEqual("mcp-for-unity", thirdArg, "Third arg should be mcp-for-unity");
+            var fourthArg = (args[3] as TomlString).Value;
+            var fifthArg = (args[4] as TomlString).Value;
+
+            Assert.AreEqual("--prerelease", firstArg, "First arg should be --prerelease");
+            Assert.AreEqual("explicit", secondArg, "Second arg should be explicit");
+            Assert.AreEqual("--from", thirdArg, "Third arg should be --from");
+            Assert.IsTrue(fourthArg.Contains("mcpforunityserver"), "Fourth arg should be PyPI package reference");
+            Assert.AreEqual("mcp-for-unity", fifthArg, "Fifth arg should be mcp-for-unity");
 
             // Verify env is NOT present on non-Windows platforms
             bool hasEnv = unityMcp.TryGetNode("env", out _);


### PR DESCRIPTION
## Summary
Updates CodexConfigHelperTests to account for the new `--prerelease explicit` arguments added to the uvx command for beta server mode support.

## Changes
Updated assertion indices in 4 test methods to match the new argument order:
- `--prerelease` (index 0)
- `explicit` (index 1)
- `--from` (index 2)
- `mcpforunityserver>=0.0.0a0` (index 3)
- `mcp-for-unity` (index 4)

Previously the tests expected `--from` at index 0, but with beta server mode support, these arguments are now prepended.

## Tests Fixed
- BuildCodexServerBlock_OnWindows_IncludesSystemRootEnv
- BuildCodexServerBlock_OnNonWindows_ExcludesEnv
- UpsertCodexServerBlock_OnWindows_IncludesSystemRootEnv
- UpsertCodexServerBlock_OnNonWindows_ExcludesEnv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Adjust CodexConfigHelper uvx argument assertions in four Windows and non-Windows tests to expect the prepended --prerelease explicit flags and updated argument count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test validations to reflect changes in the Codex server command argument structure, now expecting an expanded parameter sequence across build configurations and integration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->