### PR TITLE
HTTP transport: respect retry_on_reload and add stale connection detection

### DIFF
--- a/Server/src/transport/plugin_hub.py
+++ b/Server/src/transport/plugin_hub.py
@@ -10,7 +10,7 @@ import uuid
 from typing import Any, ClassVar
 
 from starlette.endpoints import WebSocketEndpoint
-from starlette.websockets import WebSocket
+from starlette.websockets import WebSocket, WebSocketState
 
 from core.config import config
 from core.constants import API_KEY_HEADER
@@ -546,11 +546,102 @@ class PluginHub(WebSocketEndpoint):
             raise RuntimeError(f"Plugin session {session_id} not connected")
         return websocket
 
+    @classmethod
+    async def _evict_connection(cls, session_id: str, reason: str) -> None:
+        """Drop a stale session from in-memory maps and registry."""
+        lock = cls._lock
+        if lock is None:
+            return
+
+        websocket: WebSocket | None = None
+        ping_task: asyncio.Task | None = None
+        pending_futures: list[asyncio.Future] = []
+        async with lock:
+            websocket = cls._connections.pop(session_id, None)
+            ping_task = cls._ping_tasks.pop(session_id, None)
+            cls._last_pong.pop(session_id, None)
+            keys_to_remove: list[object] = []
+            for key, entry in list(cls._pending.items()):
+                if entry.get("session_id") == session_id:
+                    future = entry.get("future")
+                    if future and not future.done():
+                        pending_futures.append(future)
+                    keys_to_remove.append(key)
+            for key in keys_to_remove:
+                cls._pending.pop(key, None)
+
+        if ping_task is not None and not ping_task.done():
+            ping_task.cancel()
+
+        for future in pending_futures:
+            if not future.done():
+                future.set_exception(
+                    PluginDisconnectedError(
+                        f"Unity plugin session {session_id} disconnected while awaiting command_result"
+                    )
+                )
+
+        if websocket is not None:
+            try:
+                await websocket.close(code=1001)
+            except Exception:
+                pass
+
+        if cls._registry is not None:
+            try:
+                await cls._registry.unregister(session_id)
+            except Exception:
+                logger.debug(
+                    "Failed to unregister evicted plugin session %s",
+                    session_id,
+                    exc_info=True,
+                )
+
+        logger.debug("Evicted plugin session %s (%s)", session_id, reason)
+
+    @classmethod
+    async def _ensure_live_connection(cls, session_id: str) -> bool:
+        """Best-effort pre-send liveness check for a plugin WebSocket."""
+        try:
+            websocket = await cls._get_connection(session_id)
+        except RuntimeError:
+            await cls._evict_connection(session_id, "missing_websocket")
+            return False
+
+        if (
+            websocket.client_state == WebSocketState.CONNECTED
+            and websocket.application_state == WebSocketState.CONNECTED
+        ):
+            return True
+
+        logger.debug(
+            "Detected stale plugin connection before send: session=%s app_state=%s client_state=%s",
+            session_id,
+            websocket.application_state,
+            websocket.client_state,
+        )
+        await cls._evict_connection(session_id, "stale_websocket_state")
+        return False
+
+    @staticmethod
+    def _unavailable_retry_response(reason: str = "no_unity_session") -> dict[str, Any]:
+        return MCPResponse(
+            success=False,
+            error="Unity session not available; please retry",
+            hint="retry",
+            data={"reason": reason, "retry_after_ms": 250},
+        ).model_dump()
+
     # ------------------------------------------------------------------
     # Session resolution helpers
     # ------------------------------------------------------------------
     @classmethod
-    async def _resolve_session_id(cls, unity_instance: str | None, user_id: str | None = None) -> str:
+    async def _resolve_session_id(
+        cls,
+        unity_instance: str | None,
+        user_id: str | None = None,
+        retry_on_reload: bool = True,
+    ) -> str:
         """Resolve a project hash (Unity instance id) to an active plugin session.
 
         During Unity domain reloads the plugin's WebSocket session is torn down
@@ -561,6 +652,7 @@ class PluginHub(WebSocketEndpoint):
         Args:
             unity_instance: Target instance (Name@hash or hash)
             user_id: User ID from API key validation (for remote-hosted mode session isolation)
+            retry_on_reload: If False, do not wait for reconnects when no session is present.
         """
         if cls._registry is None:
             raise RuntimeError("Plugin registry not configured")
@@ -589,6 +681,8 @@ class PluginHub(WebSocketEndpoint):
             max_wait_s = 20.0
         # Clamp to [0, 20] to prevent misconfiguration from causing excessive waits
         max_wait_s = max(0.0, min(max_wait_s, 20.0))
+        if not retry_on_reload:
+            max_wait_s = 0.0
         retry_ms = float(getattr(config, "reload_retry_ms", 250))
         sleep_seconds = max(0.05, min(0.25, retry_ms / 1000.0))
 
@@ -684,6 +778,7 @@ class PluginHub(WebSocketEndpoint):
         command_type: str,
         params: dict[str, Any],
         user_id: str | None = None,
+        retry_on_reload: bool = True,
     ) -> dict[str, Any]:
         """Send a command to a Unity instance.
 
@@ -692,28 +787,42 @@ class PluginHub(WebSocketEndpoint):
             command_type: Command type to execute
             params: Command parameters
             user_id: User ID for session isolation in remote-hosted mode
+            retry_on_reload: If False, do not wait for session reconnect on reload.
         """
         try:
