### PR TITLE
docs: fix incorrect tab reference for Claude Desktop setup

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/ClaudeDesktopConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/ClaudeDesktopConfigurator.cs
@@ -56,7 +56,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
             if (useHttp)
             {
                 return "# Claude Desktop does not support HTTP transport.\n" +
-                       "# Open Advanced Settings and disable HTTP transport to use stdio, then regenerate.";
+                       "# In Connect tab, change the Transport option from HTTP to stdio, then regenerate.";
             }
 
             return base.GetManualSnippet();


### PR DESCRIPTION
## Description
Corrected a misleading instruction in the Claude Desktop configuration UI. The text previously directed users to the "Advanced Settings" tab for transport configuration, but these options are located in the "Connect" tab in the current version.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Changes Made
- Modified the instructional text within the Claude Desktop "Manual Configuration" dropdown.
- Changed "Advanced Settings tab" to "Connect tab" to accurately reflect the UI layout.
- Updated the specific action text to: "In Connect tab, change the Transport option from HTTP to stdio, then regenerate."


## Testing/Screenshots/Recordings

<img width="612" height="718" alt="Screenshot 2026-03-02 at 12 45 28" src="https://github.com/user-attachments/assets/ee67ab7d-d155-4f2b-9acb-49a1618c66f0" />


## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`


## Related Issues
Fixes #850 

## Additional Notes
This was observed and tested on version 9.4.7 using Unity 6.3 LTS.

## Summary by Sourcery

Documentation:
- Update the Claude Desktop manual configuration snippet to direct users to the Connect tab for changing the transport from HTTP to stdio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration instructions for Claude Desktop to provide clearer guidance on transport settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->