### PR TITLE
feat(manage_editor): add open_prefab_stage and save_prefab_stage actions

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageEditor.cs
+++ b/MCPForUnity/Editor/Tools/ManageEditor.cs
@@ -417,7 +417,8 @@ namespace MCPForUnity.Editor.Tools
                     return new ErrorResponse($"Prefab not found at path: '{prefabPath}'.");
                 }
 
-                if (PrefabUtility.GetPrefabAssetType(asset) == PrefabAssetType.NotAPrefab)
+                var prefabType = PrefabUtility.GetPrefabAssetType(asset);
+                if (prefabType == PrefabAssetType.NotAPrefab)
                 {
                     return new ErrorResponse($"Asset at '{prefabPath}' is not a prefab.");
                 }
@@ -430,7 +431,7 @@ namespace MCPForUnity.Editor.Tools
 
                 return new SuccessResponse(
                     $"Opened prefab stage for '{prefabPath}'. Use manage_gameobject/manage_components to edit objects inside, then save_prefab_stage to persist changes.",
-                    new { prefabPath, rootName = stage.prefabContentsRoot.name });
+                    new { prefabPath, rootName = stage.prefabContentsRoot.name, prefabType = prefabType.ToString() });
             }
             catch (Exception e)
             {
@@ -445,16 +446,19 @@ namespace MCPForUnity.Editor.Tools
                 var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
                 if (prefabStage == null)
                 {
-                    return new SuccessResponse("Not currently in prefab editing mode. Nothing to save.");
+                    return new ErrorResponse("Not currently in prefab editing mode. Open a prefab stage first with open_prefab_stage.");
                 }
 
                 string prefabPath = prefabStage.assetPath;
 
-                // Mark the prefab stage scene as dirty then save
                 EditorSceneManager.MarkSceneDirty(prefabStage.scene);
-                EditorSceneManager.SaveScene(prefabStage.scene);
+                bool saved = EditorSceneManager.SaveScene(prefabStage.scene);
+                if (!saved)
+                {
+                    return new ErrorResponse($"Failed to save prefab stage for '{prefabPath}'. The file may be read-only or the disk may be full.");
+                }
 
-                return new SuccessResponse($"Saved prefab stage changes for '{prefabPath}'.", new { prefabPath });
+                return new SuccessResponse($"Saved prefab stage changes for '{prefabPath}'.", new { prefabPath, saved });
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary

Closes #976

Adds `open_prefab_stage` and `save_prefab_stage` actions to `manage_editor`, completing the prefab stage workflow alongside the existing `close_prefab_stage`.

## Problem

There was no way to programmatically open a prefab in Prefab Mode via MCP. Users had to manually double-click prefabs in the Editor before AI agents could modify objects inside them. The existing `manage_gameobject` and `manage_components` tools already support prefab stage (via `GameObjectLookup.GetAllSceneObjects()` which checks `PrefabStageUtility.GetCurrentPrefabStage()`), but there was no MCP action to enter the stage.

## Changes

**New actions in `manage_editor`:**

| Action | Parameter | Description |
|--------|-----------|-------------|
| `open_prefab_stage` | `path` (required) | Opens a prefab in Prefab Mode using `PrefabStageUtility.OpenPrefab()`. Validates the asset exists and is a prefab. |
| `save_prefab_stage` | — | Saves changes in the currently open prefab stage back to the prefab asset. |

**Updated:** Supported actions list in the error message now includes the new actions.

## Workflow

```
manage_editor(action="open_prefab_stage", path="Assets/Prefabs/MyPrefab.prefab")
  → manage_gameobject / manage_components (modify objects inside)
  → manage_editor(action="save_prefab_stage")
  → manage_editor(action="close_prefab_stage")
```

**Alternative headless approach** (already works, no stage needed):
```
manage_prefabs(action="modify_contents", path="...", componentProperties={...})
```

## Implementation Details

- Uses `PrefabStageUtility.OpenPrefab(path)` (not `AssetDatabase.OpenAsset`) as it is purpose-built for Prefab Mode
- Validates asset exists and is actually a prefab before opening
- Returns root object name on success for easy subsequent tool calls
- Save uses `EditorSceneManager.MarkSceneDirty` + `SaveScene` on the prefab stage scene
- Follows the same error handling pattern as existing `close_prefab_stage`

## Test Plan

- [ ] Open a prefab via `open_prefab_stage`, verify stage is active
- [ ] Modify objects inside via `manage_components` `set_property`
- [ ] Save via `save_prefab_stage`, verify changes persist in the `.prefab` asset
- [ ] Close via `close_prefab_stage`, verify return to main scene
- [ ] Error case: invalid path, non-prefab asset, no stage open when saving
- [ ] Verify existing `close_prefab_stage` still works unchanged

## Summary by Sourcery

Add support in the editor management tool for opening and saving Unity prefab stages to complete the prefab editing workflow.

New Features:
- Introduce an open_prefab_stage action to open a prefab in Prefab Mode by asset path and return basic metadata.
- Introduce a save_prefab_stage action to persist changes made in the currently open prefab stage.

Enhancements:
- Expand the unknown-action error message to list the new prefab stage actions alongside existing manage_editor actions.