### PR TITLE
test: fix PackageUpdateServiceTests override signature

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/PackageUpdateServiceTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/PackageUpdateServiceTests.cs
@@ -342,7 +342,7 @@ namespace MCPForUnityTests.Editor.Services
             return IsGitInstallationResult;
         }
 
-        protected override string FetchLatestVersionFromGitHub()
+        protected override string FetchLatestVersionFromGitHub(string branch)
         {
             GitFetchCalled = true;
             return GitFetchResult;


### PR DESCRIPTION
## Summary
- update TestablePackageUpdateService override to match PackageUpdateService method signature
- fix compile error in Unity tests: CS0115 on FetchLatestVersionFromGitHub

## Why
PackageUpdateService.FetchLatestVersionFromGitHub now takes a branch parameter, but the test subclass still overrode the old no-arg method.

## Change
- TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/PackageUpdateServiceTests.cs
  - FetchLatestVersionFromGitHub() -> FetchLatestVersionFromGitHub(string branch)

## Summary by Sourcery

Tests:
- Update the TestablePackageUpdateService override of FetchLatestVersionFromGitHub to accept a branch parameter matching the production service API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to support branch parameter handling.

---

**Note:** This is an internal testing change with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->