### PR TITLE
Add per-call unity_instance routing via tool arguments

### DIFF
--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -268,7 +268,8 @@ This server provides tools to interact with the Unity Game Engine Editor.
 
 Targeting Unity instances:
 - Use the resource mcpforunity://instances to list active Unity sessions (Name@hash).
-- When multiple instances are connected, call set_active_instance with the exact Name@hash before using tools/resources. The server will error if multiple are connected and no active instance is set.
+- When multiple instances are connected, call set_active_instance with the exact Name@hash before using tools/resources to pin routing for the whole session. The server will error if multiple are connected and no active instance is set.
+- Alternatively, pass unity_instance as a parameter on any individual tool call to route just that call (e.g. unity_instance="MyGame@abc123", unity_instance="abc" for a hash prefix, or unity_instance="6401" for a port number in stdio mode). This does not change the session default.
 
 Important Workflows:
 

--- a/Server/src/services/tools/batch_execute.py
+++ b/Server/src/services/tools/batch_execute.py
@@ -116,6 +116,13 @@ async def batch_execute(
             raise ValueError(
                 f"Command '{tool_name}' must specify parameters as an object/dict")
 
+        if "unity_instance" in params:
+            raise ValueError(
+                f"Command '{tool_name}' at index {index} contains 'unity_instance'. "
+                "Per-command instance routing is not supported inside batch_execute. "
+                "Set unity_instance on the outer batch_execute call to route the entire batch."
+            )
+
         normalized_commands.append({
             "tool": tool_name,
             "params": params,

--- a/Server/tests/integration/test_inline_unity_instance.py
+++ b/Server/tests/integration/test_inline_unity_instance.py
@@ -1,0 +1,410 @@
+"""
+Tests for per-call unity_instance routing via middleware argument interception.
+
+When a tool call includes unity_instance in its arguments, the middleware:
+  1. Pops the key before Pydantic validation sees it
+  2. Resolves it to a validated instance identifier
+  3. Sets it in request-scoped state for that call only (does NOT persist to session)
+"""
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from .test_helpers import DummyContext
+from core.config import config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class DummyMiddlewareContext:
+    """Minimal MiddlewareContext stand-in with a mutable arguments dict."""
+
+    def __init__(self, ctx, arguments: dict | None = None):
+        self.fastmcp_context = ctx
+        self.message = SimpleNamespace(arguments=arguments if arguments is not None else {})
+
+
+def _make_middleware(monkeypatch, *, transport="stdio", plugin_hub_configured=False, sessions=None, pool_instances=None):
+    """
+    Build a UnityInstanceMiddleware with patched transport dependencies.
+
+    sessions: dict of session_id -> SimpleNamespace(project=..., hash=...)
+    pool_instances: list of SimpleNamespace(id=..., hash=...)
+    """
+    plugin_hub_mod = types.ModuleType("transport.plugin_hub")
+
+    _sessions = sessions or {}
+    _configured = plugin_hub_configured
+
+    class FakePluginHub:
+        @classmethod
+        def is_configured(cls):
+            return _configured
+
+        @classmethod
+        async def get_sessions(cls, user_id=None):
+            return SimpleNamespace(sessions=_sessions)
+
+        @classmethod
+        async def _resolve_session_id(cls, instance, user_id=None):
+            return None
+
+    plugin_hub_mod.PluginHub = FakePluginHub
+    monkeypatch.setitem(sys.modules, "transport.plugin_hub", plugin_hub_mod)
+    monkeypatch.delitem(sys.modules, "transport.unity_instance_middleware", raising=False)
+
+    from transport.unity_instance_middleware import UnityInstanceMiddleware
+
+    middleware = UnityInstanceMiddleware()
+    monkeypatch.setattr(config, "transport_mode", transport)
+    monkeypatch.setattr(config, "http_remote_hosted", False)
+
+    if pool_instances is not None:
+        async def fake_discover(ctx):
+            return pool_instances
+        monkeypatch.setattr(middleware, "_discover_instances", fake_discover)
+
+    return middleware
+
+
+# ---------------------------------------------------------------------------
+# Pop behaviour
+# ---------------------------------------------------------------------------
+
+def test_unity_instance_is_popped_from_arguments(monkeypatch):
+    """unity_instance key must be removed from arguments before the tool function sees them."""
+    instances = [SimpleNamespace(id="Proj@abc123", hash="abc123")]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    args = {"action": "get_active", "unity_instance": "abc123"}
+    mw_ctx = DummyMiddlewareContext(ctx, arguments=args)
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert "unity_instance" not in args
+    assert "action" in args  # other keys untouched
+
+
+def test_arguments_without_unity_instance_untouched(monkeypatch):
+    """When unity_instance is absent, arguments dict is left completely untouched."""
+    mw = _make_middleware(monkeypatch, pool_instances=[SimpleNamespace(id="Proj@abc123", hash="abc123")])
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    # Seed a persisted instance so auto-select isn't needed
+    mw.set_active_instance(ctx, "Proj@abc123")
+
+    args = {"action": "get_active", "name": "Test"}
+    mw_ctx = DummyMiddlewareContext(ctx, arguments=args)
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert args == {"action": "get_active", "name": "Test"}
+
+
+# ---------------------------------------------------------------------------
+# Per-call routing (no persistence)
+# ---------------------------------------------------------------------------
+
+def test_inline_routes_to_specified_instance(monkeypatch):
+    """Per-call unity_instance sets request state to the resolved instance."""
+    instances = [SimpleNamespace(id="Proj@abc123", hash="abc123")]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "abc123"})
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+def test_inline_does_not_persist_to_session(monkeypatch):
+    """Per-call unity_instance must not change the session-persisted instance."""
+    instances = [
+        SimpleNamespace(id="ProjA@aaa111", hash="aaa111"),
+        SimpleNamespace(id="ProjB@bbb222", hash="bbb222"),
+    ]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw.set_active_instance(ctx, "ProjA@aaa111")
+
+    # Call 1: inline override to ProjB
+    mw_ctx1 = DummyMiddlewareContext(ctx, arguments={"unity_instance": "bbb222"})
+    asyncio.run(mw._inject_unity_instance(mw_ctx1))
+    assert ctx.get_state("unity_instance") == "ProjB@bbb222"
+
+    # Call 2: no inline — must revert to session-persisted ProjA
+    mw_ctx2 = DummyMiddlewareContext(ctx, arguments={})
+    asyncio.run(mw._inject_unity_instance(mw_ctx2))
+    assert ctx.get_state("unity_instance") == "ProjA@aaa111"
+
+
+def test_inline_overrides_session_persisted_instance(monkeypatch):
+    """Inline unity_instance takes precedence over session-persisted instance."""
+    instances = [
+        SimpleNamespace(id="ProjA@aaa111", hash="aaa111"),
+        SimpleNamespace(id="ProjB@bbb222", hash="bbb222"),
+    ]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw.set_active_instance(ctx, "ProjA@aaa111")
+
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "ProjB@bbb222"})
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert ctx.get_state("unity_instance") == "ProjB@bbb222"
+    # Session still pinned to ProjA
+    assert mw.get_active_instance(ctx) == "ProjA@aaa111"
+
+
+# ---------------------------------------------------------------------------
+# Port number resolution (stdio)
+# ---------------------------------------------------------------------------
+
+def test_port_number_resolves_to_name_hash_stdio(monkeypatch):
+    """Bare port number resolves to the matching Name@hash in stdio mode."""
+    instances = [
+        SimpleNamespace(id="Proj@abc123", hash="abc123", port=6401),
+        SimpleNamespace(id="Other@def456", hash="def456", port=6402),
+    ]
+    mw = _make_middleware(monkeypatch, transport="stdio", pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "6401"})
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+def test_port_number_not_found_raises(monkeypatch):
+    """Port number with no matching instance raises ValueError."""
+    instances = [SimpleNamespace(id="Proj@abc123", hash="abc123", port=6401)]
+    mw = _make_middleware(monkeypatch, transport="stdio", pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "9999"})
+
+    with pytest.raises(ValueError, match="No Unity instance found on port 9999"):
+        asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+
+def test_port_number_errors_in_http_mode(monkeypatch):
+    """Bare port number raises ValueError in HTTP transport mode."""
+    mw = _make_middleware(monkeypatch, transport="http")
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "6401"})
+
+    with pytest.raises(ValueError, match="not supported in HTTP transport mode"):
+        asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+
+# ---------------------------------------------------------------------------
+# Name@hash and hash prefix resolution
+# ---------------------------------------------------------------------------
+
+def test_name_at_hash_resolves_exactly(monkeypatch):
+    """Full Name@hash resolves directly without discovery."""
+    instances = [SimpleNamespace(id="Proj@abc123", hash="abc123")]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "Proj@abc123"})
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+def test_unknown_name_at_hash_raises(monkeypatch):
+    """Unknown Name@hash raises ValueError."""
+    instances = [SimpleNamespace(id="Proj@abc123", hash="abc123")]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "Ghost@deadbeef"})
+
+    with pytest.raises(ValueError, match="not found"):
+        asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+
+def test_hash_prefix_resolves_unique(monkeypatch):
+    """Unique hash prefix resolves to the full Name@hash."""
+    instances = [SimpleNamespace(id="Proj@abc123", hash="abc123")]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "abc"})
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+def test_ambiguous_hash_prefix_raises(monkeypatch):
+    """Ambiguous hash prefix raises ValueError."""
+    instances = [
+        SimpleNamespace(id="ProjA@abc111", hash="abc111"),
+        SimpleNamespace(id="ProjB@abc222", hash="abc222"),
+    ]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "abc"})
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+
+def test_no_match_raises(monkeypatch):
+    """Hash prefix matching nothing raises ValueError."""
+    instances = [SimpleNamespace(id="Proj@abc123", hash="abc123")]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "xyz"})
+
+    with pytest.raises(ValueError, match="No running Unity instance"):
+        asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_none_unity_instance_falls_through_to_session(monkeypatch):
+    """None value for unity_instance falls through to session-persisted instance."""
+    mw = _make_middleware(monkeypatch)
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw.set_active_instance(ctx, "Proj@abc123")
+
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": None, "action": "x"})
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+def test_empty_string_unity_instance_falls_through_to_session(monkeypatch):
+    """Empty string unity_instance falls through to session-persisted instance."""
+    mw = _make_middleware(monkeypatch)
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw.set_active_instance(ctx, "Proj@abc123")
+
+    mw_ctx = DummyMiddlewareContext(ctx, arguments={"unity_instance": "  "})
+
+    asyncio.run(mw._inject_unity_instance(mw_ctx))
+
+    assert ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+def test_resource_read_unaffected(monkeypatch):
+    """on_read_resource with no .arguments attribute routes via session state normally."""
+    mw = _make_middleware(monkeypatch)
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    mw.set_active_instance(ctx, "Proj@abc123")
+
+    # ReadResourceRequestParams has .uri not .arguments
+    resource_ctx = SimpleNamespace(
+        fastmcp_context=ctx,
+        message=SimpleNamespace(uri="mcpforunity://scene/active"),
+    )
+
+    asyncio.run(mw._inject_unity_instance(resource_ctx))
+
+    assert ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+# ---------------------------------------------------------------------------
+# set_active_instance tool: port number support
+# ---------------------------------------------------------------------------
+
+def test_set_active_instance_port_stdio(monkeypatch):
+    """set_active_instance accepts a port number in stdio mode and resolves to Name@hash."""
+    monkeypatch.setattr(config, "transport_mode", "stdio")
+    monkeypatch.setattr(config, "http_remote_hosted", False)
+
+    from transport.unity_instance_middleware import UnityInstanceMiddleware, set_unity_instance_middleware
+    mw = UnityInstanceMiddleware()
+    set_unity_instance_middleware(mw)
+
+    pool_instance = SimpleNamespace(id="Proj@abc123", hash="abc123", port=6401)
+
+    class FakePool:
+        def discover_all_instances(self, force_refresh=False):
+            return [pool_instance]
+
+    import services.tools.set_active_instance as sat
+    monkeypatch.setattr(sat, "get_unity_connection_pool", lambda: FakePool())
+
+    from services.tools.set_active_instance import set_active_instance
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    result = asyncio.run(set_active_instance(ctx, instance="6401"))
+
+    assert result["success"] is True
+    assert result["data"]["instance"] == "Proj@abc123"
+    assert mw.get_active_instance(ctx) == "Proj@abc123"
+
+
+def test_set_active_instance_port_http_errors(monkeypatch):
+    """set_active_instance rejects port numbers in HTTP mode."""
+    monkeypatch.setattr(config, "transport_mode", "http")
+    monkeypatch.setattr(config, "http_remote_hosted", False)
+
+    from services.tools.set_active_instance import set_active_instance
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    result = asyncio.run(set_active_instance(ctx, instance="6401"))
+
+    assert result["success"] is False
+    assert "not supported in HTTP transport mode" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# batch_execute rejects inner unity_instance
+# ---------------------------------------------------------------------------
+
+def test_batch_execute_rejects_inner_unity_instance():
+    """batch_execute raises ValueError when an inner command contains unity_instance."""
+    from services.tools.batch_execute import batch_execute
+
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+    ctx._state["unity_instance"] = "Proj@abc123"
+
+    commands = [
+        {"tool": "manage_scene", "params": {"action": "get_active", "unity_instance": "6402"}},
+    ]
+
+    with pytest.raises(ValueError, match="Per-command instance routing is not supported inside batch_execute"):
+        asyncio.run(batch_execute(ctx, commands=commands))


