### PR TITLE
fix: BuildReport.SummarizeErrors() compile error on Unity 2022.3

### DIFF
--- a/MCPForUnity/Editor/Tools/Build/BuildRunner.cs
+++ b/MCPForUnity/Editor/Tools/Build/BuildRunner.cs
@@ -111,11 +111,7 @@ namespace MCPForUnity.Editor.Tools.Build
                 else
                 {
                     job.State = BuildJobState.Failed;
-#if UNITY_2022_3_OR_NEWER
-                    job.ErrorMessage = report.SummarizeErrors();
-#else
-                    job.ErrorMessage = $"Build failed with result: {summary.result}";
-#endif
+                    job.ErrorMessage = GetBuildErrorMessage(report);
                 }
             }
             catch (Exception ex)
@@ -206,6 +202,22 @@ namespace MCPForUnity.Editor.Tools.Build
                 action();
             }
             EditorApplication.update += RunOnce;
+        }
+
+        private static string GetBuildErrorMessage(BuildReport report)
+        {
+            var summary = report.summary;
+
+#if UNITY_2023_1_OR_NEWER
+            var msg = report.SummarizeErrors();
+            if (!string.IsNullOrEmpty(msg))
+                return msg;
+#endif
+
+            if (summary.totalErrors > 0)
+                return $"{summary.totalErrors} build error(s)";
+
+            return $"Build failed with result: {summary.result}";
         }
 
         private static string[] GetDefaultScenes()


### PR DESCRIPTION
## Summary

Fixes #984

`BuildReport.SummarizeErrors()` was introduced in **Unity 2023.1**, but the preprocessor guard used `UNITY_2022_3_OR_NEWER`, causing a `CS1061` compile error on Unity 2022.3 LTS.

## Changes

- Extracted error message logic into a `GetBuildErrorMessage()` helper method
- Changed the version guard from `UNITY_2022_3_OR_NEWER` to `UNITY_2023_1_OR_NEWER`
- Added empty string fallback since `SummarizeErrors()` can return empty on some build failures
- Added error count fallback (`"{n} build error(s)"`) for pre-2023.1 Unity versions, providing more useful info than the previous generic message

## Affected Versions

| Unity Version | Before | After |
|---------------|--------|-------|
| 2022.3 LTS | CS1061 compile error | Falls back to error count / result message |
| 2023.1+ | Works | Works (with empty string safety) |
| Unity 6 (6000.x) | Works | Works (with empty string safety) |

## Test Plan

- [ ] Verify compilation on Unity 2022.3 LTS
- [ ] Verify `SummarizeErrors()` works on Unity 2023.1+
- [ ] Verify fallback message on failed builds (pre-2023.1)

## Summary by Sourcery

Fix build error handling across Unity versions by centralizing error message generation and correcting the version guard for BuildReport.SummarizeErrors.

Bug Fixes:
- Resolve CS1061 compile error on Unity 2022.3 by guarding usage of BuildReport.SummarizeErrors with the correct Unity 2023.1+ preprocessor symbol.
- Ensure builds that fail on Unity 2023.1+ handle empty responses from BuildReport.SummarizeErrors safely.

Enhancements:
- Introduce a shared GetBuildErrorMessage helper to provide consistent, informative build failure messages across Unity versions, including an error count fallback when available.