### PR TITLE
fix: preserve tool toggle state and filter tools in client listings (rebased #723)

### DIFF
--- a/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
+++ b/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
@@ -226,16 +226,6 @@ namespace MCPForUnity.Editor.Services
             {
                 bool defaultValue = metadata.AutoRegister || metadata.IsBuiltIn;
                 EditorPrefs.SetBool(key, defaultValue);
-                return;
-            }
-
-            if (metadata.IsBuiltIn && !metadata.AutoRegister)
-            {
-                bool currentValue = EditorPrefs.GetBool(key, metadata.AutoRegister);
-                if (currentValue == metadata.AutoRegister)
-                {
-                    EditorPrefs.SetBool(key, true);
-                }
             }
         }
 

--- a/MCPForUnity/Editor/Services/Transport/IMcpTransportClient.cs
+++ b/MCPForUnity/Editor/Services/Transport/IMcpTransportClient.cs
@@ -14,5 +14,6 @@ namespace MCPForUnity.Editor.Services.Transport
         Task<bool> StartAsync();
         Task StopAsync();
         Task<bool> VerifyAsync();
+        Task ReregisterToolsAsync();
     }
 }

--- a/MCPForUnity/Editor/Services/Transport/TransportManager.cs
+++ b/MCPForUnity/Editor/Services/Transport/TransportManager.cs
@@ -42,16 +42,6 @@ namespace MCPForUnity.Editor.Services.Transport
             };
         }
 
-        private IMcpTransportClient GetClient(TransportMode mode)
-        {
-            return mode switch
-            {
-                TransportMode.Http => _httpClient,
-                TransportMode.Stdio => _stdioClient,
-                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported transport mode"),
-            };
-        }
-
         public async Task<bool> StartAsync(TransportMode mode)
         {
             IMcpTransportClient client = GetOrCreateClient(mode);
@@ -161,6 +151,20 @@ namespace MCPForUnity.Editor.Services.Transport
             {
                 UpdateState(mode, TransportState.Disconnected(transportName));
             }
+        }
+
+        /// <summary>
+        /// Gets the active transport client for the specified mode.
+        /// Returns null if the client hasn't been created yet.
+        /// </summary>
+        public IMcpTransportClient GetClient(TransportMode mode)
+        {
+            return mode switch
+            {
+                TransportMode.Http => _httpClient,
+                TransportMode.Stdio => _stdioClient,
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported transport mode"),
+            };
         }
 
         private void UpdateState(TransportMode mode, TransportState state)

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioTransportClient.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioTransportClient.cs
@@ -46,5 +46,12 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
             return Task.FromResult(running);
         }
 
+        public Task ReregisterToolsAsync()
+        {
+            // Stdio transport doesn't support dynamic tool reregistration
+            // Tools are registered at server startup
+            return Task.CompletedTask;
+        }
+
     }
 }

--- a/MCPForUnity/Editor/Services/Transport/Transports/WebSocketTransportClient.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/WebSocketTransportClient.cs
@@ -562,6 +562,29 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
             McpLog.Info($"[WebSocket] Sent {tools.Count} tools registration", false);
         }
 
