### PR TITLE
fix(run_tests): support snake_case params and handle double-serialized arrays

### DIFF
--- a/MCPForUnity/Editor/Helpers/ParamCoercion.cs
+++ b/MCPForUnity/Editor/Helpers/ParamCoercion.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Globalization;
-using System.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace MCPForUnity.Editor.Helpers
@@ -317,86 +315,6 @@ namespace MCPForUnity.Editor.Helpers
                 return false;
             }
             return true;
-        }
-
-        /// <summary>
-        /// Looks up a parameter by camelCase key with snake_case fallback.
-        /// MCP tool schemas use snake_case, but some handlers expect camelCase.
-        /// </summary>
-        /// <param name="params">The JSON parameters object</param>
-        /// <param name="camelKey">The camelCase key (e.g. "testNames")</param>
-        /// <param name="snakeKey">The snake_case key (e.g. "test_names")</param>
-        /// <returns>The token if found under either key, or null</returns>
-        public static JToken GetParam(JObject @params, string camelKey, string snakeKey = null)
-        {
-            if (@params == null) return null;
-            return @params[camelKey] ?? (snakeKey != null ? @params[snakeKey] : null);
-        }
-
-        /// <summary>
-        /// Coerces a JToken to a string array, handling various MCP serialization formats:
-        /// plain strings, JSON arrays, stringified JSON arrays, and double-serialized arrays.
-        /// </summary>
-        /// <param name="token">The JSON token to coerce</param>
-        /// <returns>A string array, or null if empty/missing</returns>
-        public static string[] CoerceStringArray(JToken token)
-        {
-            if (token == null || token.Type == JTokenType.Null) return null;
-
-            if (token.Type == JTokenType.String)
-            {
-                var value = token.ToString();
-                if (string.IsNullOrWhiteSpace(value)) return null;
-                // Handle stringified JSON arrays (e.g. "[\"name1\", \"name2\"]")
-                var trimmed = value.Trim();
-                if (trimmed.StartsWith("[") && trimmed.EndsWith("]"))
-                {
-                    try
-                    {
-                        var parsed = JArray.Parse(trimmed);
-                        var values = parsed.Values<string>()
-                            .Where(s => !string.IsNullOrWhiteSpace(s))
-                            .ToArray();
-                        return values.Length > 0 ? values : null;
-                    }
-                    catch (JsonException) { /* not a valid JSON array, treat as plain string */ }
-                }
-                return new[] { value };
-            }
-
-            if (token.Type == JTokenType.Array)
-            {
-                var array = token as JArray;
-                if (array == null || array.Count == 0) return null;
-                // Handle double-serialized arrays: MCP bridge may send ["[\"name1\"]"]
-                // where the inner string is a stringified JSON array
-                if (array.Count == 1 && array[0].Type == JTokenType.String)
-                {
-                    var inner = array[0].ToString().Trim();
-                    if (inner.StartsWith("[") && inner.EndsWith("]"))
-                    {
-                        try
-                        {
-                            array = JArray.Parse(inner);
-                        }
-                        catch (JsonException) { /* use original array */ }
-                    }
-                }
-                // Handle single-level nested arrays: [[name1, name2]]
-                // Multi-element outer arrays (e.g. [["a"], ["b"]]) are not unwrapped
-                // as that format is not produced by known MCP clients.
-                else if (array.Count == 1 && array[0].Type == JTokenType.Array)
-                {
-                    array = array[0] as JArray ?? array;
-                }
-                var values = array
-                    .Values<string>()
-                    .Where(s => !string.IsNullOrWhiteSpace(s))
-                    .ToArray();
-                return values.Length > 0 ? values : null;
-            }
-
-            return null;
         }
 
         /// <summary>

--- a/MCPForUnity/Editor/Tools/GetTestJob.cs
+++ b/MCPForUnity/Editor/Tools/GetTestJob.cs
@@ -19,8 +19,9 @@ namespace MCPForUnity.Editor.Tools
                 return new ErrorResponse("Missing required parameter 'job_id'.");
             }
 
