### PR TITLE
fix: handle bare Assets/ path in manage_shader

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageShader.cs
+++ b/MCPForUnity/Editor/Tools/ManageShader.cs
@@ -67,7 +67,11 @@ namespace MCPForUnity.Editor.Tools
             if (!string.IsNullOrEmpty(relativeDir))
             {
                 relativeDir = AssetPathUtility.NormalizeSeparators(relativeDir).Trim('/');
-                if (relativeDir.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(relativeDir, "Assets", StringComparison.OrdinalIgnoreCase))
+                {
+                    relativeDir = "";
+                }
+                else if (relativeDir.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
                 {
                     relativeDir = relativeDir.Substring("Assets/".Length).TrimStart('/');
                 }


### PR DESCRIPTION
## Summary
- manage_shader was creating files at Assets/Assets/ when path: Assets/ was passed
- Root cause: Trim(/) stripped the trailing slash before StartsWith(Assets/) could match
- Fix: also check for bare Assets (case-insensitive) after trimming

## Test plan
- [x] 621 EditMode tests pass
- [x] path: Assets/ now correctly defaults to Assets/Shaders/
- [x] path: Assets/Shaders still works as before

## Summary by Sourcery

Bug Fixes:
- Fix handling of bare `Assets` or `Assets/` paths so shaders are no longer created under an unintended `Assets/Assets/` subdirectory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader path handling to correctly normalize root directory references and ensure proper fallback to default directories for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->