### PR TITLE
fix: prevent main branch deletion in sync_beta step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,7 +350,8 @@ jobs:
         run: |
           set -euo pipefail
           # Enable auto-merge (requires repo setting "Allow auto-merge")
-          gh pr merge "$PR_NUMBER" --merge --auto || true
+          # Use --no-delete-branch to prevent deleting main (the head branch)
+          gh pr merge "$PR_NUMBER" --merge --auto --no-delete-branch || true
           # Wait for PR to be merged (poll up to 2 minutes)
           for i in {1..24}; do
             STATE=$(gh pr view "$PR_NUMBER" --json state -q '.state')
@@ -362,7 +363,7 @@ jobs:
             sleep 5
           done
           echo "Sync PR did not merge in time. Attempting direct merge..."
-          gh pr merge "$PR_NUMBER" --merge
+          gh pr merge "$PR_NUMBER" --merge --no-delete-branch
 
   publish_docker:
     name: Publish Docker image


### PR DESCRIPTION
## Summary
- Added `--no-delete-branch` flag to `gh pr merge` commands in the sync_beta job

## Problem
The release workflow's sync_beta step creates a PR with `main` as the head branch (`--head main --base beta`). When the PR merges and the repo has "Automatically delete head branches" enabled, GitHub deletes `main`.

## Solution
Added `--no-delete-branch` to both merge commands to explicitly preserve the main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the release workflow's sync_beta job to pass --no-delete-branch to GitHub CLI PR merge commands so the main branch is preserved after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to preserve branch history during merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->