### PR TITLE
feat: Add configurable init_timeout for PlayMode test initialization

### DIFF
--- a/MCPForUnity/Editor/Services/TestJobManager.cs
+++ b/MCPForUnity/Editor/Services/TestJobManager.cs
@@ -52,6 +52,7 @@ namespace MCPForUnity.Editor.Services
         private const int FailureCap = 25;
         private const long StuckThresholdMs = 60_000;
         private const long DefaultInitializationTimeoutMs = 15_000; // 15 seconds default; override per-job via run_tests init_timeout param
+        private const long MaxInitializationTimeoutMs = 600_000; // 10 minutes hard cap
         private const int MaxJobsToKeep = 10;
         private const long MinPersistIntervalMs = 1000; // Throttle persistence to reduce overhead
 
@@ -300,6 +301,10 @@ namespace MCPForUnity.Editor.Services
 
         public static string StartJob(TestMode mode, TestFilterOptions filterOptions = null, long initTimeoutMs = 0)
         {
+            // Clamp to valid range: non-positive values mean "use default", cap at 10 minutes
+            if (initTimeoutMs < 0) initTimeoutMs = 0;
+            if (initTimeoutMs > MaxInitializationTimeoutMs) initTimeoutMs = MaxInitializationTimeoutMs;
+
             string jobId = Guid.NewGuid().ToString("N");
             long started = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             string modeStr = mode.ToString();

--- a/MCPForUnity/Editor/Services/TestJobManager.cs
+++ b/MCPForUnity/Editor/Services/TestJobManager.cs
@@ -40,6 +40,7 @@ namespace MCPForUnity.Editor.Services
         public List<TestJobFailure> FailuresSoFar { get; set; }
         public string Error { get; set; }
         public TestRunResult Result { get; set; }
+        public long InitTimeoutMs { get; set; }
     }
 
     /// <summary>
@@ -50,7 +51,7 @@ namespace MCPForUnity.Editor.Services
         // Keep this small to avoid ballooning payloads during polling.
         private const int FailureCap = 25;
         private const long StuckThresholdMs = 60_000;
-        private const long InitializationTimeoutMs = 15_000; // 15 seconds to call OnRunStarted, else fail
+        private const long DefaultInitializationTimeoutMs = 15_000; // 15 seconds default; override per-job via run_tests init_timeout param
         private const int MaxJobsToKeep = 10;
         private const long MinPersistIntervalMs = 1000; // Throttle persistence to reduce overhead
 
@@ -139,6 +140,7 @@ namespace MCPForUnity.Editor.Services
             public long? last_finished_unix_ms { get; set; }
             public List<TestJobFailure> failures_so_far { get; set; }
             public string error { get; set; }
+            public long init_timeout_ms { get; set; }
         }
 
         private static TestJobStatus ParseStatus(string status)
@@ -201,6 +203,7 @@ namespace MCPForUnity.Editor.Services
                             LastFinishedUnixMs = pj.last_finished_unix_ms,
                             FailuresSoFar = pj.failures_so_far ?? new List<TestJobFailure>(),
                             Error = pj.error,
+                            InitTimeoutMs = pj.init_timeout_ms,
                             // Intentionally not persisted to avoid ballooning SessionState.
                             Result = null
                         };
@@ -273,7 +276,8 @@ namespace MCPForUnity.Editor.Services
                             last_finished_test_full_name = j.LastFinishedTestFullName,
                             last_finished_unix_ms = j.LastFinishedUnixMs,
                             failures_so_far = (j.FailuresSoFar ?? new List<TestJobFailure>()).Take(FailureCap).ToList(),
-                            error = j.Error
+                            error = j.Error,
+                            init_timeout_ms = j.InitTimeoutMs
                         })
                         .ToList();
 
@@ -294,7 +298,7 @@ namespace MCPForUnity.Editor.Services
             }
         }
 
-        public static string StartJob(TestMode mode, TestFilterOptions filterOptions = null)
+        public static string StartJob(TestMode mode, TestFilterOptions filterOptions = null, long initTimeoutMs = 0)
         {
             string jobId = Guid.NewGuid().ToString("N");
             long started = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -316,7 +320,8 @@ namespace MCPForUnity.Editor.Services
                 LastFinishedUnixMs = null,
                 FailuresSoFar = new List<TestJobFailure>(),
                 Error = null,
-                Result = null
+                Result = null,
+                InitTimeoutMs = initTimeoutMs
             };
 
             // Single lock scope for check-and-set to avoid TOCTOU race
