### PR TITLE
fix: add pyenv shims to PATH on macOS

### DIFF
--- a/MCPForUnity/Editor/Dependencies/PlatformDetectors/MacOSPlatformDetector.cs
+++ b/MCPForUnity/Editor/Dependencies/PlatformDetectors/MacOSPlatformDetector.cs
@@ -188,6 +188,7 @@ Note: If using Homebrew, make sure /opt/homebrew/bin is in your PATH.";
             var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             return new[]
             {
+                Path.Combine(homeDir, ".pyenv", "shims"), // pyenv: Python/uv when Unity is launched from Dock/Spotlight
                 "/opt/homebrew/bin",
                 "/usr/local/bin",
                 "/usr/bin",


### PR DESCRIPTION
## Description
Add `~/.pyenv/shims` to the augmented PATH in `MacOSPlatformDetector` so that Python installed via pyenv can be found when Unity is launched from Dock/Spotlight on macOS.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made
- Added `Path.Combine(homeDir, ".pyenv", "shims")` to `GetPathAdditions()` in `MacOSPlatformDetector.cs`
- The pyenv shims path is placed first in the array so it takes priority when present

## Testing/Screenshots/Recordings
This is a minimal one-line change. Testing requires:
1. macOS system with pyenv installed
2. Python 3.10+ installed via pyenv
3. Unity launched from Dock/Spotlight (not terminal)
4. Verify MCP for Unity can detect Python correctly

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`

## Related Issues
Fixes #812

## Additional Notes
**Root cause:** On macOS, GUI applications launched from Dock/Spotlight do not inherit the interactive shell's PATH (from `.zshrc`/`.bashrc`). The pyenv shims directory (`~/.pyenv/shims`) was not included in the augmented PATH, causing Python detection to fail for pyenv users.

**Solution:** Add the pyenv shims directory to the augmented PATH. If the user doesn't use pyenv, this directory typically doesn't exist and the resolver continues with the next paths in the list.

## Summary by Sourcery

Bug Fixes:
- Include the pyenv shims directory in the macOS PATH additions so Python/uv installed via pyenv can be detected when Unity is launched from Dock or Spotlight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python/uv detection on macOS when launching Unity from Dock or Spotlight

<!-- end of auto-generated comment: release notes by coderabbit.ai -->