+        public async Task ReregisterToolsAsync()
+        {
+            if (!IsConnected || _lifecycleCts == null)
+            {
+                McpLog.Warn("[WebSocket] Cannot reregister tools: not connected");
+                return;
+            }
+
+            try
+            {
+                await SendRegisterToolsAsync(_lifecycleCts.Token).ConfigureAwait(false);
+                McpLog.Info("[WebSocket] Tool reregistration completed", false);
+            }
+            catch (System.OperationCanceledException)
+            {
+                McpLog.Warn("[WebSocket] Tool reregistration cancelled");
+            }
+            catch (System.Exception ex)
+            {
+                McpLog.Error($"[WebSocket] Tool reregistration failed: {ex.Message}");
+            }
+        }
+
         private async Task HandleExecuteAsync(JObject payload, CancellationToken token)
         {
             string commandId = payload.Value<string>("id");

--- a/Server/src/services/registry/tool_registry.py
+++ b/Server/src/services/registry/tool_registry.py
@@ -10,6 +10,7 @@ _tool_registry: list[dict[str, Any]] = []
 def mcp_for_unity_tool(
     name: str | None = None,
     description: str | None = None,
+    unity_target: str | None = "self",
     **kwargs
 ) -> Callable:
     """
@@ -20,6 +21,10 @@ def mcp_for_unity_tool(
     Args:
         name: Tool name (defaults to function name)
         description: Tool description
+        unity_target: Visibility target used by middleware filtering.
+            - "self" (default): tool follows its own enabled state.
+            - None: server-only tool, always visible in tool listing.
+            - "<tool_name>": alias tool that follows another Unity tool state.
         **kwargs: Additional arguments passed to @mcp.tool()
 
     Example:
@@ -29,11 +34,29 @@ def mcp_for_unity_tool(
     """
     def decorator(func: Callable) -> Callable:
         tool_name = name if name is not None else func.__name__
+        # Safety guard: unity_target is internal metadata and must never leak into mcp.tool kwargs.
+        tool_kwargs = dict(kwargs)  # Create a copy to avoid side effects
+        if "unity_target" in tool_kwargs:
+            del tool_kwargs["unity_target"]
+
+        if unity_target is None:
+            normalized_unity_target: str | None = None
+        elif isinstance(unity_target, str) and unity_target.strip():
+            normalized_unity_target = (
+                tool_name if unity_target == "self" else unity_target.strip()
+            )
+        else:
+            raise ValueError(
+                f"Invalid unity_target for tool '{tool_name}': {unity_target!r}. "
+                "Expected None or a non-empty string."
+            )
+
         _tool_registry.append({
             'func': func,
             'name': tool_name,
             'description': description,
-            'kwargs': kwargs
+            'unity_target': normalized_unity_target,
+            'kwargs': tool_kwargs,
         })
 
         return func

--- a/Server/src/services/resources/custom_tools.py
+++ b/Server/src/services/resources/custom_tools.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from models import MCPResponse
 from services.custom_tool_service import (
     CustomToolService,
+    get_user_id_from_context,
     resolve_project_id_for_unity_instance,
     ToolDefinitionModel,
 )
@@ -42,7 +43,8 @@ async def get_custom_tools(ctx: Context) -> CustomToolsResourceResponse | MCPRes
         )
 
     service = CustomToolService.get_instance()
