### PR TITLE
fix: enforce tool toggle checks in batch_execute

### DIFF
--- a/MCPForUnity/Editor/Tools/BatchExecute.cs
+++ b/MCPForUnity/Editor/Tools/BatchExecute.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Services;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 
@@ -101,6 +102,22 @@ namespace MCPForUnity.Editor.Tools
                     {
                         break;
                     }
+                    continue;
+                }
+
+                // Block disabled tools (mirrors TransportCommandDispatcher check)
+                var toolMeta = MCPServiceLocator.ToolDiscovery.GetToolMetadata(toolName);
+                if (toolMeta != null && !MCPServiceLocator.ToolDiscovery.IsToolEnabled(toolName))
+                {
+                    invocationFailureCount++;
+                    anyCommandFailed = true;
+                    commandResults.Add(new
+                    {
+                        tool = toolName,
+                        callSucceeded = false,
+                        result = new ErrorResponse($"Tool '{toolName}' is disabled in the Unity Editor.")
+                    });
+                    if (failFast) break;
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- `batch_execute` was bypassing disabled-tool checks by calling `CommandRegistry.InvokeCommandAsync` directly
- Adds the same `IsToolEnabled` guard that `TransportCommandDispatcher` already uses
- Disabled tools now return `"Tool 'X' is disabled in the Unity Editor."` errors in batch results

## Test plan
- [x] 621 EditMode tests pass (577 passed, 44 skipped)
- [x] Manually verified: disabled tools blocked in batch, enabled tools still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent batch tool execution from bypassing existing disabled-tool checks by validating tool enablement before invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent execution of commands when tools are disabled in the Unity Editor. Disabled tools now properly block command execution, recording the attempt as a failed invocation with detailed error information. Failure counters are automatically updated, ensuring consistent and accurate tracking of command execution results throughout your workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->