### PR TITLE
Fix constructor name for GeminiCliConfigurator

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/GeminiCliConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/GeminiCliConfigurator.cs
@@ -9,7 +9,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
 {
     public class GeminiCliConfigurator : JsonFileMcpConfigurator
     {
-        public GeminiConfigurator() : base(new McpClient
+        public GeminiCliConfigurator() : base(new McpClient
         {
             name = "Gemini CLI",
             windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "settings.json"),


### PR DESCRIPTION
Quick fix on the constructor name

## Summary by Sourcery

Bug Fixes:
- Fix the constructor name in GeminiCliConfigurator so it matches the class and instantiates correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a naming inconsistency in the Gemini CLI configurator component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->