-    tools = await service.list_registered_tools(project_id)
+    user_id = get_user_id_from_context(ctx)
+    tools = await service.list_registered_tools(project_id, user_id=user_id)
 
     data = CustomToolsData(
         project_id=project_id,

--- a/Server/src/services/tools/debug_request_context.py
+++ b/Server/src/services/tools/debug_request_context.py
@@ -13,6 +13,7 @@ from transport.plugin_hub import PluginHub
 
 
 @mcp_for_unity_tool(
+    unity_target=None,
     description="Return the current FastMCP request context details (client_id, session_id, and meta dump).",
     annotations=ToolAnnotations(
         title="Debug Request Context",

--- a/Server/src/services/tools/execute_custom_tool.py
+++ b/Server/src/services/tools/execute_custom_tool.py
@@ -4,6 +4,7 @@ from models.models import MCPResponse
 
 from services.custom_tool_service import (
     CustomToolService,
+    get_user_id_from_context,
     resolve_project_id_for_unity_instance,
 )
 from services.registry import mcp_for_unity_tool
@@ -12,6 +13,7 @@ from services.tools import get_unity_instance_from_context
 
 @mcp_for_unity_tool(
     name="execute_custom_tool",
+    unity_target=None,
     description="Execute a project-scoped custom tool registered by Unity.",
     annotations=ToolAnnotations(
         title="Execute Custom Tool",
@@ -40,4 +42,11 @@ async def execute_custom_tool(ctx: Context, tool_name: str, parameters: dict | N
         )
 
     service = CustomToolService.get_instance()
-    return await service.execute_tool(project_id, tool_name, unity_instance, parameters)
+    user_id = get_user_id_from_context(ctx)
+    return await service.execute_tool(
+        project_id,
+        tool_name,
+        unity_instance,
+        parameters,
+        user_id=user_id,
+    )

--- a/Server/src/services/tools/find_in_file.py
+++ b/Server/src/services/tools/find_in_file.py
@@ -66,6 +66,7 @@ def _split_uri(uri: str) -> tuple[str, str]:
 
 
 @mcp_for_unity_tool(
+    unity_target="manage_script",
     description="Searches a file with a regex pattern and returns line numbers and excerpts.",
     annotations=ToolAnnotations(
         title="Find in File",

--- a/Server/src/services/tools/manage_script.py
+++ b/Server/src/services/tools/manage_script.py
@@ -65,6 +65,7 @@ def _split_uri(uri: str) -> tuple[str, str]:
 
 
 @mcp_for_unity_tool(
+    unity_target="manage_script",
     description=(
         """Apply small text edits to a C# script identified by URI.
     IMPORTANT: This tool replaces EXACT character positions. Always verify content at target lines/columns BEFORE editing!
@@ -375,6 +376,7 @@ async def apply_text_edits(
 
 
 @mcp_for_unity_tool(
+    unity_target="manage_script",
     description="Create a new C# script at the given project path.",
     annotations=ToolAnnotations(
         title="Create Script",
@@ -426,6 +428,7 @@ async def create_script(
 
 
 @mcp_for_unity_tool(
+    unity_target="manage_script",
     description="Delete a C# script by URI or Assets-relative path.",
     annotations=ToolAnnotations(
         title="Delete Script",
@@ -454,6 +457,7 @@ async def delete_script(
 
 
 @mcp_for_unity_tool(
+    unity_target="manage_script",
     description="Validate a C# script and return diagnostics.",
     annotations=ToolAnnotations(
         title="Validate Script",
@@ -575,6 +579,7 @@ async def manage_script(
 
 
 @mcp_for_unity_tool(
+    unity_target=None,
     description=(
         """Get manage_script capabilities (supported ops, limits, and guards).
     Returns:
@@ -613,6 +618,7 @@ async def manage_script_capabilities(ctx: Context) -> dict[str, Any]:
 
 
 @mcp_for_unity_tool(
+    unity_target="manage_script",
     description="Get SHA256 and basic metadata for a Unity C# script without returning file contents. Requires uri (script path under Assets/ or mcpforunity://path/Assets/... or file://...).",
     annotations=ToolAnnotations(
         title="Get SHA",

--- a/Server/src/services/tools/script_apply_edits.py
+++ b/Server/src/services/tools/script_apply_edits.py
@@ -312,6 +312,7 @@ def _err(code: str, message: str, *, expected: dict[str, Any] | None = None, rew
 
 @mcp_for_unity_tool(
     name="script_apply_edits",
+    unity_target="manage_script",
     description=(
         """Structured C# edits (methods/classes) with safer boundaries - prefer this over raw text.
     Best practices:

--- a/Server/src/services/tools/set_active_instance.py
+++ b/Server/src/services/tools/set_active_instance.py
@@ -12,6 +12,7 @@ from core.config import config
 
 
 @mcp_for_unity_tool(
+    unity_target=None,
     description="Set the active Unity instance for this client/session. Accepts Name@hash or hash.",
     annotations=ToolAnnotations(
         title="Set Active Instance",

--- a/Server/src/transport/plugin_hub.py
+++ b/Server/src/transport/plugin_hub.py
@@ -318,12 +318,16 @@ class PluginHub(WebSocketEndpoint):
         )
 
     @classmethod
-    async def get_tools_for_project(cls, project_hash: str) -> list[Any]:
-        """Retrieve tools registered for a active project hash."""
+    async def get_tools_for_project(
+        cls,
+        project_hash: str,
+        user_id: str | None = None,
+    ) -> list[Any]:
+        """Retrieve tools registered for an active project hash."""
         if cls._registry is None:
             return []
 
-        session_id = await cls._registry.get_session_id_by_hash(project_hash)
+        session_id = await cls._registry.get_session_id_by_hash(project_hash, user_id=user_id)
         if not session_id:
             return []
 
@@ -334,12 +338,17 @@ class PluginHub(WebSocketEndpoint):
         return list(session.tools.values())
 
     @classmethod
-    async def get_tool_definition(cls, project_hash: str, tool_name: str) -> Any | None:
+    async def get_tool_definition(
+        cls,
+        project_hash: str,
+        tool_name: str,
+        user_id: str | None = None,
+    ) -> Any | None:
         """Retrieve a specific tool definition for an active project hash."""
         if cls._registry is None:
             return None
 
-        session_id = await cls._registry.get_session_id_by_hash(project_hash)
+        session_id = await cls._registry.get_session_id_by_hash(project_hash, user_id=user_id)
         if not session_id:
             return None
 

--- a/Server/tests/test_custom_tool_service_user_scope.py
+++ b/Server/tests/test_custom_tool_service_user_scope.py
@@ -1,0 +1,106 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from core.config import config
+from models.models import MCPResponse, ToolDefinitionModel
+from services.custom_tool_service import CustomToolService
+from services.resources.custom_tools import get_custom_tools
+from services.tools.execute_custom_tool import execute_custom_tool
+
+
+class _DummyMcp:
+    def custom_route(self, _path, methods=None):  # noqa: ARG002
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+@pytest.mark.asyncio
+async def test_list_registered_tools_threads_user_id_to_plugin_hub():
+    service = CustomToolService(_DummyMcp())
+
+    with patch("services.custom_tool_service.PluginHub.get_tools_for_project", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = []
+        await service.list_registered_tools("project-hash", user_id="user-1")
+
+    mock_get.assert_awaited_once_with("project-hash", user_id="user-1")
+
+
+@pytest.mark.asyncio
+async def test_get_tool_definition_threads_user_id_to_plugin_hub():
+    service = CustomToolService(_DummyMcp())
+
+    with patch("services.custom_tool_service.PluginHub.get_tool_definition", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = None
+        await service.get_tool_definition("project-hash", "my_tool", user_id="user-1")
+
+    mock_get.assert_awaited_once_with("project-hash", "my_tool", user_id="user-1")
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_threads_user_id_to_definition_lookup_and_transport():
+    service = CustomToolService(_DummyMcp())
+    definition = ToolDefinitionModel(name="my_tool", description="My tool", requires_polling=False)
+
+    with patch.object(service, "get_tool_definition", new_callable=AsyncMock) as mock_get_definition:
+        with patch("services.custom_tool_service.send_with_unity_instance", new_callable=AsyncMock) as mock_send:
+            mock_get_definition.return_value = definition
+            mock_send.return_value = {"success": True, "message": "ok"}
+
+            await service.execute_tool(
+                "project-hash",
+                "my_tool",
+                "Project@project-hash",
+                {"x": 1},
+                user_id="user-1",
+            )
+
+    mock_get_definition.assert_awaited_once_with("project-hash", "my_tool", user_id="user-1")
+    mock_send.assert_awaited_once()
+    assert mock_send.call_args.kwargs["user_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_execute_custom_tool_threads_user_id_from_context(monkeypatch):
+    monkeypatch.setattr(config, "http_remote_hosted", True)
+
+    ctx = Mock()
+    state = {"unity_instance": "Project@project-hash", "user_id": "user-1"}
+    ctx.get_state = Mock(side_effect=lambda key: state.get(key))
+
+    service = Mock()
+    service.execute_tool = AsyncMock(return_value=MCPResponse(success=True, message="ok"))
+
+    with patch("services.tools.execute_custom_tool.resolve_project_id_for_unity_instance", return_value="project-hash"):
+        with patch("services.tools.execute_custom_tool.CustomToolService.get_instance", return_value=service):
+            await execute_custom_tool(ctx, "my_tool", {})
+
+    service.execute_tool.assert_awaited_once_with(
+        "project-hash",
+        "my_tool",
+        "Project@project-hash",
+        {},
+        user_id="user-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_custom_tools_resource_threads_user_id_from_context(monkeypatch):
+    monkeypatch.setattr(config, "http_remote_hosted", True)
+
+    ctx = Mock()
+    state = {"unity_instance": "Project@project-hash", "user_id": "user-1"}
+    ctx.get_state = Mock(side_effect=lambda key: state.get(key))
+
+    service = Mock()
+    service.list_registered_tools = AsyncMock(
+        return_value=[ToolDefinitionModel(name="my_tool", description="My tool")]
+    )
+
+    with patch("services.resources.custom_tools.resolve_project_id_for_unity_instance", return_value="project-hash"):
+        with patch("services.resources.custom_tools.CustomToolService.get_instance", return_value=service):
+            await get_custom_tools(ctx)
+
+    service.list_registered_tools.assert_awaited_once_with("project-hash", user_id="user-1")

--- a/Server/tests/test_tool_registry_metadata.py
+++ b/Server/tests/test_tool_registry_metadata.py
@@ -1,0 +1,64 @@
+import pytest
+
+from services.registry import get_registered_tools, mcp_for_unity_tool
+import services.registry.tool_registry as tool_registry_module
+
+
+@pytest.fixture(autouse=True)
+def restore_tool_registry_state():
+    original_registry = list(tool_registry_module._tool_registry)
+    try:
+        yield
+    finally:
+        tool_registry_module._tool_registry[:] = original_registry
+
+
+def test_tool_registry_defaults_unity_target_to_tool_name():
+    @mcp_for_unity_tool()
+    def _default_target_tool():
+        return None
+
+    registered_tools = get_registered_tools()
+    tool_info = next(item for item in registered_tools if item["name"] == "_default_target_tool")
+    assert tool_info["unity_target"] == "_default_target_tool"
+
+
+def test_tool_registry_supports_server_only_and_alias_targets():
+    @mcp_for_unity_tool(unity_target=None)
+    def _server_only_tool():
+        return None
+
+    @mcp_for_unity_tool(unity_target="manage_script")
+    def _manage_script_alias_tool():
+        return None
+
+    registered_tools = get_registered_tools()
+    server_only = next(item for item in registered_tools if item["name"] == "_server_only_tool")
+    alias_tool = next(item for item in registered_tools if item["name"] == "_manage_script_alias_tool")
+
+    assert server_only["unity_target"] is None
+    assert alias_tool["unity_target"] == "manage_script"
+
+
+def test_tool_registry_does_not_leak_unity_target_into_tool_kwargs():
+    @mcp_for_unity_tool(unity_target="manage_script", annotations={"title": "x"})
+    def _non_leaking_target_tool():
+        return None
+
+    registered_tools = get_registered_tools()
+    tool_info = next(item for item in registered_tools if item["name"] == "_non_leaking_target_tool")
+    assert tool_info["unity_target"] == "manage_script"
+    assert "unity_target" not in tool_info["kwargs"]
+    assert tool_info["kwargs"]["annotations"] == {"title": "x"}
+
+
+def test_tool_registry_rejects_invalid_unity_target_values():
+    with pytest.raises(ValueError, match="Invalid unity_target"):
+        @mcp_for_unity_tool(unity_target="")
+        def _invalid_empty_target_tool():
+            return None
+
+    with pytest.raises(ValueError, match="Invalid unity_target"):
+        @mcp_for_unity_tool(unity_target=123)  # type: ignore[arg-type]
+        def _invalid_non_string_target_tool():
+            return None

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs
@@ -1,0 +1,155 @@
+using System.Linq;
+using NUnit.Framework;
+using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Services;
+using UnityEditor;
+
+namespace MCPForUnity.Editor.Tests.EditMode.Services
+{
+    [TestFixture]
+    public class ToolDiscoveryServiceTests
+    {
+        private const string TestToolName = "test_tool_for_testing";
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Clean up any test preferences
+            string testKey = EditorPrefKeys.ToolEnabledPrefix + TestToolName;
+            if (EditorPrefs.HasKey(testKey))
+            {
+                EditorPrefs.DeleteKey(testKey);
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Clean up test preferences after each test
+            string testKey = EditorPrefKeys.ToolEnabledPrefix + TestToolName;
+            if (EditorPrefs.HasKey(testKey))
+            {
+                EditorPrefs.DeleteKey(testKey);
+            }
+        }
+
+        [Test]
+        public void SetToolEnabled_WritesToEditorPrefs()
+        {
+            // Arrange
+            var service = new ToolDiscoveryService();
+
+            // Act
+            service.SetToolEnabled(TestToolName, false);
+
+            // Assert
+            string key = EditorPrefKeys.ToolEnabledPrefix + TestToolName;
+            Assert.IsTrue(EditorPrefs.HasKey(key), "Preference key should exist after SetToolEnabled");
+            Assert.IsFalse(EditorPrefs.GetBool(key, true), "Preference should be set to false");
+        }
+
+        [Test]
+        public void IsToolEnabled_ReturnsFalse_WhenToolDoesNotExist()
+        {
+            // Arrange - Ensure no preference exists
+            string key = EditorPrefKeys.ToolEnabledPrefix + TestToolName;
+            if (EditorPrefs.HasKey(key))
+            {
+                EditorPrefs.DeleteKey(key);
+            }
+
+            var service = new ToolDiscoveryService();
+
+            // Act - For a non-existent tool, IsToolEnabled should return false
+            // (since metadata.AutoRegister defaults to false for non-existent tools)
+            bool result = service.IsToolEnabled(TestToolName);
+
+            // Assert - Non-existent tools return false (no metadata found)
+            Assert.IsFalse(result, "Non-existent tool should return false");
+        }
+
+        [Test]
+        public void IsToolEnabled_ReturnsStoredValue_WhenPreferenceExists()
+        {
+            // Arrange
+            string key = EditorPrefKeys.ToolEnabledPrefix + TestToolName;
+            EditorPrefs.SetBool(key, false);  // Store false value
+            var service = new ToolDiscoveryService();
+
+            // Act
+            bool result = service.IsToolEnabled(TestToolName);
+
+            // Assert
+            Assert.IsFalse(result, "Should return the stored preference value (false)");
+        }
+
+        [Test]
+        public void IsToolEnabled_ReturnsTrue_WhenPreferenceSetToTrue()
+        {
+            // Arrange
+            string key = EditorPrefKeys.ToolEnabledPrefix + TestToolName;
+            EditorPrefs.SetBool(key, true);
+            var service = new ToolDiscoveryService();
+
+            // Act
+            bool result = service.IsToolEnabled(TestToolName);
+
+            // Assert
+            Assert.IsTrue(result, "Should return the stored preference value (true)");
+        }
+
+        [Test]
+        public void ToolToggle_PersistsAcrossServiceInstances()
+        {
+            // Arrange
+            var service1 = new ToolDiscoveryService();
+            service1.SetToolEnabled(TestToolName, false);
+
+            // Act - Create a new service instance
+            var service2 = new ToolDiscoveryService();
+            bool result = service2.IsToolEnabled(TestToolName);
+
+            // Assert - The disabled state should persist
+            Assert.IsFalse(result, "Tool state should persist across service instances");
+        }
+
+        [Test]
+        public void DiscoverAllTools_DoesNotOverrideStoredFalse_ForBuiltInAutoRegisterFalseTool()
+        {
+            // Arrange
+            var service = new ToolDiscoveryService();
+            var builtInTool = service.DiscoverAllTools()
+                .FirstOrDefault(tool => tool.IsBuiltIn && !tool.AutoRegister);
+
+            Assert.IsNotNull(builtInTool, "Expected at least one built-in tool with AutoRegister=false.");
+
+            string key = EditorPrefKeys.ToolEnabledPrefix + builtInTool.Name;
+            bool hadOriginalKey = EditorPrefs.HasKey(key);
+            bool originalValue = hadOriginalKey && EditorPrefs.GetBool(key, true);
+
+            try
+            {
+                EditorPrefs.SetBool(key, false);
+                service.InvalidateCache();
+
+                // Act
+                service.DiscoverAllTools();
+                bool enabled = service.IsToolEnabled(builtInTool.Name);
+
+                // Assert
+                Assert.IsFalse(enabled, $"Built-in tool '{builtInTool.Name}' should remain disabled when preference is false.");
+            }
+            finally
+            {
+                if (hadOriginalKey)
+                {
+                    EditorPrefs.SetBool(key, originalValue);
+                }
+                else
+                {
+                    EditorPrefs.DeleteKey(key);
+                }
+            }
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f3b1c9b5dc24a52ae7053af3e2135ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/Editor.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea478f98f983e4c4daafd9a07cf03e3b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Rebased version of #723 by @whatevertogo to resolve merge conflicts after #688 landed on beta.

Original PR: #723 | Original author: @whatevertogo

Fixes #709 - Disabled tools now persist across Unity Editor restarts and are correctly filtered from client tool listings.

Conflict resolution: kept both ForceStop() from #688 and public GetClient() from #723 in TransportManager.cs.

Bug fix included: added missing using UnityEditor.UIElements for IntegerField (pushed directly to author branch).

## Summary by Sourcery

Align Unity tool enablement between client and server, ensuring disabled tools persist across sessions and are correctly filtered from tool listings in HTTP/hosted modes.

Bug Fixes:
- Ensure Unity Editor tool enabled/disabled state is persisted via EditorPrefs and respected across ToolDiscoveryService instances.
- Fix missing UnityEditor.UIElements import to support IntegerField usage in the tools UI.

Enhancements:
- Add user-scoped tool registration and lookup so remote-hosted users with shared project hashes see only their own registered custom tools.
- Introduce registry-driven tool visibility metadata and middleware filtering so Unity-managed tools and their aliases are hidden when disabled while keeping server-only tools visible.
- Add support for declaring server-only and alias Unity tools via mcp_for_unity_tool metadata without leaking internal flags into MCP annotations.
- Expose a client-facing transport method to trigger tool re-registration over WebSocket when tool toggles change, while leaving stdio behavior unchanged.

Tests:
- Add extensive middleware tests covering tool filtering behavior, alias handling, failure and stale-state fallbacks, and multi-session union of enabled tools.
- Add tests verifying user-scoped behavior of PluginHub and CustomToolService for tool listing, lookup, and execution APIs.
- Add tests for tool registry metadata behavior, including unity_target defaults, server-only and alias handling, and validation of invalid values.
- Add Unity edit-mode tests for ToolDiscoveryService to ensure EditorPrefs-backed enablement and persistence semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic tool reregistration capability, allowing tools to be updated after enabling/disabling without restart.
  * Implemented user-scoped tool visibility in multi-user hosting scenarios.
  * Added HTTP-based tool filtering for better project-aware tool management.

* **Bug Fixes**
  * Simplified tool preference initialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->