### PR TITLE
Log evicted WebSocket close errors instead of silently swallowing

### DIFF
--- a/Server/src/transport/plugin_hub.py
+++ b/Server/src/transport/plugin_hub.py
@@ -584,8 +584,8 @@ class PluginHub(WebSocketEndpoint):
         if websocket is not None:
             try:
                 await websocket.close(code=1001)
-            except Exception:
-                pass
+            except Exception as close_ex:
+                logger.debug("Error closing evicted WebSocket for session %s: %s", session_id, close_ex)
 
         if cls._registry is not None:
             try:


### PR DESCRIPTION
Follow-up to #798 — addresses CodeRabbit review suggestion to log the swallowed exception in _evict_connection when closing a stale WebSocket, matching the pattern used in _ping_loop.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add debug-level logging for exceptions raised while closing stale WebSocket connections during eviction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for WebSocket connection closure operations, enabling better visibility into connection termination issues for system diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->