### PR TITLE
fix: guard against null progress in nudge check

### DIFF
--- a/Server/src/services/tools/run_tests.py
+++ b/Server/src/services/tools/run_tests.py
@@ -282,7 +282,7 @@ async def get_test_job(
             # This handles OS-level throttling (e.g., macOS App Nap) that can
             # stall PlayMode tests when Unity is in the background.
             # Uses exponential backoff: 1s, 2s, 4s, 8s, 10s max between nudges.
-            progress = data.get("progress", {})
+            progress = data.get("progress") or {}
             editor_is_focused = progress.get("editor_is_focused", True)
             current_time_ms = int(time.time() * 1000)
 
@@ -324,7 +324,7 @@ async def get_test_job(
     data = response.get("data", {})
     status = data.get("status", "")
     if status == "running":
-        progress = data.get("progress", {})
+        progress = data.get("progress") or {}
         editor_is_focused = progress.get("editor_is_focused", True)
         last_update_unix_ms = data.get("last_update_unix_ms")
         current_time_ms = int(time.time() * 1000)


### PR DESCRIPTION
## Summary

- Fix `data.get("progress", {})` returning `None` when Unity sends `"progress": null` (e.g. before first test starts), which would cause `AttributeError` on the subsequent `.get()` call
- Applied to both the `wait_timeout` polling path and the fire-and-forget nudge path

Addresses missed CodeRabbit feedback from #804.

## Test plan

- [x] 725 Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent AttributeError when Unity sends null progress data by defaulting progress to an empty object in both polling and fire-and-forget nudge paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of test progress data to prevent potential issues when progress information is unavailable, enhancing stability during test execution monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->