### PR TITLE
update for resources-bug-fix

### DIFF
--- a/MCPForUnity/Editor/Windows/Components/Advanced/McpAdvancedSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/Advanced/McpAdvancedSection.cs
@@ -44,6 +44,7 @@ namespace MCPForUnity.Editor.Windows.Components.Advanced
         public event Action OnGitUrlChanged;
         public event Action OnHttpServerCommandUpdateRequested;
         public event Action OnTestConnectionRequested;
+        public event Action OnPackageDeployed;
 
         public VisualElement Root { get; private set; }
 
@@ -489,6 +490,7 @@ namespace MCPForUnity.Editor.Windows.Components.Advanced
             else
             {
                 EditorUtility.DisplayDialog("Deployment Complete", result.Message + (string.IsNullOrEmpty(result.BackupPath) ? string.Empty : $"\nBackup: {result.BackupPath}"), "OK");
+                OnPackageDeployed?.Invoke();
             }
 
             UpdateDeploymentSection();
@@ -506,6 +508,7 @@ namespace MCPForUnity.Editor.Windows.Components.Advanced
             else
             {
                 EditorUtility.DisplayDialog("Restore Complete", result.Message, "OK");
+                OnPackageDeployed?.Invoke();
             }
 
             UpdateDeploymentSection();

--- a/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -275,6 +275,11 @@ namespace MCPForUnity.Editor.Windows
                     if (connectionSection != null)
                         await connectionSection.VerifyBridgeConnectionAsync();
                 };
+                advancedSection.OnPackageDeployed += () =>
+                {
+                    UpdateVersionLabel();
+                    QueueUpdateCheck();
+                };
                 // Wire up health status updates from Connection to Advanced
                 connectionSection?.SetHealthStatusUpdateCallback((isHealthy, statusText) =>
                     advancedSection?.UpdateHealthStatus(isHealthy, statusText));

--- a/Server/src/services/resources/__init__.py
+++ b/Server/src/services/resources/__init__.py
@@ -1,11 +1,13 @@
 """
 MCP Resources package - Auto-discovers and registers all resources in this directory.
 """
+import functools
 import inspect
 import logging
 from pathlib import Path
 
 from fastmcp import FastMCP
+from pydantic import BaseModel
 from core.telemetry_decorator import telemetry_resource
 from core.logging_decorator import log_execution
 
@@ -16,6 +18,25 @@ logger = logging.getLogger("mcp-for-unity-server")
 
 # Export decorator for easy imports within tools
 __all__ = ['register_all_resources']
+
+
+def _serialize_pydantic(func):
+    """Wrap a resource function so Pydantic models are serialized to JSON strings.
+
+    FastMCP 3.x expects resource functions to return str, bytes, or ResourceResult.
+    Our resource functions return MCPResponse (a Pydantic BaseModel). This wrapper
+    converts them to JSON strings automatically.
+    """
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        result = await func(*args, **kwargs)
+        if isinstance(result, BaseModel):
+            return result.model_dump_json()
+        if isinstance(result, dict):
+            import json
+            return json.dumps(result)
+        return result
+    return wrapper
 
 
 def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True):
@@ -55,7 +76,8 @@ def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True):
         has_query_params = '{?' in uri
 
         if has_query_params:
-            wrapped_template = log_execution(resource_name, "Resource")(func)
+            wrapped_template = _serialize_pydantic(func)
+            wrapped_template = log_execution(resource_name, "Resource")(wrapped_template)
             wrapped_template = telemetry_resource(
                 resource_name)(wrapped_template)
             wrapped_template = mcp.resource(
@@ -69,7 +91,8 @@ def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True):
             registered_count += 1
             resource_info['func'] = wrapped_template
         else:
-            wrapped = log_execution(resource_name, "Resource")(func)
+            wrapped = _serialize_pydantic(func)
+            wrapped = log_execution(resource_name, "Resource")(wrapped)
             wrapped = telemetry_resource(resource_name)(wrapped)
             wrapped = mcp.resource(
                 uri=uri,

--- a/Server/uv.lock
+++ b/Server/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "mcpforunityserver"
-version = "9.4.8"
+version = "9.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fix the resources bug that emerged when updating FastMCP to V3. It does not accept Pydantic BaseModel anyway so it is now wrapped in JSON format. GUI updates that update the version number when using advanced deployment are also included.

## Summary by Sourcery

Wrap MCP resource handlers to serialize Pydantic and dict responses for FastMCP v3 compatibility and update the Unity editor UI to refresh version info after advanced deployments.

Bug Fixes:
- Ensure resource functions returning Pydantic models or dicts are serialized to JSON so FastMCP 3.x accepts their outputs.
- Trigger Unity editor version label and update checks after package deploy and restore actions in the advanced deployment section.

Enhancements:
- Introduce a reusable serialization wrapper for MCP resource registration that can be layered with existing logging and telemetry decorators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package deployment now automatically triggers version label updates and queues an update validation check in the editor interface.

* **Bug Fixes**
  * Enhanced resource serialization handling to ensure proper JSON conversion and compatibility with FastMCP 3.x for various result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->