### PR TITLE
fix: improve tool descriptions with explicit cross-references

### DIFF
--- a/Server/src/services/tools/find_gameobjects.py
+++ b/Server/src/services/tools/find_gameobjects.py
@@ -15,7 +15,13 @@ from services.tools.preflight import preflight
 
 
 @mcp_for_unity_tool(
-    description="Search for GameObjects in the scene. Requires search_term (name, tag, layer name, component type, or path). Returns instance IDs only (paginated). Use mcpforunity://scene/gameobject/{id} resource to get full GameObject data."
+    description=(
+        "Search for GameObjects in the scene by name, tag, layer, component type, or path. "
+        "Returns instance IDs only (paginated). "
+        "Then use mcpforunity://scene/gameobject/{id} resource for full data, "
+        "or mcpforunity://scene/gameobject/{id}/components for component details. "
+        "For CRUD operations (create/modify/delete), use manage_gameobject instead."
+    )
 )
 async def find_gameobjects(
     ctx: Context,

--- a/Server/src/services/tools/manage_components.py
+++ b/Server/src/services/tools/manage_components.py
@@ -14,7 +14,13 @@ from services.tools.preflight import preflight
 
 
 @mcp_for_unity_tool(
-    description="Manages components on GameObjects (add, remove, set_property). For reading component data, use the mcpforunity://scene/gameobject/{id}/components resource."
+    description=(
+        "Add, remove, or set properties on components attached to GameObjects. "
+        "Actions: add, remove, set_property. Requires target (instance ID or name) and component_type. "
+        "For READING component data, use the mcpforunity://scene/gameobject/{id}/components resource "
+        "or mcpforunity://scene/gameobject/{id}/component/{name} for a single component. "
+        "For creating/deleting GameObjects themselves, use manage_gameobject instead."
+    )
 )
 async def manage_components(
     ctx: Context,

--- a/Server/src/services/tools/manage_gameobject.py
+++ b/Server/src/services/tools/manage_gameobject.py
@@ -40,7 +40,13 @@ def _normalize_component_properties(value: Any) -> tuple[dict[str, dict[str, Any
 
 
 @mcp_for_unity_tool(
-    description="Performs CRUD operations on GameObjects. Actions: create, modify, delete, duplicate, move_relative. For finding GameObjects use find_gameobjects tool. For component operations use manage_components tool.",
+    description=(
+        "Performs CRUD operations on GameObjects. "
+        "Actions: create, modify, delete, duplicate, move_relative. "
+        "NOT for searching — use the find_gameobjects tool to search by name/tag/layer/component/path. "
+        "NOT for component management — use the manage_components tool (add/remove/set_property) "
+        "or mcpforunity://scene/gameobject/{id}/components resource (read)."
+    ),
     annotations=ToolAnnotations(
         title="Manage GameObject",
         destructiveHint=True,
@@ -137,7 +143,7 @@ async def manage_gameobject(
     if action is None:
         return {
             "success": False,
-            "message": "Missing required parameter 'action'. Valid actions: create, modify, delete, duplicate, move_relative. For finding GameObjects use find_gameobjects tool. For component operations use manage_components tool."
+            "message": "Missing required parameter 'action'. Valid actions: create, modify, delete, duplicate, move_relative. To SEARCH for GameObjects use the find_gameobjects tool. To manage COMPONENTS use the manage_components tool."
         }
 
     # --- Normalize vector parameters with detailed error handling ---


### PR DESCRIPTION
## Description

Updates tool descriptions on `manage_gameobject`, `find_gameobjects`, and `manage_components` to use explicit negative routing ("NOT for X — use Y tool") and include full resource URIs.

LLMs pick which tool to use based on the `description` field in the MCP schema. When descriptions are vague about tool boundaries, LLMs guess wrong. This change makes the routing unambiguous.

## Type of Change

- Refactoring (no functional changes)

## Changes Made

**`manage_gameobject`** — Added explicit "NOT for searching" / "NOT for component management" with tool names and resource URIs:
```
NOT for searching — use the find_gameobjects tool to search by name/tag/layer/component/path.
NOT for component management — use the manage_components tool (add/remove/set_property)
or mcpforunity://scene/gameobject/{id}/components resource (read).
```

**`find_gameobjects`** — Added cross-references to downstream resources and back to `manage_gameobject`:
```
Then use mcpforunity://scene/gameobject/{id} resource for full data,
or mcpforunity://scene/gameobject/{id}/components for component details.
For CRUD operations (create/modify/delete), use manage_gameobject instead.
```

**`manage_components`** — Added cross-references to read resources and back to `manage_gameobject`:
```
For READING component data, use the mcpforunity://scene/gameobject/{id}/components resource
or mcpforunity://scene/gameobject/{id}/component/{name} for a single component.
For creating/deleting GameObjects themselves, use manage_gameobject instead.
```

## Testing/Screenshots/Recordings

All 563 Python tests pass. Description-only changes — no parameter or logic modifications.

## Documentation Updates

- [x] I have added/removed/modified tools or resources
  - No tools/resources were added or removed. Only the inline `description` strings were updated — these are embedded in the MCP schema that LLMs see.

## Related Issues

Companion to #693 (vestigial param removal). Together these two changes address the LLM tool routing confusion that caused ~46 failed calls in a single session.

## Summary by Sourcery

Clarify and tighten MCP tool boundaries and routing between GameObject CRUD, search, and component-management tools by improving their descriptions and cross-references.

Enhancements:
- Strengthen manage_gameobject description to explicitly exclude search and component-management use cases and reference the appropriate tools and resources.
- Expand find_gameobjects description to detail supported search dimensions, returned data, and follow-up resources and tools for further operations.
- Refine manage_components description to clearly scope it to component-level changes, point to read-only component resources, and redirect GameObject creation/deletion to the manage_gameobject tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced tool descriptions and error messages to clarify functionality scope and provide better guidance on tool usage and relationships between tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->