@@ -491,9 +496,10 @@ namespace MCPForUnity.Editor.Services
                 if (job.Status == TestJobStatus.Running && job.TotalTests == null)
                 {
                     long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-                    if (!EditorApplication.isCompiling && !EditorApplication.isUpdating && now - job.StartedUnixMs > InitializationTimeoutMs)
+                    long initTimeout = job.InitTimeoutMs > 0 ? job.InitTimeoutMs : DefaultInitializationTimeoutMs;
+                    if (!EditorApplication.isCompiling && !EditorApplication.isUpdating && now - job.StartedUnixMs > initTimeout)
                     {
-                        McpLog.Warn($"[TestJobManager] Job {jobId} failed to initialize within {InitializationTimeoutMs}ms, auto-failing");
+                        McpLog.Warn($"[TestJobManager] Job {jobId} failed to initialize within {initTimeout}ms, auto-failing");
                         job.Status = TestJobStatus.Failed;
                         job.Error = "Test job failed to initialize (tests did not start within timeout)";
                         job.FinishedUnixMs = now;

--- a/MCPForUnity/Editor/Tools/RunTests.cs
+++ b/MCPForUnity/Editor/Tools/RunTests.cs
@@ -45,7 +45,8 @@ namespace MCPForUnity.Editor.Tools
                 bool includeFailedTests = p.GetBool("includeFailedTests");
 
                 var filterOptions = GetFilterOptions(@params);
-                string jobId = TestJobManager.StartJob(parsedMode.Value, filterOptions);
+                long initTimeoutMs = p.GetInt("initTimeout") ?? 0;
+                string jobId = TestJobManager.StartJob(parsedMode.Value, filterOptions, initTimeoutMs);
 
                 return Task.FromResult<object>(new SuccessResponse("Test job started.", new
                 {

--- a/Server/src/services/tools/run_tests.py
+++ b/Server/src/services/tools/run_tests.py
@@ -171,6 +171,9 @@ async def run_tests(
                             "Initialization timeout in milliseconds. PlayMode tests may need longer "
                             "due to domain reload (default: 15000). Recommended: 120000 for PlayMode."] = None,
 ) -> RunTestsStartResponse | MCPResponse:
+    if init_timeout is not None and init_timeout <= 0:
+        return MCPResponse(success=False, error="init_timeout must be a positive integer (milliseconds) or None")
+
     unity_instance = await get_unity_instance_from_context(ctx)
 
     gate = await preflight(ctx, requires_no_tests=True, wait_for_no_compile=True, refresh_if_dirty=True)

--- a/Server/src/services/tools/run_tests.py
+++ b/Server/src/services/tools/run_tests.py
@@ -167,6 +167,9 @@ async def run_tests(
                                     "Include details for failed/skipped tests only (default: false)"] = False,
     include_details: Annotated[bool,
                                "Include details for all tests (default: false)"] = False,
+    init_timeout: Annotated[int | None,
+                            "Initialization timeout in milliseconds. PlayMode tests may need longer "
+                            "due to domain reload (default: 15000). Recommended: 120000 for PlayMode."] = None,
 ) -> RunTestsStartResponse | MCPResponse:
     unity_instance = await get_unity_instance_from_context(ctx)
 
@@ -197,6 +200,8 @@ async def run_tests(
         params["includeFailedTests"] = True
     if include_details:
         params["includeDetails"] = True
+    if init_timeout is not None and init_timeout > 0:
+        params["initTimeout"] = init_timeout
 
     response = await unity_transport.send_with_unity_instance(
         async_send_command_with_retry,

--- a/Server/tests/integration/test_run_tests_async.py
+++ b/Server/tests/integration/test_run_tests_async.py
@@ -34,6 +34,66 @@ async def test_run_tests_async_forwards_params(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_tests_forwards_init_timeout(monkeypatch):
+    from services.tools.run_tests import run_tests
+
+    captured = {}
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        captured["params"] = params
+        return {"success": True, "data": {"job_id": "abc123", "status": "running", "mode": "PlayMode"}}
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await run_tests(
+        DummyContext(),
+        mode="PlayMode",
+        init_timeout=120000,
+    )
+    assert captured["params"]["initTimeout"] == 120000
+    assert resp.success is True
+
+
+@pytest.mark.asyncio
+async def test_run_tests_omits_init_timeout_when_none(monkeypatch):
+    from services.tools.run_tests import run_tests
+
+    captured = {}
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        captured["params"] = params
+        return {"success": True, "data": {"job_id": "abc123", "status": "running", "mode": "EditMode"}}
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await run_tests(DummyContext(), mode="EditMode")
+    assert "initTimeout" not in captured["params"]
+    assert resp.success is True
+
+
+@pytest.mark.asyncio
+async def test_run_tests_rejects_negative_init_timeout():
+    from services.tools.run_tests import run_tests
+
+    resp = await run_tests(DummyContext(), mode="EditMode", init_timeout=-1)
+    assert resp.success is False
+    assert "init_timeout" in resp.error
+
+
+@pytest.mark.asyncio
+async def test_run_tests_rejects_zero_init_timeout():
+    from services.tools.run_tests import run_tests
+
+    resp = await run_tests(DummyContext(), mode="EditMode", init_timeout=0)
+    assert resp.success is False
+    assert "init_timeout" in resp.error
+
+
+@pytest.mark.asyncio
 async def test_get_test_job_forwards_job_id(monkeypatch):
     from services.tools.run_tests import get_test_job
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs
@@ -20,7 +20,6 @@ namespace MCPForUnityTests.Editor.Services
         private Type _testJobType;
 
         private string _originalJobId;
-        private object _originalJobs;
 
         [SetUp]
         public void SetUp()

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs
@@ -61,6 +61,10 @@ namespace MCPForUnityTests.Editor.Services
             jobs?.Remove("test-init-timeout-job");
             jobs?.Remove("test-init-timeout-default");
             jobs?.Remove("test-init-timeout-persist");
+            // Flush cleaned state to SessionState so synthetic jobs don't survive domain reloads.
+            // The persist test writes to SessionState; without this, the stub job would be
+            // restored on the next [InitializeOnLoadMethod] and pollute later test runs.
+            _persistMethod.Invoke(null, new object[] { true });
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using MCPForUnity.Editor.Services;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    /// <summary>
+    /// Tests for TestJobManager's per-job InitTimeoutMs feature.
+    /// Uses reflection to manipulate internal state since StartJob triggers a real test run.
+    /// </summary>
+    public class TestJobManagerInitTimeoutTests
+    {
+        private FieldInfo _jobsField;
+        private FieldInfo _currentJobIdField;
+        private MethodInfo _getJobMethod;
+        private MethodInfo _persistMethod;
+        private MethodInfo _restoreMethod;
+        private Type _testJobType;
+
+        private string _originalJobId;
+        private object _originalJobs;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var asm = typeof(MCPServiceLocator).Assembly;
+            var managerType = asm.GetType("MCPForUnity.Editor.Services.TestJobManager");
+            Assert.NotNull(managerType, "Could not find TestJobManager");
+
+            _testJobType = asm.GetType("MCPForUnity.Editor.Services.TestJob");
+            Assert.NotNull(_testJobType, "Could not find TestJob");
+
+            _jobsField = managerType.GetField("Jobs", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(_jobsField, "Could not find Jobs field");
+
+            _currentJobIdField = managerType.GetField("_currentJobId", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(_currentJobIdField, "Could not find _currentJobId field");
+
+            _getJobMethod = managerType.GetMethod("GetJob", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(_getJobMethod, "Could not find GetJob method");
+
+            _persistMethod = managerType.GetMethod("PersistToSessionState", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(_persistMethod, "Could not find PersistToSessionState method");
+
+            _restoreMethod = managerType.GetMethod("TryRestoreFromSessionState", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(_restoreMethod, "Could not find TryRestoreFromSessionState method");
+
+            // Snapshot original state
+            _originalJobId = _currentJobIdField.GetValue(null) as string;
+            // We'll restore _currentJobId in TearDown; Jobs dictionary is shared static state
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Restore original state
+            _currentJobIdField.SetValue(null, _originalJobId);
+            // Clean up any test jobs we inserted
+            var jobs = _jobsField.GetValue(null) as System.Collections.IDictionary;
+            jobs?.Remove("test-init-timeout-job");
+            jobs?.Remove("test-init-timeout-default");
+            jobs?.Remove("test-init-timeout-persist");
+        }
+
+        [Test]
+        public void GetJob_WithCustomInitTimeout_UsesPerJobTimeout()
+        {
+            // Arrange: insert a job with a custom init timeout and a start time far enough in the
+            // past to exceed the default 15s but within the custom 120s.
+            var jobs = _jobsField.GetValue(null) as System.Collections.IDictionary;
+            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            var job = Activator.CreateInstance(_testJobType);
+            _testJobType.GetProperty("JobId").SetValue(job, "test-init-timeout-job");
+            _testJobType.GetProperty("Status").SetValue(job, TestJobStatus.Running);
+            _testJobType.GetProperty("Mode").SetValue(job, "PlayMode");
+            _testJobType.GetProperty("StartedUnixMs").SetValue(job, now - 30_000); // 30s ago
+            _testJobType.GetProperty("LastUpdateUnixMs").SetValue(job, now - 30_000);
+            _testJobType.GetProperty("TotalTests").SetValue(job, null); // Not initialized yet
+            _testJobType.GetProperty("InitTimeoutMs").SetValue(job, 120_000L); // 120s custom timeout
+            _testJobType.GetProperty("FailuresSoFar").SetValue(job, new List<TestJobFailure>());
+
+            jobs["test-init-timeout-job"] = job;
+            _currentJobIdField.SetValue(null, "test-init-timeout-job");
+
+            // Act: GetJob should NOT auto-fail because 30s < 120s custom timeout
+            var result = _getJobMethod.Invoke(null, new object[] { "test-init-timeout-job" });
+
+            // Assert: job should still be running
+            var status = (TestJobStatus)_testJobType.GetProperty("Status").GetValue(result);
+            Assert.AreEqual(TestJobStatus.Running, status,
+                "Job with 120s custom timeout should not auto-fail after 30s");
+        }
+
+        [Test]
+        public void GetJob_WithDefaultTimeout_AutoFailsAfter15Seconds()
+        {
+            // Arrange: insert a job with InitTimeoutMs=0 (use default) and start time 20s ago
+            var jobs = _jobsField.GetValue(null) as System.Collections.IDictionary;
+            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            var job = Activator.CreateInstance(_testJobType);
+            _testJobType.GetProperty("JobId").SetValue(job, "test-init-timeout-default");
+            _testJobType.GetProperty("Status").SetValue(job, TestJobStatus.Running);
+            _testJobType.GetProperty("Mode").SetValue(job, "EditMode");
+            _testJobType.GetProperty("StartedUnixMs").SetValue(job, now - 20_000); // 20s ago
+            _testJobType.GetProperty("LastUpdateUnixMs").SetValue(job, now - 20_000);
+            _testJobType.GetProperty("TotalTests").SetValue(job, null);
+            _testJobType.GetProperty("InitTimeoutMs").SetValue(job, 0L); // Use default
+            _testJobType.GetProperty("FailuresSoFar").SetValue(job, new List<TestJobFailure>());
+
+            jobs["test-init-timeout-default"] = job;
+            _currentJobIdField.SetValue(null, "test-init-timeout-default");
+
+            // Act: GetJob should auto-fail because 20s > 15s default
+            var result = _getJobMethod.Invoke(null, new object[] { "test-init-timeout-default" });
+
+            // Assert: job should be failed
+            var status = (TestJobStatus)_testJobType.GetProperty("Status").GetValue(result);
+            Assert.AreEqual(TestJobStatus.Failed, status,
+                "Job with default timeout should auto-fail after 20s");
+        }
+
+        [Test]
+        public void InitTimeoutMs_SurvivesPersistAndRestore()
+        {
+            // Arrange: insert a job with custom InitTimeoutMs
+            var jobs = _jobsField.GetValue(null) as System.Collections.IDictionary;
+            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            var job = Activator.CreateInstance(_testJobType);
+            _testJobType.GetProperty("JobId").SetValue(job, "test-init-timeout-persist");
+            _testJobType.GetProperty("Status").SetValue(job, TestJobStatus.Running);
+            _testJobType.GetProperty("Mode").SetValue(job, "PlayMode");
+            _testJobType.GetProperty("StartedUnixMs").SetValue(job, now);
+            _testJobType.GetProperty("LastUpdateUnixMs").SetValue(job, now);
+            _testJobType.GetProperty("TotalTests").SetValue(job, null);
+            _testJobType.GetProperty("InitTimeoutMs").SetValue(job, 90_000L);
+            _testJobType.GetProperty("FailuresSoFar").SetValue(job, new List<TestJobFailure>());
+
+            jobs["test-init-timeout-persist"] = job;
+            _currentJobIdField.SetValue(null, "test-init-timeout-persist");
+
+            // Act: persist then restore (simulates domain reload)
+            _persistMethod.Invoke(null, new object[] { true });
+            // Clear in-memory state
+            jobs.Remove("test-init-timeout-persist");
+            _currentJobIdField.SetValue(null, null);
+            // Restore from SessionState
+            _restoreMethod.Invoke(null, null);
+
+            // Assert: restored job should have the same InitTimeoutMs
+            var restoredJobs = _jobsField.GetValue(null) as System.Collections.IDictionary;
+            Assert.IsTrue(restoredJobs.Contains("test-init-timeout-persist"),
+                "Job should be restored from SessionState");
+
+            var restoredJob = restoredJobs["test-init-timeout-persist"];
+            var restoredTimeout = (long)_testJobType.GetProperty("InitTimeoutMs").GetValue(restoredJob);
+            Assert.AreEqual(90_000L, restoredTimeout,
+                "InitTimeoutMs should survive persist/restore cycle");
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TestJobManagerInitTimeoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e0b6718bcbe94429595354c108865f67

--- a/docs/development/README-DEV-zh.md
+++ b/docs/development/README-DEV-zh.md
@@ -126,6 +126,7 @@ uv run python -m cli.main editor tests --failed-only
 
 ```
 run_tests(mode="EditMode")
+run_tests(mode="PlayMode", init_timeout=120000)  # PlayMode 由于域重载可能需要更长的初始化时间
 get_test_job(job_id="<id>", wait_timeout=60)
 ```
 

--- a/docs/development/README-DEV.md
+++ b/docs/development/README-DEV.md
@@ -126,6 +126,7 @@ uv run python -m cli.main editor tests --failed-only
 
 ```
 run_tests(mode="EditMode")
+run_tests(mode="PlayMode", init_timeout=120000)  # PlayMode may need longer init due to domain reload
 get_test_job(job_id="<id>", wait_timeout=60)
 ```
 


### PR DESCRIPTION
## Description

  PlayMode tests require entering play mode which triggers a domain reload. On large Unity projects this can take >15s, causing the hardcoded 15s init timeout to
  auto-fail the test job before tests actually start. This PR adds a configurable `init_timeout` parameter to `run_tests` so callers can specify a longer
  initialization timeout for PlayMode tests.

  ## Type of Change

  - New feature (non-breaking change that adds functionality)

  ## Changes Made

  - **Python** (`Server/src/services/tools/run_tests.py`): Added `init_timeout` parameter to `run_tests()` function signature. When set, forwarded to Unity as
  `initTimeout` in the params dict.
  - **C# RunTests** (`MCPForUnity/Editor/Tools/RunTests.cs`): Reads `initTimeout` param from the request and passes it to `TestJobManager.StartJob()`.
  - **C# TestJobManager** (`MCPForUnity/Editor/Services/TestJobManager.cs`):
    - Added `InitTimeoutMs` field to `TestJob` for per-job timeout override
    - Renamed `InitializationTimeoutMs` to `DefaultInitializationTimeoutMs` (15s, unchanged default)
    - `StartJob()` accepts optional `initTimeoutMs` parameter
    - `GetJob()` uses per-job timeout when set, falls back to 15s default
    - `InitTimeoutMs` persisted/restored across domain reloads via SessionState

  ## Testing/Screenshots/Recordings

  Tested on a large Unity project (~18s domain reload time for PlayMode):
  - Verified PlayMode tests fail with default 15s timeout (auto-fail before tests start)
  - Verified PlayMode tests succeed with `init_timeout=120000`
  - Verified EditMode tests still work without specifying `init_timeout` (default 15s is sufficient)
  - Verified per-job timeout survives domain reload (SessionState persistence)

  ## Documentation Updates

  - [x] I have added/removed/modified tools or resources
  - [x] If yes, I have updated all documentation files using:
    - [x] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
    - [x] Manual updates following the guide at `tools/UPDATE_DOCS.md`

  ## Related Issues

  None

  ## Additional Notes

  The default timeout remains 15s (no breaking change). The `init_timeout` parameter is optional and only needed for projects where PlayMode domain reload exceeds
  15s. Recommended value for PlayMode: 120000 (120s).

## Summary by Sourcery

Add configurable per-job initialization timeout for Unity test runs and propagate it from the Python run_tests tool through the editor pipeline.

New Features:
- Allow callers of the Python run_tests tool to specify an init_timeout parameter to control Unity test initialization timeouts on a per-run basis.

Enhancements:
- Introduce a per-job initialization timeout in TestJobManager with a default value, using the override when provided and persisting it across domain reloads.
- Extend the editor RunTests command handler to read the initTimeout parameter and pass it through when starting test jobs.

Documentation:
- Update developer documentation to demonstrate using init_timeout for PlayMode runs that require longer initialization due to domain reloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-job initialization timeout for test runs, forwarded to the test runner and persisted across sessions.

* **Bug Fixes**
  * Validation rejects non-positive init_timeout inputs and clamps overly large values; timeout checks now honor per-job settings and report the resolved timeout.

* **Documentation**
  * Developer docs updated with a PlayMode example using an extended init_timeout.

* **Tests**
  * New integration and edit-mode tests covering forwarding, validation, persistence, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->