### PR TITLE
Update TestRunnerService.cs

### DIFF
--- a/MCPForUnity/Editor/Services/TestRunnerService.cs
+++ b/MCPForUnity/Editor/Services/TestRunnerService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,132 @@ using UnityEngine.SceneManagement;
 
 namespace MCPForUnity.Editor.Services
 {
+    /// <summary>
+    /// Restores <see cref="EditorSettings.enterPlayModeOptionsEnabled"/> and
+    /// <see cref="EditorSettings.enterPlayModeOptions"/> if a previous test run was interrupted
+    /// (e.g. by domain reload or editor crash) before <see cref="TestRunnerService"/> could restore them.
+    /// Two persistence layers:
+    /// <list type="bullet">
+    /// <item><see cref="SessionState"/> — survives domain reloads within the same editor session.</item>
+    /// <item>A marker file in <c>Library/</c> — survives editor crashes and force quits.</item>
+    /// </list>
+    /// </summary>
+    [InitializeOnLoad]
+    internal static class PlayModeOptionsGuard
+    {
+        private const string KeyPending = "MCPForUnity.PlayModeOptions.PendingRestore";
+        private const string KeyEnabled = "MCPForUnity.PlayModeOptions.OriginalEnabled";
+        private const string KeyOptions = "MCPForUnity.PlayModeOptions.OriginalOptions";
+
+        // Library/ is project-local and gitignored by default.
+        private static readonly string MarkerPath = Path.Combine("Library", "MCPPlayModeOptionsBackup.txt");
+
+        static PlayModeOptionsGuard()
+        {
+            // After domain reload or editor restart: if a restore is pending and no test run
+            // is active, restore now. TryLoad checks SessionState first, then the marker file.
+            if (TryLoad(out _, out _) && !TestRunStatus.IsRunning)
+            {
+                Restore();
+            }
+        }
+
+        internal static bool IsPending => TryLoad(out _, out _);
+
+        internal static void Save(bool originalEnabled, EnterPlayModeOptions originalOptions)
+        {
+            // SessionState (domain reload)
+            SessionState.SetBool(KeyEnabled, originalEnabled);
+            SessionState.SetInt(KeyOptions, (int)originalOptions);
+            SessionState.SetBool(KeyPending, true);
+
+            // Marker file (crash recovery). Two lines: enabled flag, then options int.
+            try
+            {
+                File.WriteAllText(MarkerPath, $"{(originalEnabled ? 1 : 0)}\n{(int)originalOptions}");
+            }
+            catch (Exception ex)
+            {
+                McpLog.Warn($"[PlayModeOptionsGuard] Failed to write marker file: {ex.Message}");
+            }
+        }
+
+        internal static void Restore()
+        {
+            if (!TryLoad(out bool origEnabled, out EnterPlayModeOptions origOptions))
+            {
+                return;
+            }
+
+            EditorSettings.enterPlayModeOptions = origOptions;
+            EditorSettings.enterPlayModeOptionsEnabled = origEnabled;
+            Clear();
+            McpLog.Info("[PlayModeOptionsGuard] Restored enterPlayModeOptions after interrupted test run.");
+        }
+
+        internal static void Clear()
+        {
+            SessionState.SetBool(KeyPending, false);
+            try
+            {
+                if (File.Exists(MarkerPath))
+                {
+                    File.Delete(MarkerPath);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+
+        /// <summary>
+        /// Checks SessionState first (available after domain reload), then falls back to the
+        /// marker file (available after editor crash/restart).
+        /// </summary>
+        private static bool TryLoad(out bool originalEnabled, out EnterPlayModeOptions originalOptions)
+        {
+            // Fast path: SessionState is available after domain reload.
+            if (SessionState.GetBool(KeyPending, false))
+            {
+                originalEnabled = SessionState.GetBool(KeyEnabled, false);
+                originalOptions = (EnterPlayModeOptions)SessionState.GetInt(KeyOptions, 0);
+                return true;
+            }
+
+            // Slow path: marker file survives editor crash/restart.
+            originalEnabled = false;
+            originalOptions = EnterPlayModeOptions.None;
+            try
+            {
+                if (!File.Exists(MarkerPath))
+                {
+                    return false;
+                }
+
+                string[] lines = File.ReadAllLines(MarkerPath);
+                if (lines.Length < 2)
+                {
+                    return false;
+                }
+
+                if (!int.TryParse(lines[0].Trim(), out int enabledInt) ||
+                    !int.TryParse(lines[1].Trim(), out int optionsInt))
+                {
+                    return false;
+                }
+
+                originalEnabled = enabledInt != 0;
+                originalOptions = (EnterPlayModeOptions)optionsInt;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
     /// <summary>
     /// Concrete implementation of <see cref="ITestRunnerService"/>.
     /// Coordinates Unity Test Runner operations and produces structured results.
@@ -205,7 +332,15 @@ namespace MCPForUnity.Editor.Services
             TestJobManager.OnRunFinished();
             TestJobManager.FinalizeCurrentJobFromRunFinished(payload);
 
-            // Report result to awaiting caller if we have a completion source
+            // If a domain reload destroyed the original RunTestsAsync caller, the finally block
+            // that would normally restore EditorSettings never ran. Restore from SessionState.
+            if (_runCompletionSource == null && PlayModeOptionsGuard.IsPending)
+            {
+                PlayModeOptionsGuard.Restore();
+            }
+
+            // Report result to awaiting caller if we have a completion source.
+            // The caller's finally block handles restoration in this case.
             if (_runCompletionSource != null)
             {
                 _runCompletionSource.TrySetResult(payload);
@@ -324,6 +459,10 @@ namespace MCPForUnity.Editor.Services
                 return false;
             }
 
+            // Persist originals to SessionState so they survive domain reloads. If the run is
+            // interrupted (domain reload, crash), PlayModeOptionsGuard restores them on next load.
+            PlayModeOptionsGuard.Save(originalEnterPlayModeOptionsEnabled, originalEnterPlayModeOptions);
+
             var desired = originalEnterPlayModeOptions | EnterPlayModeOptions.DisableDomainReload;
             EditorSettings.enterPlayModeOptionsEnabled = true;
             EditorSettings.enterPlayModeOptions = desired;
@@ -334,6 +473,7 @@ namespace MCPForUnity.Editor.Services
         {
             EditorSettings.enterPlayModeOptions = originalOptions;
             EditorSettings.enterPlayModeOptionsEnabled = originalEnabled;
+            PlayModeOptionsGuard.Clear();
         }
 
         private static void SaveDirtyScenesIfNeeded()


### PR DESCRIPTION
Fix on issue#932, prevent the two params being the same after Domain Reload or Editor Crash/Force Quit by storing a Library/ mark file and a SessionState.

## Summary by Sourcery

Add a guard to persist and restore Unity play mode options across domain reloads or editor crashes during test runs to prevent leaving modified settings behind.

Enhancements:
- Introduce a PlayModeOptionsGuard that stores original play mode options in SessionState and a Library marker file for recovery after interrupted test runs.
- Integrate the guard into the test runner lifecycle to restore or clear play mode options when runs finish or are interrupted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test runner stability by ensuring editor settings are properly preserved and restored when domain reloads or editor crashes occur during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->