### PR TITLE
UIFix

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageUI.cs
+++ b/MCPForUnity/Editor/Tools/ManageUI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
@@ -19,6 +20,9 @@ namespace MCPForUnity.Editor.Tools
         {
             ".uxml", ".uss"
         };
+
+        // UTF-8 without BOM — UI Builder in Unity 6 can fail to open UXML files with a BOM.
+        private static readonly Encoding Utf8NoBom = new UTF8Encoding(false);
 
         static ManageUI()
         {
@@ -167,10 +171,35 @@ namespace MCPForUnity.Editor.Tools
                 Directory.CreateDirectory(dir);
             }
 
-            File.WriteAllText(fullPath, contents, Encoding.UTF8);
+            bool isUxml = path.EndsWith(".uxml", StringComparison.OrdinalIgnoreCase);
+            var validationWarnings = new List<string>();
+
+            if (isUxml)
+            {
+                string xmlError = ValidateUxmlContent(contents, validationWarnings);
+                if (xmlError != null)
+                {
+                    return new ErrorResponse($"UXML validation failed — file was NOT written. {xmlError}");
+                }
+            }
+
+            File.WriteAllText(fullPath, contents, Utf8NoBom);
             AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceUpdate);
 
-            return new SuccessResponse($"Created {Path.GetExtension(path).TrimStart('.')} file at {path}",
+            if (isUxml)
+            {
+                ValidateUxmlPostImport(path, validationWarnings);
+            }
+
+            string ext = Path.GetExtension(path).TrimStart('.');
+            if (validationWarnings.Count > 0)
+            {
+                return new SuccessResponse(
+                    $"Created {ext} file at {path} with {validationWarnings.Count} warning(s)",
+                    new { path, validationWarnings });
+            }
+
+            return new SuccessResponse($"Created {ext} file at {path}",
                 new { path });
         }
 
@@ -233,10 +262,35 @@ namespace MCPForUnity.Editor.Tools
                 return new ErrorResponse($"File not found: {path}. Use 'create' action for new files.");
             }
 
-            File.WriteAllText(fullPath, contents, Encoding.UTF8);
+            bool isUxml = path.EndsWith(".uxml", StringComparison.OrdinalIgnoreCase);
+            var validationWarnings = new List<string>();
+
+            if (isUxml)
+            {
+                string xmlError = ValidateUxmlContent(contents, validationWarnings);
+                if (xmlError != null)
+                {
+                    return new ErrorResponse($"UXML validation failed — file was NOT updated. {xmlError}");
+                }
+            }
+
+            File.WriteAllText(fullPath, contents, Utf8NoBom);
             AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceUpdate);
 
-            return new SuccessResponse($"Updated {Path.GetExtension(path).TrimStart('.')} file at {path}",
+            if (isUxml)
+            {
+                ValidateUxmlPostImport(path, validationWarnings);
+            }
+
+            string ext = Path.GetExtension(path).TrimStart('.');
+            if (validationWarnings.Count > 0)
+            {
+                return new SuccessResponse(
+                    $"Updated {ext} file at {path} with {validationWarnings.Count} warning(s)",
+                    new { path, validationWarnings });
+            }
+
+            return new SuccessResponse($"Updated {ext} file at {path}",
                 new { path });
         }
 
@@ -1203,10 +1257,10 @@ namespace MCPForUnity.Editor.Tools
             if (insertIdx < 0)
                 return new ErrorResponse("Could not find insertion point. Ensure UXML has a root <ui:UXML> or <UXML> element.");
 
-            string styleTag = $"\n    <Style src=\"project://database/{stylesheetPath}\" />";
+            string styleTag = $"\n    <ui:Style src=\"project://database/{stylesheetPath}\" />";
             content = content.Insert(insertIdx, styleTag);
 
-            File.WriteAllText(fullPath, content, Encoding.UTF8);
+            File.WriteAllText(fullPath, content, Utf8NoBom);
             AssetDatabase.ImportAsset(uxmlPath, ImportAssetOptions.ForceUpdate);
 
             return new SuccessResponse($"Linked stylesheet '{stylesheetPath}' to '{uxmlPath}'.",
@@ -1783,6 +1837,72 @@ namespace MCPForUnity.Editor.Tools
             }
 
             return p.Get("contents");
