### PR TITLE
When there are multiple Editor folders, fix the issue by retrieving t…

### DIFF
--- a/MCPForUnity/Editor/Helpers/AssetPathUtility.cs
+++ b/MCPForUnity/Editor/Helpers/AssetPathUtility.cs
@@ -127,7 +127,7 @@ namespace MCPForUnity.Editor.Helpers
 
                 // Script is at: {packageRoot}/Editor/Helpers/AssetPathUtility.cs
                 // Extract {packageRoot}
-                int editorIndex = scriptPath.IndexOf("/Editor/", StringComparison.Ordinal);
+                int editorIndex = scriptPath.LastIndexOf("/Editor/", StringComparison.Ordinal);
 
                 if (editorIndex >= 0)
                 {


### PR DESCRIPTION
When there are multiple Editor folders, fix the issue by retrieving the index of the last Editor.

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect MCP package root resolution when projects contain more than one Editor folder in the script path hierarchy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package root path detection to correctly handle projects with multiple nested directory levels. The tool now reliably identifies your package location across various project structures and directory hierarchies, ensuring stable operation regardless of path complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->