### PR TITLE
feat(editor): add MCP skill installer/sync window

### DIFF
--- a/MCPForUnity/Editor/Setup/McpForUnitySkillInstaller.cs
+++ b/MCPForUnity/Editor/Setup/McpForUnitySkillInstaller.cs
@@ -1,0 +1,834 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace MCPForUnity.Editor.Setup
+{
+    public class McpForUnitySkillInstaller : EditorWindow
+    {
+        private const string RepoUrlKey = "UnityMcpSkillSync.RepoUrl";
+        private const string BranchKey = "UnityMcpSkillSync.Branch";
+        private const string CliKey = "UnityMcpSkillSync.Cli";
+        private const string InstallDirKey = "UnityMcpSkillSync.InstallDir";
+        private const string LastSyncedCommitKey = "UnityMcpSkillSync.LastSyncedCommit";
+        private const string FixedSkillSubdir = "unity-mcp-skill";
+        private const string CodexCli = "codex";
+        private const string ClaudeCli = "claude";
+        private static readonly string[] BranchOptions = { "beta", "main" };
+        private static readonly string[] CliOptions = { CodexCli, ClaudeCli };
+
+        private string _repoUrl;
+        private string _targetBranch;
+        private string _cliType;
+        private string _installDir;
+        private Vector2 _scroll;
+        private volatile bool _isRunning;
+        private readonly ConcurrentQueue<Action> _mainThreadActions = new();
+        private readonly ConcurrentQueue<string> _pendingLogs = new();
+        private readonly StringBuilder _logBuilder = new(4096);
+
+        [MenuItem("Window/MCP For Unity/Install(Sync) MCP Skill")]
+        public static void OpenWindow()
+        {
+            GetWindow<McpForUnitySkillInstaller>("Unity MCP Skill Install(Sync)");
+        }
+
+        private void OnEnable()
+        {
+            var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            _repoUrl = EditorPrefs.GetString(RepoUrlKey, "https://github.com/CoplayDev/unity-mcp");
+            _targetBranch = EditorPrefs.GetString(BranchKey, "beta");
+            if (!BranchOptions.Contains(_targetBranch))
+            {
+                _targetBranch = "beta";
+            }
+            _cliType = EditorPrefs.GetString(CliKey, CodexCli);
+            if (!CliOptions.Contains(_cliType))
+            {
+                _cliType = CodexCli;
+            }
+            _installDir = EditorPrefs.GetString(InstallDirKey, GetDefaultInstallDir(userHome, _cliType));
+            EditorApplication.update += OnEditorUpdate;
+        }
+
+        private void OnDisable()
+        {
+            EditorApplication.update -= OnEditorUpdate;
+            EditorPrefs.SetString(RepoUrlKey, _repoUrl);
+            EditorPrefs.SetString(BranchKey, _targetBranch);
+            EditorPrefs.SetString(CliKey, _cliType);
+            EditorPrefs.SetString(InstallDirKey, _installDir);
+        }
+
+        private void OnGUI()
+        {
+            FlushPendingLogs();
+            EditorGUILayout.HelpBox("Sync Unity MCP Skill to the latest on the selected branch and output the changed file list.", MessageType.Info);
+            EditorGUILayout.Space(4f);
+
+            EditorGUILayout.LabelField("Config", EditorStyles.boldLabel);
+            _repoUrl = EditorGUILayout.TextField("Repo URL", _repoUrl);
+            var branchIndex = Array.IndexOf(BranchOptions, _targetBranch);
+            if (branchIndex < 0)
+            {
+                branchIndex = 0;
+            }
+
+            var selectedBranchIndex = EditorGUILayout.Popup("Branch", branchIndex, BranchOptions);
+            _targetBranch = BranchOptions[selectedBranchIndex];
+
+            var cliIndex = Array.IndexOf(CliOptions, _cliType);
+            if (cliIndex < 0)
+            {
+                cliIndex = 0;
+            }
+
+            var selectedCliIndex = EditorGUILayout.Popup("CLI", cliIndex, CliOptions);
+            if (selectedCliIndex != cliIndex)
+            {
+                var previousCli = _cliType;
+                _cliType = CliOptions[selectedCliIndex];
+                TryApplyCliDefaultInstallPath(previousCli, _cliType);
+            }
+
+            _installDir = EditorGUILayout.TextField("Install Dir", _installDir);
+
+            EditorGUILayout.Space(8f);
+            EditorGUILayout.BeginHorizontal();
+            using (new EditorGUI.DisabledScope(_isRunning))
+            {
+                if (GUILayout.Button($"Sync Latest ({_targetBranch})", GUILayout.Height(32f)))
+                {
+                    AppendLineImmediate("Sync task queued...");
+                    AppendLineImmediate("Will use GitHub API to read the remote directory tree and perform incremental sync (no repository clone).");
+                    RunSyncLatest();
+                }
+            }
+
+            if (GUILayout.Button("Clear Log", GUILayout.Width(100f), GUILayout.Height(32f)))
+            {
+                _logBuilder.Clear();
+                while (_pendingLogs.TryDequeue(out _))
+                {
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space(8f);
+            EditorGUILayout.LabelField("Output", EditorStyles.boldLabel);
+            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+            EditorGUILayout.TextArea(_logBuilder.ToString(), GUILayout.ExpandHeight(true));
+            EditorGUILayout.EndScrollView();
+        }
+
+        private void OnEditorUpdate()
+        {
+            ExecuteMainThreadActions();
+            var changed = FlushPendingLogs();
+            if (_isRunning || changed)
+            {
+                Repaint();
+            }
+        }
+
+        private void RunSyncLatest()
+        {
+            var lastSyncedCommitKey = GetLastSyncedCommitKey();
+            var lastSyncedCommit = EditorPrefs.GetString(lastSyncedCommitKey, string.Empty);
+            ExecuteWithGuard(() =>
+            {
+                AppendLine("=== Sync Start ===");
+                if (!TryParseGitHubRepository(_repoUrl, out var repoInfo))
+                {
+                    throw new InvalidOperationException($"Repo URL is not a recognized GitHub repository URL: {_repoUrl}");
+                }
+
+                AppendLine($"Target repository: {repoInfo.Owner}/{repoInfo.Repo}@{_targetBranch}");
+                var snapshot = FetchRemoteSnapshot(repoInfo, _targetBranch, FixedSkillSubdir);
+                var installPath = GetInstallPath();
+
+                if (!Directory.Exists(installPath))
+                {
+                    Directory.CreateDirectory(installPath);
+                }
+
+                var localFiles = ListFiles(installPath);
+                var plan = BuildPlan(snapshot.Files, localFiles);
+                var commitChanged = !string.Equals(lastSyncedCommit, snapshot.CommitSha, StringComparison.Ordinal);
+
+                AppendLine($"Remote Commit: {ShortCommit(lastSyncedCommit)} -> {ShortCommit(snapshot.CommitSha)}");
+                AppendLine(commitChanged
+                    ? $"Commit: detected newer commit on {_targetBranch}."
+                    : $"Commit: no new commit on {_targetBranch} since last sync.");
+                AppendLine($"Plan => Added:{plan.Added.Count} Updated:{plan.Updated.Count} Deleted:{plan.Deleted.Count}");
+                AppendSummary(plan, commitChanged);
+                LogPlanDetails(plan);
+
+                ApplyPlan(repoInfo, snapshot.CommitSha, snapshot.SubdirPath, installPath, plan);
+                AppendLine("Files mirrored to install directory.");
+
+                ValidateFileHashes(installPath, snapshot.Files);
+                EnqueueMainThreadAction(() => EditorPrefs.SetString(lastSyncedCommitKey, snapshot.CommitSha));
+                AppendLine($"Synced to commit: {snapshot.CommitSha}");
+                AppendLine("=== Sync Done ===");
+            });
+        }
+
+        private void ExecuteWithGuard(Action action)
+        {
+            if (_isRunning)
+            {
+                return;
+            }
+
+            _isRunning = true;
+            Task.Run(() =>
+            {
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    AppendLine($"[ERROR] {ex.Message}");
+                }
+                finally
+                {
+                    _isRunning = false;
+                }
+            });
+        }
+
+        private string GetLastSyncedCommitKey()
+        {
+            var scope = $"{_repoUrl}|{_targetBranch}|{NormalizeRemotePath(FixedSkillSubdir)}";
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(scope));
+            var suffix = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+            return $"{LastSyncedCommitKey}.{suffix}";
+        }
+
+        private static bool TryParseGitHubRepository(string url, out GitHubRepoInfo repoInfo)
+        {
+            repoInfo = default;
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return false;
+            }
+
+            var trimmed = url.Trim();
+            if (trimmed.StartsWith("git@github.com:", StringComparison.OrdinalIgnoreCase))
+            {
+                var repoPath = trimmed.Substring("git@github.com:".Length).Trim('/');
+                return TryParseOwnerAndRepo(repoPath, out repoInfo);
+            }
+
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+            {
+                return false;
+            }
+
+            if (!string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var repoPathFromUri = uri.AbsolutePath.Trim('/');
+            return TryParseOwnerAndRepo(repoPathFromUri, out repoInfo);
+        }
+
+        private static bool TryParseOwnerAndRepo(string path, out GitHubRepoInfo repoInfo)
+        {
+            repoInfo = default;
+            var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length < 2)
+            {
+                return false;
+            }
+
+            var owner = segments[0].Trim();
+            var repo = segments[1].Trim();
+            if (repo.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                repo = repo.Substring(0, repo.Length - 4);
+            }
+
+            if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
+            {
+                return false;
+            }
+
+            repoInfo = new GitHubRepoInfo(owner, repo);
+            return true;
+        }
+
+        private RemoteSnapshot FetchRemoteSnapshot(GitHubRepoInfo repoInfo, string branch, string subdir)
+        {
+            using var client = CreateGitHubClient();
+            var treeApiUrl = BuildTreeApiUrl(repoInfo, branch);
+            AppendLine($"Fetching remote directory tree: {treeApiUrl}");
+            var json = DownloadString(client, treeApiUrl);
+            var treeResponse = JsonUtility.FromJson<GitHubTreeResponse>(json);
+            if (treeResponse == null || treeResponse.tree == null)
+            {
+                throw new InvalidOperationException("Failed to parse GitHub directory tree response.");
+            }
+
+            if (treeResponse.truncated)
+            {
+                AppendLine("Warning: GitHub returned a truncated directory tree; results may be incomplete.");
+            }
+
+            var normalizedSubdir = NormalizeRemotePath(subdir);
+            var subdirPrefix = string.IsNullOrEmpty(normalizedSubdir) ? string.Empty : $"{normalizedSubdir}/";
+            var remoteFiles = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var entry in treeResponse.tree)
+            {
+                if (!string.Equals(entry.type, "blob", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var remotePath = NormalizeRemotePath(entry.path);
+                if (string.IsNullOrEmpty(remotePath))
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(subdirPrefix) &&
+                    !remotePath.StartsWith(subdirPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var relativePath = string.IsNullOrEmpty(subdirPrefix)
+                    ? remotePath
+                    : remotePath.Substring(subdirPrefix.Length);
+                if (string.IsNullOrWhiteSpace(relativePath) || string.IsNullOrWhiteSpace(entry.sha))
+                {
+                    continue;
+                }
+
+                remoteFiles[relativePath] = entry.sha.Trim().ToLowerInvariant();
+            }
+
+            if (remoteFiles.Count == 0)
+            {
+                throw new InvalidOperationException($"Remote directory not found: {normalizedSubdir}");
+            }
+
+            var commitSha = treeResponse.sha?.Trim();
+            if (string.IsNullOrWhiteSpace(commitSha))
+            {
+                throw new InvalidOperationException("Remote directory tree response is missing commit SHA.");
+            }
+
+            AppendLine($"Remote file count: {remoteFiles.Count}");
+            return new RemoteSnapshot(commitSha, normalizedSubdir, remoteFiles);
+        }
+
+        private static string BuildTreeApiUrl(GitHubRepoInfo repoInfo, string branch)
+        {
+            return $"https://api.github.com/repos/{Uri.EscapeDataString(repoInfo.Owner)}/{Uri.EscapeDataString(repoInfo.Repo)}/git/trees/{Uri.EscapeDataString(branch)}?recursive=1";
+        }
+
+        private static string BuildRawFileUrl(GitHubRepoInfo repoInfo, string commitSha, string remoteFilePath)
+        {
+            var encodedPath = string.Join("/",
+                NormalizeRemotePath(remoteFilePath)
+                    .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(Uri.EscapeDataString));
+            return $"https://raw.githubusercontent.com/{Uri.EscapeDataString(repoInfo.Owner)}/{Uri.EscapeDataString(repoInfo.Repo)}/{Uri.EscapeDataString(commitSha)}/{encodedPath}";
+        }
+
+        private static HttpClient CreateGitHubClient()
+        {
+            var client = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(60)
+            };
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("UnityMcpSkillSyncWindow/1.0");
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+            return client;
+        }
+
+        private static string DownloadString(HttpClient client, string url)
+        {
+            using var response = client.GetAsync(url).GetAwaiter().GetResult();
+            var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"GitHub request failed: {(int)response.StatusCode} {response.ReasonPhrase} ({url})\n{body}");
+            }
+
+            return body;
+        }
+
+        private static byte[] DownloadBytes(HttpClient client, string url)
+        {
+            using var response = client.GetAsync(url).GetAwaiter().GetResult();
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                throw new InvalidOperationException($"File download failed: {(int)response.StatusCode} {response.ReasonPhrase} ({url})\n{body}");
+            }
+
+            return response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+        }
+
+        private static string NormalizeRemotePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            return path.Replace('\\', '/').Trim().Trim('/');
+        }
+
+        private static string CombineRemotePath(string left, string right)
+        {
+            var normalizedLeft = NormalizeRemotePath(left);
+            var normalizedRight = NormalizeRemotePath(right);
+            if (string.IsNullOrEmpty(normalizedLeft))
+            {
+                return normalizedRight;
+            }
+
+            if (string.IsNullOrEmpty(normalizedRight))
+            {
+                return normalizedLeft;
+            }
+
+            return $"{normalizedLeft}/{normalizedRight}";
+        }
+
+        private static SyncPlan BuildPlan(Dictionary<string, string> remoteFiles, Dictionary<string, string> localFiles)
+        {
+            var plan = new SyncPlan();
+            foreach (var remoteEntry in remoteFiles)
+            {
+                if (!localFiles.TryGetValue(remoteEntry.Key, out var localPath))
+                {
+                    plan.Added.Add(remoteEntry.Key);
+                    continue;
+                }
+
+                var localBlobSha = ComputeGitBlobSha1(localPath);
+                if (!string.Equals(localBlobSha, remoteEntry.Value, StringComparison.Ordinal))
+                {
+                    plan.Updated.Add(remoteEntry.Key);
+                }
+            }
+
+            foreach (var localRelativePath in localFiles.Keys)
+            {
+                if (!remoteFiles.ContainsKey(localRelativePath))
+                {
+                    plan.Deleted.Add(localRelativePath);
+                }
+            }
+
+            plan.Added.Sort(StringComparer.Ordinal);
+            plan.Updated.Sort(StringComparer.Ordinal);
+            plan.Deleted.Sort(StringComparer.Ordinal);
+            return plan;
+        }
+
+        private void ApplyPlan(GitHubRepoInfo repoInfo, string commitSha, string remoteSubdir, string targetRoot, SyncPlan plan)
+        {
+            using var client = CreateGitHubClient();
+            foreach (var relativePath in plan.Added.Concat(plan.Updated))
+            {
+                var remoteFilePath = CombineRemotePath(remoteSubdir, relativePath);
+                var downloadUrl = BuildRawFileUrl(repoInfo, commitSha, remoteFilePath);
+                var targetFile = Path.Combine(targetRoot, relativePath);
+                var targetDirectory = Path.GetDirectoryName(targetFile);
+                if (!string.IsNullOrEmpty(targetDirectory))
+                {
+                    Directory.CreateDirectory(targetDirectory);
+                }
+
+                AppendLine($"Download: {relativePath}");
+                var bytes = DownloadBytes(client, downloadUrl);
+                File.WriteAllBytes(targetFile, bytes);
+            }
+
+            foreach (var relativePath in plan.Deleted)
+            {
+                var targetFile = Path.Combine(targetRoot, relativePath);
+                if (File.Exists(targetFile))
+                {
+                    File.Delete(targetFile);
+                }
+            }
+
+            RemoveEmptyDirectories(targetRoot);
+        }
+
+        private void ValidateFileHashes(string installRoot, Dictionary<string, string> remoteFiles)
+        {
+            var checkedCount = 0;
+            foreach (var remoteEntry in remoteFiles)
+            {
+                var localPath = Path.Combine(installRoot, remoteEntry.Key);
+                if (!File.Exists(localPath))
+                {
+                    throw new InvalidOperationException($"Missing synced file: {remoteEntry.Key}");
+                }
+
+                var localBlobSha = ComputeGitBlobSha1(localPath);
+                if (!string.Equals(localBlobSha, remoteEntry.Value, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"File hash mismatch: {remoteEntry.Key} ({ShortHash(localBlobSha)} != {ShortHash(remoteEntry.Value)})");
+                }
+
+                checkedCount++;
+            }
+
+            AppendLine($"Hash checks passed ({checkedCount}/{remoteFiles.Count}).");
+        }
+
+        private static string ComputeGitBlobSha1(string filePath)
+        {
+            var bytes = File.ReadAllBytes(filePath);
+            return ComputeGitBlobSha1(bytes);
+        }
+
+        private static string ComputeGitBlobSha1(byte[] bytes)
+        {
+            var headerBytes = Encoding.UTF8.GetBytes($"blob {bytes.Length}\0");
+            using var sha1 = SHA1.Create();
+            sha1.TransformBlock(headerBytes, 0, headerBytes.Length, null, 0);
+            sha1.TransformFinalBlock(bytes, 0, bytes.Length);
+            return BitConverter.ToString(sha1.Hash ?? Array.Empty<byte>()).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static Dictionary<string, string> ListFiles(string root)
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (!Directory.Exists(root))
+            {
+                return map;
+            }
+
+            var normalizedRoot = Path.GetFullPath(root);
+            foreach (var filePath in Directory.GetFiles(normalizedRoot, "*", SearchOption.AllDirectories))
+            {
+                var relativePath = Path.GetRelativePath(normalizedRoot, filePath).Replace('\\', '/');
+                map[relativePath] = filePath;
+            }
+
+            return map;
+        }
+
+        private static void RemoveEmptyDirectories(string root)
+        {
+            if (!Directory.Exists(root))
+            {
+                return;
+            }
+
+            var directories = Directory.GetDirectories(root, "*", SearchOption.AllDirectories);
+            Array.Sort(directories, (a, b) => string.CompareOrdinal(b, a));
+            foreach (var directory in directories)
+            {
+                if (Directory.EnumerateFileSystemEntries(directory).Any())
+                {
+                    continue;
+                }
+
+                Directory.Delete(directory, false);
+            }
+        }
+
+        private string GetInstallPath()
+        {
+            return ExpandPath(_installDir);
+        }
+
+        private void TryApplyCliDefaultInstallPath(string previousCli, string currentCli)
+        {
+            var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var previousDefaultInstall = GetDefaultInstallDir(userHome, previousCli);
+            var currentDefaultInstall = GetDefaultInstallDir(userHome, currentCli);
+
+            if (string.IsNullOrWhiteSpace(_installDir) || PathsEqual(_installDir, previousDefaultInstall))
+            {
+                _installDir = currentDefaultInstall;
+            }
+        }
+
+        private static string GetDefaultInstallDir(string userHome, string cliType)
+        {
+            var baseDir = IsClaudeCli(cliType) ? ".claude" : ".codex";
+            return Path.Combine(userHome, baseDir, "skills/unity-mcp-skill");
+        }
+
+        private static bool IsClaudeCli(string cliType)
+        {
+            return string.Equals(cliType, ClaudeCli, StringComparison.Ordinal);
+        }
+
+        private static bool PathsEqual(string left, string right)
+        {
+            if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            {
+                return false;
+            }
+
+            try
+            {
+                return string.Equals(ExpandPath(left), ExpandPath(right), StringComparison.Ordinal);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string ExpandPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            var expanded = path.Trim();
+            if (expanded.StartsWith("~", StringComparison.Ordinal))
+            {
+                var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                expanded = Path.Combine(userHome, expanded.Substring(1).TrimStart('/', '\\'));
+            }
+
+            return Path.GetFullPath(expanded);
+        }
+
+        private void EnqueueMainThreadAction(Action action)
+        {
+            if (action == null)
+            {
+                return;
+            }
+
+            _mainThreadActions.Enqueue(action);
+        }
+
+        private void ExecuteMainThreadActions()
+        {
+            while (_mainThreadActions.TryDequeue(out var action))
+            {
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    AppendLineImmediate($"[ERROR] Main-thread action execution failed: {ex.Message}");
+                }
+            }
+        }
+
+        private void AppendLine(string line)
+        {
+            var sanitized = SanitizeLogLine(line);
+            if (string.IsNullOrWhiteSpace(sanitized))
+            {
+                return;
+            }
+
+            _pendingLogs.Enqueue($"[{DateTime.Now:HH:mm:ss}] {sanitized}");
+        }
+
+        private void AppendLineImmediate(string line)
+        {
+            var sanitized = SanitizeLogLine(line);
+            if (string.IsNullOrWhiteSpace(sanitized))
+            {
+                return;
+            }
+
+            _logBuilder.AppendLine($"[{DateTime.Now:HH:mm:ss}] {sanitized}");
+            _scroll.y = float.MaxValue;
+            Repaint();
+        }
+
+        private bool FlushPendingLogs()
+        {
+            var hasNewLine = false;
+            while (_pendingLogs.TryDequeue(out var line))
+            {
+                _logBuilder.AppendLine(line);
+                hasNewLine = true;
+            }
+
+            if (hasNewLine)
+            {
+                _scroll.y = float.MaxValue;
+            }
+
+            return hasNewLine;
+        }
+
+        private static string SanitizeLogLine(string line)
+        {
+            if (string.IsNullOrEmpty(line))
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder(line.Length);
+            var inEscape = false;
+            foreach (var ch in line)
+            {
+                if (inEscape)
+                {
+                    // End ANSI escape sequence on final byte.
+                    if (ch >= '@' && ch <= '~')
+                    {
+                        inEscape = false;
+                    }
+                    continue;
+                }
+
+                if (ch == '\u001b')
+                {
+                    inEscape = true;
+                    continue;
+                }
+
+                if (ch == '\t' || (ch >= ' ' && ch != 127))
+                {
+                    sb.Append(ch);
+                }
+            }
+
+            return sb.ToString().Trim();
+        }
+
+        private void LogPlanDetails(SyncPlan plan)
+        {
+            if (plan.Added.Count == 0 && plan.Updated.Count == 0 && plan.Deleted.Count == 0)
+            {
+                AppendLine("No file changes.");
+                return;
+            }
+
+            foreach (var path in plan.Added)
+            {
+                AppendLine($"+ {path}");
+            }
+
+            foreach (var path in plan.Updated)
+            {
+                AppendLine($"~ {path}");
+            }
+
+            foreach (var path in plan.Deleted)
+            {
+                AppendLine($"- {path}");
+            }
+        }
+
+        private void AppendSummary(SyncPlan plan, bool commitChanged)
+        {
+            var added = plan.Added.Count;
+            var updated = plan.Updated.Count;
+            var deleted = plan.Deleted.Count;
+
+            if (added == 0 && updated == 0 && deleted == 0)
+            {
+                AppendLine("Conclusion: No file changes in this run.");
+                return;
+            }
+
+            if (added == 0 && updated == 0 && deleted > 0)
+            {
+                AppendLine(commitChanged
+                    ? "Conclusion: A new commit was detected, but skill content was unchanged; only local redundant files were cleaned up."
+                    : "Conclusion: Skill content was unchanged; only local redundant files were cleaned up.");
+                return;
+            }
+
+            AppendLine($"Conclusion: Skill files were updated (added {added}, modified {updated}, deleted {deleted}).");
+        }
+
+        private static string ShortCommit(string commit)
+        {
+            if (string.IsNullOrWhiteSpace(commit))
+            {
+                return "(none)";
+            }
+
+            return commit.Length <= 8 ? commit : commit.Substring(0, 8);
+        }
+
+        private static string ShortHash(string hash)
+        {
+            if (string.IsNullOrWhiteSpace(hash))
+            {
+                return "(none)";
+            }
+
+            return hash.Length <= 6 ? hash : hash.Substring(0, 6);
+        }
+
+        private readonly struct GitHubRepoInfo
+        {
+            public GitHubRepoInfo(string owner, string repo)
+            {
+                Owner = owner;
+                Repo = repo;
+            }
+
+            public string Owner { get; }
+            public string Repo { get; }
+        }
+
+        private readonly struct RemoteSnapshot
+        {
+            public RemoteSnapshot(string commitSha, string subdirPath, Dictionary<string, string> files)
+            {
+                CommitSha = commitSha;
+                SubdirPath = subdirPath;
+                Files = files;
+            }
+
+            public string CommitSha { get; }
+            public string SubdirPath { get; }
+            public Dictionary<string, string> Files { get; }
+        }
+
+        [Serializable]
+        private sealed class GitHubTreeResponse
+        {
+            public string sha;
+            public GitHubTreeEntry[] tree;
+            public bool truncated;
+        }
+
+        [Serializable]
+        private sealed class GitHubTreeEntry
+        {
+            public string path;
+            public string type;
+            public string sha;
+        }
+
+        private sealed class SyncPlan
+        {
+            public List<string> Added { get; } = new();
+            public List<string> Updated { get; } = new();
+            public List<string> Deleted { get; } = new();
+        }
+    }
+}