-            bool includeDetails = ParamCoercion.CoerceBool(ParamCoercion.GetParam(@params, "includeDetails", "include_details"), false);
-            bool includeFailedTests = ParamCoercion.CoerceBool(ParamCoercion.GetParam(@params, "includeFailedTests", "include_failed_tests"), false);
+            var p = new ToolParams(@params);
+            bool includeDetails = p.GetBool("includeDetails");
+            bool includeFailedTests = p.GetBool("includeFailedTests");
 
             var job = TestJobManager.GetJob(jobId);
             if (job == null)

--- a/MCPForUnity/Editor/Tools/RunTests.cs
+++ b/MCPForUnity/Editor/Tools/RunTests.cs
@@ -40,8 +40,9 @@ namespace MCPForUnity.Editor.Tools
                     return Task.FromResult<object>(new ErrorResponse(parseError));
                 }
 
-                bool includeDetails = ParamCoercion.CoerceBool(ParamCoercion.GetParam(@params, "includeDetails", "include_details"), false);
-                bool includeFailedTests = ParamCoercion.CoerceBool(ParamCoercion.GetParam(@params, "includeFailedTests", "include_failed_tests"), false);
+                var p = new ToolParams(@params);
+                bool includeDetails = p.GetBool("includeDetails");
+                bool includeFailedTests = p.GetBool("includeFailedTests");
 
                 var filterOptions = GetFilterOptions(@params);
                 string jobId = TestJobManager.StartJob(parsedMode.Value, filterOptions);
@@ -73,10 +74,11 @@ namespace MCPForUnity.Editor.Tools
                 return null;
             }
 
-            var testNames = ParamCoercion.CoerceStringArray(ParamCoercion.GetParam(@params, "testNames", "test_names"));
-            var groupNames = ParamCoercion.CoerceStringArray(ParamCoercion.GetParam(@params, "groupNames", "group_names"));
-            var categoryNames = ParamCoercion.CoerceStringArray(ParamCoercion.GetParam(@params, "categoryNames", "category_names"));
-            var assemblyNames = ParamCoercion.CoerceStringArray(ParamCoercion.GetParam(@params, "assemblyNames", "assembly_names"));
+            var p = new ToolParams(@params);
+            var testNames = p.GetStringArray("testNames");
+            var groupNames = p.GetStringArray("groupNames");
+            var categoryNames = p.GetStringArray("categoryNames");
+            var assemblyNames = p.GetStringArray("assemblyNames");
 
             if (testNames == null && groupNames == null && categoryNames == null && assemblyNames == null)
             {


### PR DESCRIPTION
## Summary
- **snake_case parameter support**: `GetFilterOptions()` in `RunTests.cs` only checked camelCase keys (`testNames`, `groupNames`, etc.) but the MCP tool schema defines them in snake_case (`test_names`, `group_names`, etc.). Added fallback lookups so both naming conventions work.
- **Double-serialized array handling**: Some MCP clients (e.g. Claude Code) serialize array parameters as a stringified JSON array inside an outer array (`["[\"name1\"]"]`). Added detection and unwrapping for this pattern in `ParseStringArray()`.
- **Same snake_case fix in `GetTestJob.cs`**: `include_details` and `include_failed_tests` parameters also only checked camelCase.

## Root Cause
When an MCP client sends `test_names: ["MyTest"]`, the C# handler looked up `@params["testNames"]` which returned null, so no filter was applied. The double-serialization issue compounded this — even if the key matched, the array value `["[\"MyTest\"]"]` would extract the stringified JSON as a literal test name, which never matched any test.

## Testing
Verified with Claude Code MCP client:
- Before: `run_tests(test_names=["SomeTest"])` always ran 0 tests
- After: correctly filters to only the specified tests

Fixes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve MCP test commands parameter handling for better compatibility with different clients.

Bug Fixes:
- Allow run_tests and get_test_job commands to read both camelCase and snake_case parameter names for filter and include options.
- Correctly parse array parameters that may be provided as stringified JSON arrays, double-serialized arrays, or nested arrays so test filters apply as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated parameter handling for test operations to improve code consistency and reduce duplication across testing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->