### PR TITLE
[bug-fix]Duplicate signature fix

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageScript.cs
+++ b/MCPForUnity/Editor/Tools/ManageScript.cs
@@ -2662,21 +2662,79 @@ namespace MCPForUnity.Editor.Tools
             }
             var codeOnly = new string(codeChars);
 
-            // Step 2: Compute brace depth at each position (no strings/comments to confuse)
-            var depthArr = new int[codeOnly.Length];
+            // Step 2: Build containing type name at each position via single pass
+            var typePattern = new Regex(
+                @"\b(?:class|struct|interface|record)\s+(\w+)",
+                RegexOptions.CultureInvariant, TimeSpan.FromSeconds(2));
+            // Map opening-brace position -> fully qualified type name
+            var typeBraceMap = new System.Collections.Generic.Dictionary<int, string>();
             {
-                int bd = 0;
+                var typeMatches = typePattern.Matches(codeOnly);
+                // Pre-scan: for each type declaration, find its opening brace and record full name
+                // We need to process in order and track nesting, so do a single forward pass
+                var preStack = new System.Collections.Generic.List<(string name, int openDepth)>();
+                int preBd = 0;
+                int nextTm = 0;
                 for (int i = 0; i < codeOnly.Length; i++)
                 {
-                    if (codeOnly[i] == '{') bd++;
-                    else if (codeOnly[i] == '}') bd = Math.Max(0, bd - 1);
-                    depthArr[i] = bd;
+                    while (nextTm < typeMatches.Count && typeMatches[nextTm].Index == i)
+                    {
+                        int bp = codeOnly.IndexOf('{', typeMatches[nextTm].Index + typeMatches[nextTm].Length);
+                        if (bp >= 0)
+                        {
+                            string tn = typeMatches[nextTm].Groups[1].Value;
+                            string fn = preStack.Count > 0 ? preStack[preStack.Count - 1].name + "." + tn : tn;
+                            typeBraceMap[bp] = fn;
+                        }
+                        nextTm++;
+                    }
+                    if (codeOnly[i] == '{')
+                    {
+                        if (typeBraceMap.TryGetValue(i, out string mappedType))
+                            preStack.Add((mappedType, preBd));
+                        preBd++;
+                    }
+                    else if (codeOnly[i] == '}')
+                    {
+                        preBd = Math.Max(0, preBd - 1);
+                        if (preStack.Count > 0 && preStack[preStack.Count - 1].openDepth == preBd)
+                            preStack.RemoveAt(preStack.Count - 1);
+                    }
+                }
+            }
+            // Second pass: build per-position containing type array
+            var containingTypeArr = new string[codeOnly.Length];
+            {
+                var stack = new System.Collections.Generic.List<(string name, int openDepth)>();
+                int bd2 = 0;
+                string current = "";
+                for (int i = 0; i < codeOnly.Length; i++)
+                {
+                    if (codeOnly[i] == '{')
+                    {
+                        if (typeBraceMap.TryGetValue(i, out string tn))
+                        {
+                            stack.Add((tn, bd2));
+                            current = tn;
+                        }
+                        bd2++;
+                    }
+                    else if (codeOnly[i] == '}')
+                    {
+                        bd2 = Math.Max(0, bd2 - 1);
+                        if (stack.Count > 0 && stack[stack.Count - 1].openDepth == bd2)
+                        {
+                            stack.RemoveAt(stack.Count - 1);
+                            current = stack.Count > 0 ? stack[stack.Count - 1].name : "";
+                        }
+                    }
+                    containingTypeArr[i] = current;
                 }
             }
 
             // Step 3: Match method signatures on code-only text (includes => for expression-bodied)
             var methodSigPattern = new Regex(
-                @"(?:public|private|protected|internal)(?:\s+(?:static|virtual|override|abstract|sealed|async|new))*\s+\S+\s+(\w+)\s*\(([^)]*)\)\s*(?:where\s+\S+\s*:\s*\S+\s*)?(?:[{;]|=>)",
+                @"(?:(?:public|private|protected|internal)\s+)?(?:(?:static|virtual|override|abstract|sealed|async|new)\s+)*\S+\s+(\w+)\s*\(([^)]*)\)\s*(?:where\s+\S+\s*:\s*\S+\s*)?(?:[{;]|=>)",
                 RegexOptions.Multiline | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(2));
             var sigMatches = methodSigPattern.Matches(codeOnly);
             var seen = new System.Collections.Generic.Dictionary<string, int>(System.StringComparer.Ordinal);
