### PR TITLE
Update MCPForUnityEditorWindow.cs

### DIFF
--- a/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -333,6 +333,7 @@ namespace MCPForUnity.Editor.Windows
 
             // Initial updates
             RefreshAllData();
+            QueueUpdateCheck();
         }
 
         private void UpdateVersionLabel()
@@ -517,7 +518,6 @@ namespace MCPForUnity.Editor.Windows
 
             advancedSection?.UpdatePathOverrides();
             clientConfigSection?.RefreshSelectedClient();
-            QueueUpdateCheck();
         }
 
         private void SetupTabs()


### PR DESCRIPTION
Problem #830. Previously once the GUI is on focus, RefreshAllData will be called and QueueUpdateCheck() is called, for some users with internet issues (from susception), this will cause issue, and check for update is not necessary to run that often. I moved it to the CreateGUI part, so every time the package is updated, restored, reopened, this function will still run.

## Summary by Sourcery

Enhancements:
- Trigger the update check once during editor window GUI creation instead of on every data refresh to avoid excessive checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the timing of package update checks to occur when the editor window initializes, rather than during routine data refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->