### PR TITLE
fix: catch ArgumentException from Path.IsPathRooted in IsLocalServerPath

### DIFF
--- a/MCPForUnity/Editor/Helpers/AssetPathUtility.cs
+++ b/MCPForUnity/Editor/Helpers/AssetPathUtility.cs
@@ -448,8 +448,18 @@ namespace MCPForUnity.Editor.Helpers
                 return false;
 
             // Check for file:// protocol or absolute local path
-            return fromUrl.StartsWith("file://", StringComparison.OrdinalIgnoreCase) ||
-                   System.IO.Path.IsPathRooted(fromUrl);
+            if (fromUrl.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            try
+            {
+                return System.IO.Path.IsPathRooted(fromUrl);
+            }
+            catch (System.ArgumentException)
+            {
+                // fromUrl contains characters illegal in paths (e.g. a remote URL)
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- `Path.IsPathRooted()` throws `ArgumentException` when the package source URL contains characters illegal in file paths (e.g. remote PyPI URLs with `://`)
- This crashes `IsLocalServerPath()` → `ShouldForceUvxRefresh()` → `TryBuildCommand()`, preventing the MCP window from initializing
- Wrapped the call in a try/catch that returns `false` for non-path strings, since remote URLs are not local paths

## Test plan
- [ ] Open MCP for Unity window with default (remote) package source — no exception
- [ ] Verify local path overrides (absolute path and `file://` prefix) still correctly detected
- [ ] Verify dev mode force refresh still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Guard IsLocalServerPath against ArgumentException thrown by Path.IsPathRooted when the package source URL contains characters illegal in file paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when processing file paths with invalid characters, preventing potential crashes and ensuring more stable path detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->