### PR DESCRIPTION
## Summary

Adds per-call `unity_instance` routing so AI clients can target specific Unity instances on any tool call without requiring `set_active_instance` first. Supersedes the CLI flags approach from #697.

- **Middleware intercepts `unity_instance`** from tool call arguments, resolves it (Name@hash, hash prefix, or port number in stdio mode), and sets request-scoped state — without persisting to the session
- **`set_active_instance` extended** to also accept port numbers (stdio mode) for consistency
- **Server instructions updated** to document both routing approaches (session pinning vs per-call)
- **18 integration tests** covering pop behavior, per-call routing, non-persistence, port/hash/Name@hash resolution, edge cases

### How it works

Any tool call can include `unity_instance` as an extra parameter:

```python
# Route by port (stdio only)
manage_scene(action="get_active", unity_instance="6401")

# Route by hash prefix
manage_scene(action="get_active", unity_instance="abc")

# Route by exact Name@hash
manage_scene(action="get_active", unity_instance="MyGame@abc123")
```

The middleware pops the key before Pydantic validation, resolves it to a validated instance ID, and sets it in request-scoped state for that call only. Subsequent calls without `unity_instance` revert to the session-persisted instance (or auto-select).

### Design decisions

- **Per-call only, not persistent**: Inline `unity_instance` does NOT change the session default. This avoids confusion when alternating between instances
- **Port resolution via discovery**: Port numbers resolve to actual `Name@hash` by querying the connection pool, not synthetic IDs
- **Backward compatible**: Existing `set_active_instance` workflow unchanged; `unity_instance` parameter is purely additive