+        }
+
+        /// <summary>
+        /// Validates UXML content before writing to disk.
+        /// Returns null if valid, or an error message if malformed.
+        /// Populates warnings list with non-fatal issues.
+        /// Uses XmlParserContext to pre-declare common UXML namespace prefixes
+        /// (ui, uie, engine, editor) since Unity's parser is more lenient than System.Xml.
+        /// </summary>
+        private static string ValidateUxmlContent(string contents, List<string> warnings)
+        {
+            if (string.IsNullOrWhiteSpace(contents))
+                return "UXML content is empty.";
+
+            var nt = new NameTable();
+            var nsMgr = new XmlNamespaceManager(nt);
+            nsMgr.AddNamespace("ui", "UnityEngine.UIElements");
+            nsMgr.AddNamespace("uie", "UnityEditor.UIElements");
+            nsMgr.AddNamespace("engine", "UnityEngine.UIElements");
+            nsMgr.AddNamespace("editor", "UnityEditor.UIElements");
+            var ctx = new XmlParserContext(nt, nsMgr, null, XmlSpace.Default);
+
+            string rootLocalName = null;
+            try
+            {
+                using (var reader = XmlReader.Create(new StringReader(contents), null, ctx))
+                {
+                    while (reader.Read())
+                    {
+                        if (reader.NodeType == XmlNodeType.Element && rootLocalName == null)
+                            rootLocalName = reader.LocalName;
+                    }
+                }
+            }
+            catch (XmlException ex)
+            {
+                return $"Malformed XML at line {ex.LineNumber}, position {ex.LinePosition}: {ex.Message}";
+            }
+
+            if (rootLocalName == null)
+                return "UXML content has no root element.";
+
+            if (rootLocalName != "UXML")
+                warnings.Add($"Root element is <{rootLocalName}>, expected <UXML> or <ui:UXML>.");
+
+            if (!contents.Contains("UnityEngine.UIElements"))
+            {
+                warnings.Add("Missing namespace declaration xmlns:ui=\"UnityEngine.UIElements\". " +
+                              "UI Builder may fail to open this file.");
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Validates a UXML asset after import by attempting to load it as a VisualTreeAsset.
+        /// </summary>
+        private static void ValidateUxmlPostImport(string assetPath, List<string> warnings)
+        {
+            var asset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(assetPath);
+            if (asset == null)
+            {
+                warnings.Add("Unity failed to parse the UXML file. " +
+                              "The file was written but UI Builder will not be able to open it. " +
+                              "Check the console for details.");
+            }
         }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageUITests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageUITests.cs
@@ -645,6 +645,154 @@ namespace MCPForUnityTests.Editor.Tools
             }
         }
 
