### PR TITLE
UI and urp material assignmetn fix

### DIFF
--- a/.claude/skills/unity-mcp-skill/references/tools-reference.md
+++ b/.claude/skills/unity-mcp-skill/references/tools-reference.md
@@ -669,6 +669,8 @@ manage_ui(
 3. Create an empty GameObject and attach UIDocument with the UXML source
 4. Use `get_visual_tree` to inspect the result
 
+**Important:** Always use `<ui:Style>` (with the `ui:` namespace prefix) in UXML files, not bare `<Style>`. UI Builder will fail to open files that use `<Style>` without the prefix.
+
 ---
 
 ## Editor Control Tools

--- a/.claude/skills/unity-mcp-skill/references/workflows.md
+++ b/.claude/skills/unity-mcp-skill/references/workflows.md
@@ -607,6 +607,8 @@ Unity has two UI systems: **UI Toolkit** (modern, recommended) and **uGUI** (Can
 
 UI Toolkit uses a web-like approach: **UXML** (like HTML) for structure, **USS** (like CSS) for styling. This is the preferred UI system for new projects.
 
+> **Important:** Always use `<ui:Style>` (with the `ui:` namespace prefix) in UXML, not bare `<Style>`. UI Builder will fail to open files that use `<Style>` without the prefix.
+
 #### Create a Complete UI Screen
 
 ```python

--- a/MCPForUnity/Editor/Tools/ManageMaterial.cs
+++ b/MCPForUnity/Editor/Tools/ManageMaterial.cs
@@ -258,7 +258,7 @@ namespace MCPForUnity.Editor.Tools
             }
 
             int slot = p.GetInt("slot") ?? 0;
-            string mode = p.Get("mode", "property_block");
+            string mode = p.Get("mode", "create_unique");
 
             Color color;
             try
@@ -390,7 +390,18 @@ namespace MCPForUnity.Editor.Tools
         private static object CreateUniqueAndAssign(Renderer renderer, GameObject go, Color color, int slot)
         {
             string safeName = go.name.Replace(" ", "_");
-            string matPath = $"Assets/Materials/{safeName}_{go.GetInstanceID()}_mat.mat";
+
+            // Derive material folder from the scene context so generated materials
+            // live next to the scene/generation folder instead of a global dump.
+            string materialFolder = "Assets/Materials";
+            var scene = go.scene;
+            if (scene.IsValid() && !string.IsNullOrEmpty(scene.path))
+            {
+                string sceneDir = System.IO.Path.GetDirectoryName(scene.path).Replace("\\", "/");
+                materialFolder = $"{sceneDir}/Materials";
+            }
+
+            string matPath = $"{materialFolder}/{safeName}_{go.GetInstanceID()}_mat.mat";
             matPath = AssetPathUtility.SanitizeAssetPath(matPath);
             if (matPath == null)
             {
@@ -398,9 +409,11 @@ namespace MCPForUnity.Editor.Tools
             }
 
             // Ensure the Materials directory exists
-            if (!AssetDatabase.IsValidFolder("Assets/Materials"))
+            if (!AssetDatabase.IsValidFolder(materialFolder))
             {
-                AssetDatabase.CreateFolder("Assets", "Materials");
+                string parentDir = System.IO.Path.GetDirectoryName(materialFolder).Replace("\\", "/");
+                string folderName = System.IO.Path.GetFileName(materialFolder);
+                AssetDatabase.CreateFolder(parentDir, folderName);
             }
 
             Material existing = AssetDatabase.LoadAssetAtPath<Material>(matPath);

--- a/Server/src/cli/commands/material.py
+++ b/Server/src/cli/commands/material.py
@@ -161,7 +161,7 @@ def set_property(path: str, property_name: str, value: str):
 )
 @click.option(
     "--mode", "-m",
-    type=click.Choice(["shared", "instance", "property_block"]),
+    type=click.Choice(["shared", "instance", "property_block", "create_unique"]),
     default="shared",
     help="Assignment mode."
 )
@@ -208,9 +208,9 @@ def assign(material_path: str, target: str, search_method: Optional[str], slot: 
 )
 @click.option(
     "--mode", "-m",
-    type=click.Choice(["shared", "instance", "property_block"]),
-    default="property_block",
-    help="Modification mode."
+    type=click.Choice(["shared", "instance", "property_block", "create_unique"]),
+    default="create_unique",
+    help="Modification mode (default: create_unique — persistent per-object material)."
 )
 @handle_unity_errors
 def set_renderer_color(target: str, r: float, g: float, b: float, a: float, search_method: Optional[str], mode: str):

--- a/Server/src/services/tools/manage_material.py
+++ b/Server/src/services/tools/manage_material.py
@@ -58,8 +58,8 @@ async def manage_material(
     search_method: Annotated[Literal["by_id", "by_name", "by_path", "by_tag",
                                      "by_layer", "by_component"], "Search method for target"] | None = None,
     slot: Annotated[int, "Material slot index (0-based)"] | None = None,
-    mode: Annotated[Literal["shared", "instance", "property_block"],
-                    "Assignment/modification mode"] | None = None,
+    mode: Annotated[Literal["shared", "instance", "property_block", "create_unique"],
+                    "Assignment/modification mode (default: create_unique — creates a persistent per-object material)"] | None = None,
 
 ) -> dict[str, Any]:
     unity_instance = await get_unity_instance_from_context(ctx)

--- a/Server/src/services/tools/manage_ui.py
+++ b/Server/src/services/tools/manage_ui.py
@@ -42,7 +42,9 @@ _VALID_EXTENSIONS = {".uxml", ".uss"}
         "     call render_ui a second time to retrieve the saved PNG (hasContent will be true).\n"
         "   - In editor mode: assigns a RenderTexture to PanelSettings (best-effort; may stay blank).\n"
         "9. Use detach_ui_document to remove UIDocument from a GameObject\n"
-        "10. Use delete to remove .uxml/.uss files"
+        "10. Use delete to remove .uxml/.uss files\n\n"
+        "Important: Always use <ui:Style> (with the ui: namespace prefix) in UXML, not bare <Style>. "
+        "UI Builder will fail to open files that use <Style> without the prefix."
     ),
     annotations=ToolAnnotations(
         title="Manage UI",

--- a/unity-mcp-skill/references/tools-reference.md
+++ b/unity-mcp-skill/references/tools-reference.md
@@ -671,6 +671,8 @@ manage_ui(
 3. Create an empty GameObject and attach UIDocument with the UXML source
 4. Use `get_visual_tree` to inspect the result
 
+**Important:** Always use `<ui:Style>` (with the `ui:` namespace prefix) in UXML files, not bare `<Style>`. UI Builder will fail to open files that use `<Style>` without the prefix.
+
 ---
 
 ## Editor Control Tools

--- a/unity-mcp-skill/references/workflows.md
+++ b/unity-mcp-skill/references/workflows.md
@@ -610,6 +610,8 @@ Unity has two UI systems: **UI Toolkit** (modern, recommended) and **uGUI** (Can
 
 UI Toolkit uses a web-like approach: **UXML** (like HTML) for structure, **USS** (like CSS) for styling. This is the preferred UI system for new projects.
 
+> **Important:** Always use `<ui:Style>` (with the `ui:` namespace prefix) in UXML, not bare `<Style>`. UI Builder will fail to open files that use `<Style>` without the prefix.
+
 #### Create a Complete UI Screen
 
 ```python


### PR DESCRIPTION
1. Add UXML <style> format to prevent UXML showing wrong
2. Use unique instead of default property block to prevent all materials showing the same color in URP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "create_unique" mode option for material operations, enabling persistent per-object material creation.
  * Introduced scene-aware material folder derivation—materials now default to a scene-relative Materials folder when available.

* **Changes**
  * Updated default material mode from "property_block" to "create_unique" for color rendering.

* **Documentation**
  * Added guidance on proper UXML syntax: always use `<ui:Style>` with ui: namespace prefix to prevent UI Builder failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->