### PR TITLE
Bug-fix

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageBuild.cs
+++ b/MCPForUnity/Editor/Tools/ManageBuild.cs
@@ -310,14 +310,42 @@ namespace MCPForUnity.Editor.Tools
                 return new SuccessResponse($"Build scenes ({scenes.Length}).", new { scenes });
             }
 
-            // Write scene list
+            // Handle string input: try JSON parse, then comma-separated
+            if (scenesRaw.Type == JTokenType.String)
+            {
+                string scenesStr = scenesRaw.ToString();
+                try { scenesRaw = JArray.Parse(scenesStr); }
+                catch
+                {
+                    // Treat as comma-separated paths
+                    var paths = scenesStr.Split(',')
+                        .Select(s => s.Trim())
+                        .Where(s => !string.IsNullOrEmpty(s))
+                        .ToArray();
+                    if (paths.Length == 0)
+                        return new ErrorResponse("'scenes' string contained no valid paths.");
+                    var fromStr = paths.Select(sp => new EditorBuildSettingsScene(sp, true)).ToArray();
+                    EditorBuildSettings.scenes = fromStr;
+                    return new SuccessResponse($"Updated build scenes ({fromStr.Length}).", new
+                    {
+                        scenes = fromStr.Select(s => new { path = s.path, enabled = s.enabled }).ToArray()
+                    });
+                }
+            }
+
+            // Write scene list — accepts array of strings or array of {path, enabled} objects
             var sceneArray = scenesRaw as JArray;
             if (sceneArray == null)
-                return new ErrorResponse("'scenes' must be an array of {path, enabled} objects.");
+                return new ErrorResponse("'scenes' must be an array of scene paths or {path, enabled} objects.");
 
             var newScenes = new List<EditorBuildSettingsScene>();
             foreach (var item in sceneArray)
             {
+                if (item.Type == JTokenType.String)
+                {
+                    newScenes.Add(new EditorBuildSettingsScene(item.ToString(), true));
+                    continue;
+                }
                 string path = item["path"]?.ToString();
                 if (string.IsNullOrEmpty(path))
                     return new ErrorResponse("Each scene must have a 'path' field.");
@@ -373,8 +401,9 @@ namespace MCPForUnity.Editor.Tools
                 });
             }
 
-            // Get profile details
-            var profileScenes = loadedProfile.GetScenesForBuild()
+            // Get profile details — use .scenes (available since Unity 6000.0.0)
+            // instead of .GetScenesForBuild() which was added in 6000.0.36
+            var profileScenes = loadedProfile.scenes
                 .Select(s => s.path).ToArray();
             return new SuccessResponse($"Profile: {profilePath}", new
             {

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -178,6 +178,14 @@ namespace MCPForUnity.Editor.Tools
                 {
                     relativeDir = relativeDir.Substring("Assets/".Length).TrimStart('/');
                 }
+                // If path ends with .unity, it's a full scene path — extract just the directory
+                if (relativeDir.EndsWith(".unity", StringComparison.OrdinalIgnoreCase))
+                {
+                    string dirPart = Path.GetDirectoryName(relativeDir);
+                    relativeDir = string.IsNullOrEmpty(dirPart)
+                        ? string.Empty
+                        : AssetPathUtility.NormalizeSeparators(dirPart);
+                }
             }
 
             // Apply default *after* sanitizing, using the original path variable for the check

--- a/Server/uv.lock
+++ b/Server/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "mcpforunityserver"
-version = "9.6.2"
+version = "9.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes for #1002, #1003, and one other issue encountered in the discord community about using GetScenesForBuild not working in some of the early Unity 6 versions.

## Summary by Sourcery

Handle build scene configuration more flexibly and improve compatibility with early Unity 6 versions when reading profile scenes and resolving scene directories.

New Features:
- Allow the build scene list to be provided as a JSON array, a stringified JSON array, or a comma-separated string of scene paths.

Bug Fixes:
- Support arrays of plain scene path strings in addition to {path, enabled} objects when updating build scenes.
- Use the profile's scenes property instead of GetScenesForBuild to avoid failures on early Unity 6 versions.
- Correct scene directory resolution by stripping the .unity file name when a full scene path is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Build scene configuration now accepts multiple input formats: JSON arrays and comma-separated lists
  * Scene definitions support both simple path strings and objects with enabled status

* **Bug Fixes**
  * Improved scene path handling for better compatibility with Unity scene file definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->