+        // ---- UXML validation ----
+
+        [Test]
+        public void Create_MalformedXml_ReturnsError_FileNotWritten()
+        {
+            string path = $"{TempRoot}/Malformed_{Guid.NewGuid():N}.uxml";
+            string badContent = "<ui:UXML><ui:Label text=\"unclosed\">";
+
+            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "create",
+                ["path"] = path,
+                ["contents"] = badContent,
+            }));
+
+            Assert.IsFalse(result.Value<bool>("success"));
+            Assert.That(result["error"].ToString(), Does.Contain("Malformed XML"));
+
+            // Verify file was NOT written
+            string fullPath = Path.Combine(Application.dataPath,
+                path.Substring("Assets/".Length)).Replace('/', Path.DirectorySeparatorChar);
+            Assert.IsFalse(File.Exists(fullPath), "Malformed UXML should not be written to disk");
+        }
+
+        [Test]
+        public void Create_MissingNamespace_WritesWithWarning()
+        {
+            string path = $"{TempRoot}/NoNs_{Guid.NewGuid():N}.uxml";
+            string content = "<ui:UXML><ui:Label text=\"hi\" /></ui:UXML>";
+
+            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "create",
+                ["path"] = path,
+                ["contents"] = content,
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JObject;
+            Assert.IsNotNull(data);
+            var warnings = data["validationWarnings"] as JArray;
+            Assert.IsNotNull(warnings, "Should have validationWarnings");
+            Assert.That(warnings.ToString(), Does.Contain("Missing namespace"));
+        }
+
+        [Test]
+        public void Create_ValidUxml_NoWarnings()
+        {
+            string path = $"{TempRoot}/Valid_{Guid.NewGuid():N}.uxml";
+            string content = "<ui:UXML xmlns:ui=\"UnityEngine.UIElements\"><ui:Label text=\"ok\" /></ui:UXML>";
+
+            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "create",
+                ["path"] = path,
+                ["contents"] = content,
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JObject;
+            Assert.IsNull(data?["validationWarnings"],
+                "Fully valid UXML should not have validationWarnings");
+        }
+
+        [Test]
+        public void Create_WrongRootElement_WritesWithWarning()
+        {
+            string path = $"{TempRoot}/WrongRoot_{Guid.NewGuid():N}.uxml";
+            string content = "<div xmlns:ui=\"UnityEngine.UIElements\"><ui:Label text=\"hi\" /></div>";
+
+            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "create",
+                ["path"] = path,
+                ["contents"] = content,
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JObject;
+            var warnings = data["validationWarnings"] as JArray;
+            Assert.IsNotNull(warnings, "Should have validationWarnings");
+            Assert.That(warnings.ToString(), Does.Contain("Root element"));
+        }
+
+        [Test]
+        public void Create_EmptyContent_ReturnsError()
+        {
+            string path = $"{TempRoot}/Empty_{Guid.NewGuid():N}.uxml";
+
+            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "create",
+                ["path"] = path,
+                ["contents"] = "   ",
+            }));
+
+            Assert.IsFalse(result.Value<bool>("success"));
+            Assert.That(result["error"].ToString(), Does.Contain("empty"));
+        }
+
+        [Test]
+        public void Update_MalformedXml_ReturnsError_FileNotChanged()
+        {
+            string path = $"{TempRoot}/UpdateMalformed_{Guid.NewGuid():N}.uxml";
+            string original = "<ui:UXML xmlns:ui=\"UnityEngine.UIElements\" />";
+
+            ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "create",
+                ["path"] = path,
+                ["contents"] = original,
+            });
+
+            string badContent = "<ui:UXML><broken>";
+            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "update",
+                ["path"] = path,
+                ["contents"] = badContent,
+            }));
+
+            Assert.IsFalse(result.Value<bool>("success"));
+            Assert.That(result["error"].ToString(), Does.Contain("Malformed XML"));
+
+            // Verify original content was preserved
+            string fullPath = Path.Combine(Application.dataPath,
+                path.Substring("Assets/".Length)).Replace('/', Path.DirectorySeparatorChar);
+            string actual = File.ReadAllText(fullPath);
+            Assert.AreEqual(original, actual, "Original file content should be preserved");
+        }
+
+        [Test]
+        public void Create_Uss_SkipsUxmlValidation()
+        {
+            string path = $"{TempRoot}/NoValidation_{Guid.NewGuid():N}.uss";
+            // USS is CSS-like, not XML — validation should be skipped
+            string content = "This is not valid XML <broken>";
+
+            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            {
+                ["action"] = "create",
+                ["path"] = path,
+                ["contents"] = content,
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+        }
+
         // ---- Path traversal validation ----
 
         [Test]


### PR DESCRIPTION
UI toolkit BOM fix and UXML validation fix

## Summary by Sourcery

Add UXML content validation and BOM-safe file writing for UI asset management commands.

Bug Fixes:
- Prevent writing malformed UXML files on create or update operations and preserve existing file contents when validation fails.
- Avoid UI Builder issues by writing UXML and related files using UTF-8 without BOM and using the correct <ui:Style> tag in linked stylesheets.

Enhancements:
- Return structured UXML validation warnings for non-fatal issues such as missing namespaces or unexpected root elements when creating or updating files.
- Add post-import validation of UXML assets by attempting to load them as VisualTreeAsset objects to detect Unity parsing failures.

Tests:
- Add comprehensive tests covering UXML validation behavior, including malformed XML, empty content, missing namespaces, wrong root elements, preserved contents on failed updates, and skipping validation for USS files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UXML validation warnings for file operations to help identify potential issues early.

* **Bug Fixes**
  * Fixed file encoding for UI files to use UTF-8 without BOM, improving compatibility.
  * Enhanced UXML validation to prevent malformed content from being written to disk.
  * Added post-import validation checks for generated UI files to ensure proper parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->