Closes #697

## Test plan

- [x] 18 new integration tests (all passing)
- [x] Full test suite: 684/684 passing
- [x] Live smoke tested with two real Unity instances on different ports
- [x] Verified per-call routing does not persist to session state
- [x] Verified port numbers, hash prefixes, and Name@hash all resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Add support for per-call Unity instance routing via a unity_instance tool argument while keeping session-pinned routing, and extend instance selection ergonomics across transports.

New Features:
- Allow specifying a unity_instance parameter on individual tool calls to route them to a specific Unity instance without changing session state.
- Support resolving unity_instance values from port numbers (stdio), exact Name@hash identifiers, or hash prefixes with clear error messages on failure.
- Extend the set_active_instance tool to accept port numbers in stdio mode alongside Name@hash and hash prefixes for selecting the active Unity instance.
- Log guidance when multiple Unity instances are discovered, pointing users to per-call routing or set_active_instance.

Documentation:
- Document both session-pinned and per-call unity_instance routing options and their usage in the server instructions.

Tests:
- Add integration test coverage for per-call unity_instance routing behavior, including argument popping, non-persistence, resolution by port/hash/Name@hash, edge cases, and set_active_instance port support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-call Unity instance routing: specify a target instance for individual calls without changing the session.
  * Port-number targeting for stdio mode (in addition to Name@hash and hash prefixes).

* **Bug Fixes / Validation**
  * Rejects per-command instance overrides inside batch calls; require outer-level instance routing.

* **Tests**
  * Added integration tests covering per-call routing, port resolution, prefix matching, and edge cases.

* **Documentation**
  * Updated guidance for managing multiple connected Unity instances and routing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->