### PR TITLE
Merge directly because it's failing w/ the auto flag and no status checks

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -138,7 +138,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh pr merge "$PR_NUMBER" --merge --auto --delete-branch
+          gh pr merge "$PR_NUMBER" --merge --delete-branch
 
   publish_pypi_prerelease:
     name: Publish beta to PyPI (pre-release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh pr merge "$PR_NUMBER" --merge --auto --no-delete-branch
+          gh pr merge "$PR_NUMBER" --merge --no-delete-branch
 
   publish_docker:
     name: Publish Docker image


### PR DESCRIPTION
One more small fix before the bigger revamp

## Summary by Sourcery

Adjust GitHub Actions release workflows to stop using the `--auto` flag when merging pull requests via the GitHub CLI.

CI:
- Update beta release workflow to perform direct PR merges without the GitHub CLI `--auto` flag.
- Update main release workflow to perform direct PR merges without the GitHub CLI `--auto` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration workflow configuration to modify pull request merge handling behavior across release and beta release pipelines. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->