### PR TITLE
bug-fix on Manage Script name-path conflict

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageScript.cs
+++ b/MCPForUnity/Editor/Tools/ManageScript.cs
@@ -148,6 +148,12 @@ namespace MCPForUnity.Editor.Tools
 
             // Optional parameters
             string path = p.Get("path"); // Relative to Assets/
+            // If the caller passed a full file path (e.g. "Assets/Scripts/Foo.cs"),
+            // strip the filename so path is treated as a directory.
+            if (path != null && path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                path = Path.GetDirectoryName(path)?.Replace('\\', '/');
+            }
             string contents = null;
 
             // Check if we have base64 encoded contents

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
@@ -319,5 +319,25 @@ public class Foo : MonoBehaviour
             Assert.IsFalse(HasDuplicateMethodError(errors),
                 "C# keywords (if, for, while, etc.) should not be matched as duplicate methods");
         }
+
+        [Test]
+        public void HandleCommand_PathWithCsExtension_StripsFilename()
+        {
+            // When path ends with .cs (full file path instead of directory),
+            // HandleCommand should strip the filename to avoid doubled paths
+            // like "Assets/Scripts/Foo.cs/Foo.cs".
+            var paramsObj = new JObject
+            {
+                ["action"] = "read",
+                ["name"] = "TestScript",
+                ["path"] = "Assets/Scripts/TestScript.cs"
+            };
+
+            var result = ManageScript.HandleCommand(paramsObj);
+            // The script won't exist, but the error path should NOT contain doubled filename
+            string json = Newtonsoft.Json.JsonConvert.SerializeObject(result);
+            Assert.IsFalse(json.Contains("TestScript.cs/TestScript.cs"),
+                "Path ending in .cs should be treated as directory, not produce doubled filename");
+        }
     }
 }


### PR DESCRIPTION
Fix the problem where if LLM call with the name but also a path consisting the name, it will return false.

## Summary by Sourcery

Fix path handling in ManageScript when a full C# file path is provided to prevent incorrect script resolution.

Bug Fixes:
- Normalize paths that end with a .cs filename by stripping the filename and treating the path as a directory to avoid duplicated filename segments in generated paths.

Tests:
- Add a test verifying that HandleCommand does not produce doubled filename paths when given a full .cs file path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path normalization for paths ending with .cs file extensions by correctly stripping filenames and converting to directory paths.

* **Tests**
  * Added validation test for path normalization with .cs file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->