-            session_id = await cls._resolve_session_id(unity_instance, user_id=user_id)
+            session_id = await cls._resolve_session_id(
+                unity_instance,
+                user_id=user_id,
+                retry_on_reload=retry_on_reload,
+            )
         except NoUnitySessionError:
             logger.debug(
                 "Unity session unavailable; returning retry: command=%s instance=%s",
                 command_type,
                 unity_instance or "default",
             )
-            return MCPResponse(
-                success=False,
-                error="Unity session not available; please retry",
-                hint="retry",
-                data={"reason": "no_unity_session", "retry_after_ms": 250},
-            ).model_dump()
+            return cls._unavailable_retry_response("no_unity_session")
+
+        if not await cls._ensure_live_connection(session_id):
+            if not retry_on_reload:
+                return cls._unavailable_retry_response("stale_connection")
+            try:
+                session_id = await cls._resolve_session_id(
+                    unity_instance,
+                    user_id=user_id,
+                    retry_on_reload=True,
+                )
+            except NoUnitySessionError:
+                return cls._unavailable_retry_response("no_unity_session")
+            if not await cls._ensure_live_connection(session_id):
+                return cls._unavailable_retry_response("stale_connection")
 
         # During domain reload / immediate reconnect windows, the plugin may be connected but not yet
         # ready to process execute commands on the Unity main thread (which can be further delayed when
         # the Unity Editor is unfocused). For fast-path commands, we do a bounded readiness probe using
         # a main-thread ping command (handled by TransportCommandDispatcher) rather than waiting on
         # register_tools (which can be delayed by EditorApplication.delayCall).
-        if command_type in cls._FAST_FAIL_COMMANDS and command_type != "ping":
+        if retry_on_reload and command_type in cls._FAST_FAIL_COMMANDS and command_type != "ping":
             try:
                 max_wait_s = float(os.environ.get(
                     "UNITY_MCP_SESSION_READY_WAIT_SECONDS", "6"))

--- a/Server/src/transport/unity_transport.py
+++ b/Server/src/transport/unity_transport.py
@@ -71,12 +71,17 @@ async def send_with_unity_instance(
                 ).model_dump()
             )
 
+        retry_on_reload = kwargs.pop("retry_on_reload", True)
+        if not isinstance(retry_on_reload, bool):
+            retry_on_reload = True
+
         try:
             raw = await PluginHub.send_command_for_instance(
                 unity_instance,
                 command_type,
                 params,
                 user_id=user_id,
+                retry_on_reload=retry_on_reload,
             )
             return normalize_unity_response(raw)
         except Exception as exc:


### PR DESCRIPTION
## Summary

Fixes #795 — the HTTP/WebSocket transport path (PluginHub) now respects retry_on_reload=False and performs pre-send liveness checks, matching the stdio path behavior from PR #792.

- **unity_transport.py**: Extract retry_on_reload from kwargs and forward to PluginHub.send_command_for_instance() (previously silently dropped)
- **plugin_hub.py**:
  - _resolve_session_id() accepts retry_on_reload; when False, skips the reconnect wait loop
  - send_command_for_instance() accepts retry_on_reload; when False + stale connection, returns failure immediately instead of retrying
  - New _ensure_live_connection() checks WebSocket state before sending (best-effort pre-send liveness, mirrors stdios MSG_PEEK check)
  - New _evict_connection() proactively cleans up stale sessions
  - Skips fast-fail readiness probe when retry_on_reload=False

## Test plan

- [x] 3 new unit/integration tests (707/707 passing)
- [x] Smoke tested against live Unity instance via HTTP transport:
  - script_apply_edits (uses retry_on_reload=False) — survives domain reload
  - create_script (uses retry_on_reload=False) — survives domain reload
  - refresh_unity with compile — recovers from WebSocket disconnect
  - No compilation errors after mutations

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Codex <noreply@openai.com>

## Summary by Sourcery

Respect retry_on_reload for HTTP/WebSocket Unity transport and add stale connection detection and eviction to improve domain reload behavior and error signalling.

Bug Fixes:
- Ensure HTTP transport forwards retry_on_reload to PluginHub so commands can opt out of reconnect waits during Unity domain reloads.
- Avoid sending commands over stale WebSocket sessions by checking liveness before send and failing fast when retry_on_reload is disabled.

Enhancements:
- Introduce explicit stale connection eviction in PluginHub, cleaning up WebSocket state, background ping tasks, and pending futures when a session is no longer valid.
- Add a shared unavailable retry response helper to standardize error payloads when Unity sessions are missing or connections are stale.
- Gate fast-fail readiness probes on retry_on_reload to avoid unnecessary waits when callers request no reload retries.

Tests:
- Add integration tests covering no-wait behavior when retry_on_reload is disabled, fast-fail on stale HTTP sessions without retry, and HTTP transport propagation of retry_on_reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stability with proactive liveness checks and automatic cleanup of stale connections.
  * Enhanced retry control during domain reloads to enable faster fallbacks when connections are unavailable.
  * Standardized error responses for unavailable sessions.

* **Tests**
  * Added integration tests for retry behavior control and stale connection detection.
  * Added HTTP transport verification tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->