--- a/MCPForUnity/Editor/Setup/McpForUnitySkillInstaller.cs.meta
+++ b/MCPForUnity/Editor/Setup/McpForUnitySkillInstaller.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7886932de812549f195fa4f6006ef0dd


### PR DESCRIPTION
## Description
This PR adds a Unity Editor feature to install and sync `unity-mcp-skill` directly from a GitHub repository/branch, with incremental updates and integrity checks.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made
- Added a new Unity Editor window: `Install(Sync) MCP Skill` under `Window/MCP For Unity`.
- Added support for syncing `unity-mcp-skill` from a selected GitHub repo/branch.
- Added CLI presets for install path selection (`codex` and `claude`).
- Implemented incremental sync using Git tree/blob SHA comparison.
- Added cleanup of stale local files and empty directories after sync.
- Added post-sync hash validation to verify downloaded file integrity.
- Added sync logging with per-file change output (added/updated/deleted).
- Added `McpForUnitySkillInstaller.cs.meta`.

## Testing/Screenshots/Recordings
- Manually tested the Editor window in Unity.
- Verified sync behavior for initial install and re-sync runs.
- Verified incremental behavior (only changed files are updated).
- Verified stale-file cleanup and hash validation pass.
- No automated tests were added for this change.
- Screenshots/recordings: 

https://github.com/user-attachments/assets/0acf48f2-e32c-4eb2-aab9-4f8b429eff6d

<img width="299" height="128" alt="screenshot2026-02-28 16 05 07" src="https://github.com/user-attachments/assets/74312828-7037-4cc1-80e5-c15c0a720e15" />


## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
- [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
- [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`

## Related Issues
Relates to #<issue-number> (if applicable)

## Additional Notes
This is a non-breaking feature addition intended to improve setup/sync workflow for MCP skills in forked or customized environments.

## Summary by Sourcery

Add a Unity Editor window to install and incrementally sync the unity-mcp-skill from a GitHub repository into a local CLI skills directory, with logging and integrity checks.

New Features:
- Introduce an MCP Skill Installer editor window accessible from the Unity Window menu to manage unity-mcp-skill installation and sync.
- Allow configuring GitHub repo, branch, CLI type, and install directory for fetching the unity-mcp-skill contents.
- Perform incremental syncing of remote skill files using Git tree/blob SHAs without cloning the repository.
- Provide per-file change summaries and a scrollable log output in the editor window during sync operations.

Enhancements:
- Add post-sync Git-style hash validation and cleanup of deleted files and empty directories to keep the local skill directory consistent with the remote snapshot.