### PR TITLE
feat(mcpforunity): support atlas sprite resolution by guid+spriteName/fileID

### DIFF
--- a/MCPForUnity/Editor/Helpers/ComponentOps.cs
+++ b/MCPForUnity/Editor/Helpers/ComponentOps.cs
@@ -842,10 +842,11 @@ namespace MCPForUnity.Editor.Helpers
             try
             {
                 var globalId = GlobalObjectId.GetGlobalObjectIdSlow(sprite);
-                return (long)globalId.targetObjectId;
+                return unchecked((long)globalId.targetObjectId);
             }
-            catch
+            catch (Exception ex)
             {
+                McpLog.Warn($"Failed to get fileID for sprite '{sprite.name}' (instanceID={sprite.GetInstanceID()}): {ex.Message}");
                 return 0;
             }
         }


### PR DESCRIPTION
Adds atlas sprite resolution support for object references using `guid + spriteName` and `fileID` forms.

- resolves sprite references inside atlased assets more reliably
- improves object reference handling for serialized component properties
- keeps the change scoped to `ComponentOps`

Validation:
- cherry-picked cleanly onto the latest `CoplayDev/unity-mcp:beta`

## Summary by Sourcery

Improve handling of Unity object references in component serialization to better resolve atlased sprites from complex reference forms.

New Features:
- Support resolving atlas sprites referenced by GUID plus spriteName in serialized properties.
- Support resolving atlas sprites referenced by GUID plus fileID in serialized properties.

Enhancements:
- Bypass reflection-based assignment for UnityEngine.Object members backed by JObject values so that SerializedProperty-based resolution can handle complex object references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of complex Unity object references by bypassing reflection and deferring to serialized property resolution.
  * Added support for resolving sprites stored inside atlases by name.
  * Added support for resolving sprites by internal identifier when present.
  * Improved diagnostics and clearer error messages for atlas/sprite resolution failures, with safer fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->