### PR TITLE
Fix on config and log

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/KiloCodeConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/KiloCodeConfigurator.cs
@@ -13,7 +13,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
             windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
             macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
             linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
-            IsVsCodeLayout = true
+            IsVsCodeLayout = false
         })
         { }
 

--- a/MCPForUnity/Editor/Helpers/ConfigJsonBuilder.cs
+++ b/MCPForUnity/Editor/Helpers/ConfigJsonBuilder.cs
@@ -92,19 +92,16 @@ namespace MCPForUnity.Editor.Helpers
                     if (unity["headers"] != null) unity.Remove("headers");
                 }
 
-                if (isVSCode)
-                {
-                    unity["type"] = "http";
-                }
-                // Also add type for Claude Code (uses mcpServers layout but needs type field)
-                else if (client?.name == "Claude Code")
-                {
-                    unity["type"] = "http";
-                }
                 // Cline expects streamableHttp for HTTP endpoints.
-                else if (isCline)
+                if (isCline)
                 {
                     unity["type"] = "streamableHttp";
+                }
+                else
+                {
+                    // "type" is standard MCP protocol; include for all clients to avoid
+                    // clients that default to SSE when they see a URL without a type field.
+                    unity["type"] = "http";
                 }
             }
             else
@@ -121,20 +118,8 @@ namespace MCPForUnity.Editor.Helpers
                 if (unity["url"] != null) unity.Remove("url");
                 if (unity["serverUrl"] != null) unity.Remove("serverUrl");
 
-                if (isVSCode)
-                {
-                    unity["type"] = "stdio";
-                }
-                else if (isCline)
-                {
-                    unity["type"] = "stdio";
-                }
-            }
-
-            // Remove type for non-VSCode clients (except clients that explicitly require it)
-            if (!isVSCode && client?.name != "Claude Code" && !isCline && unity["type"] != null)
-            {
-                unity.Remove("type");
+                // Include type for all clients — standard MCP protocol field.
+                unity["type"] = "stdio";
             }
 
             bool requiresEnv = client?.EnsureEnvObject == true;

--- a/MCPForUnity/Editor/Services/Transport/TransportCommandDispatcher.cs
+++ b/MCPForUnity/Editor/Services/Transport/TransportCommandDispatcher.cs
@@ -402,7 +402,15 @@ namespace MCPForUnity.Editor.Services.Transport
                 }
 
                 sw?.Stop();
-                McpLogRecord.Log(command.type, parameters, logType, "SUCCESS", sw?.ElapsedMilliseconds ?? 0);
+
+                string syncLogStatus = "SUCCESS";
+                string syncLogError = null;
+                if (result is ErrorResponse errResp)
+                {
+                    syncLogStatus = "ERROR";
+                    syncLogError = errResp.Error;
+                }
+                McpLogRecord.Log(command.type, parameters, logType, syncLogStatus, sw?.ElapsedMilliseconds ?? 0, syncLogError);
 
                 var response = new { status = "success", result };
                 pending.TrySetResult(JsonConvert.SerializeObject(response));

--- a/MCPForUnity/Editor/Tools/ReadConsole.cs
+++ b/MCPForUnity/Editor/Tools/ReadConsole.cs
@@ -248,10 +248,13 @@ namespace MCPForUnity.Editor.Tools
 
             try
             {
-                // LogEntries requires calling Start/Stop around GetEntries/GetEntryInternal
-                _startGettingEntriesMethod.Invoke(null, null);
-
-                int totalEntries = (int)_getCountMethod.Invoke(null, null);
+                // LogEntries requires calling Start/Stop around GetEntries/GetEntryInternal.
+                // StartGettingEntries() returns the entry count — use it instead of GetCount()
+                // which may return stale values within an active iteration session.
+                object startResult = _startGettingEntriesMethod.Invoke(null, null);
+                int totalEntries = startResult is int startCount
+                    ? startCount
+                    : (int)_getCountMethod.Invoke(null, null);
                 // Create instance to pass to GetEntryInternal - Ensure the type is correct
                 Type logEntryType = typeof(EditorApplication).Assembly.GetType(
                     "UnityEditor.LogEntry"

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/WriteToConfigTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/WriteToConfigTests.cs
@@ -408,7 +408,6 @@ namespace MCPForUnityTests.Editor.Helpers
         private static void AssertTransportConfiguration(JObject unity, McpClient client)
         {
             bool useHttp = EditorPrefs.GetBool(UseHttpTransportPrefKey, true);
-            bool isVSCode = client.IsVsCodeLayout;
             bool isWindsurf = string.Equals(client.HttpUrlProperty, "serverUrl", StringComparison.OrdinalIgnoreCase);
 
             if (useHttp)
@@ -429,16 +428,9 @@ namespace MCPForUnityTests.Editor.Helpers
                 Assert.IsNull(unity["command"], "HTTP transport should remove command");
                 Assert.IsNull(unity["args"], "HTTP transport should remove args");
 
-                if (isVSCode)
-                {
-                    Assert.AreEqual("http", (string)unity["type"],
-                        "VSCode entries should advertise HTTP transport");
-                }
-                else
-                {
-                    Assert.IsNull(unity["type"],
-                        "Non-VSCode entries should not include type metadata in HTTP mode");
-                }
+                // "type" is now included for all clients (standard MCP protocol field).
+                Assert.AreEqual("http", (string)unity["type"],
+                    "All entries should advertise HTTP transport type");
             }
             else
             {
@@ -458,16 +450,9 @@ namespace MCPForUnityTests.Editor.Helpers
                 Assert.AreEqual("stdio", args[transportIndex + 1],
                     "--transport should be followed by stdio mode");
 
-                if (isVSCode)
-                {
-                    Assert.AreEqual("stdio", (string)unity["type"],
-                        "VSCode entries should advertise stdio transport");
-                }
-                else
-                {
-                    Assert.IsNull(unity["type"],
-                        "Non-VSCode entries should not include type metadata in stdio mode");
-                }
+                // "type" is now included for all clients (standard MCP protocol field).
+                Assert.AreEqual("stdio", (string)unity["type"],
+                    "All entries should advertise stdio transport type");
             }
         }
 


### PR DESCRIPTION
Config-related fix that should fix #909, #820

## Related Issues
<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional Notes
<!-- Any other information that reviewers should know -->

## Summary by Sourcery

Standardize MCP transport configuration metadata and improve logging behavior for console reading and command dispatch.

Bug Fixes:
- Ensure all MCP clients include the appropriate transport type field for HTTP and stdio configurations, including Cline-specific streamable HTTP endpoints.
- Prevent stale log entry counts by relying on StartGettingEntries() to determine the number of console entries during iteration.
- Record error responses in MCP command logs with explicit error status and message detail.

Enhancements:
- Align KiloCode configuration with non-VSCode layout to match its actual config structure.

Tests:
- Update configuration write tests to expect transport type metadata for all clients and transports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging to capture and include error details from command results.
  * Improved console entry count accuracy during retrieval operations.

* **Refactor**
  * Streamlined transport configuration generation for consistent handling across all client types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->