### PR TITLE
Fix run_tests array params double-encoding when client sends JSON-str…

### DIFF
--- a/Server/src/services/tools/run_tests.py
+++ b/Server/src/services/tools/run_tests.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from typing import Annotated, Any, Literal
@@ -178,15 +179,14 @@ async def run_tests(
             if not stripped:
                 return None
             # Handle JSON-stringified arrays (e.g. '["test1", "test2"]')
-            if stripped.startswith("["):
-                import json
+            if stripped.startswith("[") and stripped.endswith("]"):
                 try:
                     parsed = json.loads(stripped)
                     if isinstance(parsed, list):
                         result = [str(v).strip() for v in parsed if v and str(v).strip()]
                         return result if result else None
                 except (json.JSONDecodeError, ValueError):
-                    pass
+                    logger.debug("Failed to parse apparent JSON array in filter param: %s", stripped)
             return [stripped]
         if isinstance(value, list):
             result = [str(v).strip() for v in value if v and str(v).strip()]


### PR DESCRIPTION
## Description
Fix `run_tests` array parameter filtering (test_names, group_names, category_names, assembly_names) returning zero matching tests due to double-encoding.

## Type of Change
<!-- Save the type of change you did -->
Save your change type
- Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Updated `_coerce_string_list` in `Server/src/services/tools/run_tests.py` to detect and parse JSON-stringified arrays before forwarding to Unity
- When FastMCP/Pydantic coerces a `list[str] | str` union parameter to str, it produces `'["test1"]'` instead of a native list. The helper now parses these back to a proper `list[str]`


## Testing/Screenshots/Recordings
Debug logs on the C# side confirmed the double-encoding:

**Before (broken):**
`{"testNames":["[\"Namespace.Test1\"]"]}`
Unity receives the literal string ["Namespace.Test1"] as the test name — matches nothing, returns 0 tests.

**After (fixed):**
`{"testNames":["Namespace.Test1"]}`
Unity correctly matches and runs targeted tests correctly.

## Summary by Sourcery

Bug Fixes:
- Ensure JSON-stringified arrays passed as string values to run_tests are parsed into proper string lists before being forwarded to Unity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation to robustly handle various string formats, including whitespace trimming and array parsing, improving test configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->