### PR TITLE
fix: beta workflow pushes directly instead of creating PRs

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -108,19 +108,39 @@ jobs:
           git commit -m "chore: bump Unity package to beta version ${BETA_VERSION}"
 
           # Push with retry for race conditions (non-fast-forward)
+          # Save original commit to reset to if needed
+          ORIGINAL_HEAD=$(git rev-parse HEAD)
+
           for attempt in 1 2 3; do
             echo "Push attempt $attempt..."
             git fetch origin beta
-            git rebase origin/beta
+
+            # Rebase onto latest beta, abort if it fails
+            if ! git rebase origin/beta; then
+              echo "Rebase failed on attempt $attempt"
+              git rebase --abort 2>/dev/null || true
+              if [[ $attempt -eq 3 ]]; then
+                echo "Rebase failed after 3 attempts"
+                exit 1
+              fi
+              echo "Retrying after rebase failure..."
+              sleep 2
+              continue
+            fi
+
+            # Rebase succeeded, try to push
             if git push origin HEAD:beta; then
               echo "Push succeeded on attempt $attempt"
               break
             fi
+
+            # Push failed (likely non-fast-forward), reset to original and retry
+            echo "Push failed on attempt $attempt"
             if [[ $attempt -eq 3 ]]; then
               echo "Push failed after 3 attempts"
               exit 1
             fi
-            echo "Push failed, retrying..."
+            git reset --hard "$ORIGINAL_HEAD"
             sleep 2
           done
           echo "updated=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Remove PR-based version bump flow that caused orphaned PRs to accumulate
- Push version bump commits directly to beta branch
- Remove `pull-requests: write` permission (no longer needed)

## Why
The previous workflow created a PR for each version bump, which required manual merging and left orphaned PRs when releases happened. This simplifies the flow to just push directly to beta.

## Requires
Admin needs to allow GitHub Actions to push directly to beta branch (already requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify the beta release workflow by pushing automated version bumps directly to the beta branch instead of creating pull requests.

CI:
- Update the Unity beta version workflow to commit and push version bump changes directly to the beta branch.
- Remove unnecessary pull request write permissions from the beta release workflow and refresh comments to reflect the new direct-push behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified beta release flow to commit and push version bumps directly to the beta branch, removing the prior PR-based flow and related PR operations.
  * Renamed and clarified the commit/push step to reflect direct pushes instead of temporary-branch PR creation.

* **Bug Fixes**
  * Reduced publish race conditions and accidental cancellations by separating bot vs human runs and adding a retry/rebase-and-push strategy to handle non-fast-forward conflicts.
  * Updated prerelease messaging to reflect the new push-first behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->