@@ -2685,8 +2743,8 @@ namespace MCPForUnity.Editor.Tools
                 string methodName = sm.Groups[1].Value;
                 int paramCount = CountTopLevelParams(sm.Groups[2].Value);
                 string paramTypes = ExtractParamTypes(sm.Groups[2].Value);
-                int depth = depthArr[sm.Index];
-                string key = $"{methodName}/{paramCount}/{paramTypes}@{depth}";
+                string containingType = containingTypeArr[sm.Index];
+                string key = $"{containingType}/{methodName}/{paramCount}/{paramTypes}";
                 if (seen.TryGetValue(key, out _))
                     errors.Add($"ERROR: Duplicate method signature detected: '{methodName}' with {paramCount} parameter(s). This may indicate a corrupted edit.");
                 else

--- a/Server/src/services/tools/script_apply_edits.py
+++ b/Server/src/services/tools/script_apply_edits.py
@@ -678,7 +678,7 @@ def _err(code: str, message: str, *, expected: dict[str, Any] | None = None, rew
     - Use replace_method/delete_method for whole-method changes (keeps signatures balanced)
     - Avoid whole-file regex deletes; validators will guard unbalanced braces
     - For tail insertions, prefer anchor/regex_replace on final brace (class closing)
-    - Pass options.validate='standard' for structural checks; 'relaxed' for interior-only edits
+    - Pass options.validate='standard' for structural checks; 'basic' for interior-only edits
     Canonical fields (use these exact keys):
     - op: replace_method | insert_method | delete_method | anchor_insert | anchor_delete | anchor_replace
     - className: string (defaults to 'name' if omitted on method/class ops)

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
@@ -139,16 +139,25 @@ namespace MCPForUnityTests.Editor.Tools
         }
 
         /// <summary>
-        /// Calls ValidateScriptSyntaxUnity via reflection and returns the error list.
+        /// Calls ValidateScriptSyntax via reflection and returns the error list.
+        /// This exercises CheckDuplicateMethodSignatures (called from ValidateScriptSyntax).
         /// </summary>
         private List<string> CallValidateScriptSyntaxUnity(string contents)
         {
-            var errors = new List<string>();
-            var method = typeof(ManageScript).GetMethod("ValidateScriptSyntaxUnity",
-                BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.IsNotNull(method, "ValidateScriptSyntaxUnity method must exist");
-            method.Invoke(null, new object[] { contents, errors });
-            return errors;
+            var validationLevelType = typeof(ManageScript).GetNestedType("ValidationLevel",
+                BindingFlags.NonPublic);
+            Assert.IsNotNull(validationLevelType, "ValidationLevel enum must exist");
+            var basicLevel = Enum.ToObject(validationLevelType, 0); // ValidationLevel.Basic
+
+            var method = typeof(ManageScript).GetMethod("ValidateScriptSyntax",
+                BindingFlags.NonPublic | BindingFlags.Static, null,
+                new[] { typeof(string), validationLevelType, typeof(string[]).MakeByRefType() }, null);
+            Assert.IsNotNull(method, "ValidateScriptSyntax method must exist");
+
+            var args = new object[] { contents, basicLevel, null };
+            method.Invoke(null, args);
+            var errArray = (string[])args[2];
+            return errArray != null ? errArray.ToList() : new List<string>();
         }
 
         private bool HasDuplicateMethodError(List<string> errors)


### PR DESCRIPTION
Add a duplicate signature check that should fix issue #898, with additional test file.

## Summary by Sourcery

Add basic structural validation to detect duplicate method signatures in Unity scripts and cover it with regression tests.

Bug Fixes:
- Detect and report duplicate method signatures in script validation to prevent corrupted or duplicated methods from slipping through.

Tests:
- Add reflection-based tests for Unity script validation to assert correct detection of duplicate method signatures and avoidance of common false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced script validation to detect and report duplicate method signatures as errors (now surfaced during basic validation).
* **Tests**
  * Added extensive unit tests covering duplicate-signature scenarios to improve validation reliability.
* **Documentation**
  * Updated an internal guidance message describing the interior-only edits validation option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->