### PR TITLE
Fix script edit retry duplication during reload

### DIFF
--- a/Server/src/services/tools/script_apply_edits.py
+++ b/Server/src/services/tools/script_apply_edits.py
@@ -970,6 +970,7 @@ async def script_apply_edits(
             unity_instance,
             "manage_script",
             params_struct,
+            retry_on_reload=False,
         )
         if isinstance(resp_struct, dict) and resp_struct.get("success"):
             pass  # Optional sentinel reload removed (deprecated)
@@ -1110,6 +1111,7 @@ async def script_apply_edits(
                     unity_instance,
                     "manage_script",
                     params_text,
+                    retry_on_reload=False,
                 )
                 if not (isinstance(resp_text, dict) and resp_text.get("success")):
                     return _with_norm(resp_text if isinstance(resp_text, dict) else {"success": False, "message": str(resp_text)}, normalized_for_echo, routing="mixed/text-first")
@@ -1135,6 +1137,7 @@ async def script_apply_edits(
                 unity_instance,
                 "manage_script",
                 params_struct,
+                retry_on_reload=False,
             )
             if isinstance(resp_struct, dict) and resp_struct.get("success"):
                 pass  # Optional sentinel reload removed (deprecated)
@@ -1267,6 +1270,7 @@ async def script_apply_edits(
                 unity_instance,
                 "manage_script",
                 params,
+                retry_on_reload=False,
             )
             if isinstance(resp, dict) and resp.get("success"):
                 pass  # Optional sentinel reload removed (deprecated)
@@ -1356,6 +1360,7 @@ async def script_apply_edits(
         unity_instance,
         "manage_script",
         params,
+        retry_on_reload=False,
     )
     if isinstance(write_resp, dict) and write_resp.get("success"):
         pass  # Optional sentinel reload removed (deprecated)


### PR DESCRIPTION
## Summary
- Script edit tools (`script_apply_edits`, `apply_text_edits`, `create_script`, `delete_script`) were retrying non-idempotent commands up to 40 times when Unity entered domain reload, causing duplicated methods/edits
- Added `retry_on_reload=False` to all script-mutating `send_with_unity_instance()` calls — the edit lands on disk before the reload triggers, so retrying is unnecessary and harmful
- Read-only operations (`validate_script`, `get_sha`, `read`) are unchanged and still retry as expected

## Test plan
- [x] All 685 Python unit tests pass
- [x] Smoke tested `create_script` against live Unity — no duplication
- [x] Smoke tested `script_apply_edits` with `insert_method` — method inserted exactly once
- [x] Smoke tested `apply_text_edits` — edit applied exactly once
- [x] Smoke tested `delete_script` — clean deletion
- [x] No compilation errors after any operation

Fixes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent non-idempotent Unity script mutation operations from being retried across domain reloads to avoid duplicate edits and creations.

Bug Fixes:
- Disable retry-on-reload for script mutation calls (create, delete, and apply edits) so they are executed exactly once even when Unity reloads the domain.
- Restrict retry-on-reload behavior in the generic manage_script entry point to read-only operations, preventing duplicate side effects during reloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined background processing by switching to asyncio-based tasks for delayed actions and fire-and-forget work, improving reliability and responsiveness.
  * Standardized retry behavior for script operations: read actions may retry during reloads, while other actions avoid automatic reload retries to reduce unnecessary retries and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->