### PR TITLE
fix(test): align clip name with asset filename in ClipGetInfo test

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageAnimationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageAnimationTests.cs
@@ -254,8 +254,9 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void ClipGetInfo_ReturnsClipData()
         {
-            string clipPath = $"{TempRoot}/InfoClip_{Guid.NewGuid():N}.anim";
-            var clip = new AnimationClip { name = "InfoClip", frameRate = 30f };
+            string clipName = $"InfoClip_{Guid.NewGuid():N}";
+            string clipPath = $"{TempRoot}/{clipName}.anim";
+            var clip = new AnimationClip { name = clipName, frameRate = 30f };
             var settings = AnimationUtility.GetAnimationClipSettings(clip);
             settings.loopTime = true;
             settings.stopTime = 1.5f;
@@ -273,7 +274,7 @@ namespace MCPForUnityTests.Editor.Tools
 
             var data = result["data"] as JObject;
             Assert.IsNotNull(data);
-            Assert.AreEqual("InfoClip", data["name"].ToString());
+            Assert.AreEqual(clipName, data["name"].ToString());
             Assert.AreEqual(30f, data.Value<float>("frameRate"), 0.01f);
             Assert.IsTrue(data.Value<bool>("isLooping"));
         }


### PR DESCRIPTION
Unity renames AnimationClip objects to match the asset filename on import. The test was setting name="InfoClip" but saving to a path with a GUID suffix, causing the assertion to fail.

Pre-existing issue from #696 (animation feature PR).

## Summary by Sourcery

Bug Fixes:
- Fix ClipGetInfo_ReturnsClipData test by matching the AnimationClip name to the generated asset filename before asserting the returned name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated animation test to use dynamically generated clip names instead of hard-coded values for improved test flexibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->