### PR TITLE
fix: include UI Toolkit overlays in game_view screenshots with include_image

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -589,22 +589,80 @@ namespace MCPForUnity.Editor.Tools
                     }
                 }
 
-                // When a specific camera is requested or include_image is true, always use camera-based capture
-                // (synchronous, gives us bytes in memory for base64).
-                if (targetCamera != null || includeImage)
+                // When include_image is requested but no specific camera, use composited capture
+                // (ScreenCapture.CaptureScreenshotAsTexture) which captures UI Toolkit overlays.
+                // When a specific camera IS requested, use camera-based capture.
+                if (targetCamera != null)
                 {
+                    if (!Application.isBatchMode) EnsureGameView();
+
+                    ScreenshotCaptureResult result = ScreenshotUtility.CaptureFromCameraToAssetsFolder(
+                        targetCamera, fileName, resolvedSuperSize, ensureUniqueFileName: true,
+                        includeImage: includeImage, maxResolution: maxResolution);
+
+                    AssetDatabase.ImportAsset(result.AssetsRelativePath, ImportAssetOptions.ForceSynchronousImport);
+                    string message = $"Screenshot captured to '{result.AssetsRelativePath}' (camera: {targetCamera.name}).";
+
+                    var data = new Dictionary<string, object>
+                    {
+                        { "path", result.AssetsRelativePath },
+                        { "fullPath", result.FullPath },
+                        { "superSize", result.SuperSize },
+                        { "isAsync", false },
+                        { "camera", targetCamera.name },
+                        { "captureSource", "game_view" },
+                    };
+                    if (includeImage && result.ImageBase64 != null)
+                    {
+                        data["imageBase64"] = result.ImageBase64;
+                        data["imageWidth"] = result.ImageWidth;
+                        data["imageHeight"] = result.ImageHeight;
+                    }
+                    return new SuccessResponse(message, data);
+                }
+
+                if (includeImage && Application.isPlaying)
+                {
+                    if (!Application.isBatchMode) EnsureGameView();
+
+                    ScreenshotCaptureResult result = ScreenshotUtility.CaptureComposited(
+                        fileName, resolvedSuperSize, ensureUniqueFileName: true,
+                        includeImage: true, maxResolution: maxResolution);
+
+                    AssetDatabase.ImportAsset(result.AssetsRelativePath, ImportAssetOptions.ForceSynchronousImport);
+                    string cameraName = Camera.main != null ? Camera.main.name : "composited";
+                    string message = $"Screenshot captured to '{result.AssetsRelativePath}' (camera: {cameraName}).";
+
+                    var data = new Dictionary<string, object>
+                    {
+                        { "path", result.AssetsRelativePath },
+                        { "fullPath", result.FullPath },
+                        { "superSize", result.SuperSize },
+                        { "isAsync", false },
+                        { "camera", cameraName },
+                        { "captureSource", "game_view" },
+                    };
+                    if (result.ImageBase64 != null)
+                    {
+                        data["imageBase64"] = result.ImageBase64;
+                        data["imageWidth"] = result.ImageWidth;
+                        data["imageHeight"] = result.ImageHeight;
+                    }
+                    return new SuccessResponse(message, data);
+                }
+
+                if (includeImage)
+                {
+                    // Not in play mode — fall back to camera-based capture
+                    targetCamera = Camera.main;
                     if (targetCamera == null)
                     {
-                        targetCamera = Camera.main;
-                        if (targetCamera == null)
-                        {
-                            var allCams = UnityFindObjectsCompat.FindAll<Camera>();
-                            targetCamera = allCams.Length > 0 ? allCams[0] : null;
-                        }
+                        var allCams = UnityFindObjectsCompat.FindAll<Camera>();
+                        targetCamera = allCams.Length > 0 ? allCams[0] : null;
                     }
                     if (targetCamera == null)
                     {
-                        return new ErrorResponse("No camera found in the scene. Add a Camera to use screenshot with camera or include_image.");
+                        return new ErrorResponse("No camera found in the scene. Add a Camera to use screenshot with include_image outside of Play mode.");
                     }
 
                     if (!Application.isBatchMode) EnsureGameView();

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -602,23 +602,7 @@ namespace MCPForUnity.Editor.Tools
 
                     AssetDatabase.ImportAsset(result.AssetsRelativePath, ImportAssetOptions.ForceSynchronousImport);
                     string message = $"Screenshot captured to '{result.AssetsRelativePath}' (camera: {targetCamera.name}).";
-
-                    var data = new Dictionary<string, object>
-                    {
-                        { "path", result.AssetsRelativePath },
-                        { "fullPath", result.FullPath },
-                        { "superSize", result.SuperSize },
-                        { "isAsync", false },
-                        { "camera", targetCamera.name },
-                        { "captureSource", "game_view" },
-                    };
-                    if (includeImage && result.ImageBase64 != null)
-                    {
-                        data["imageBase64"] = result.ImageBase64;
-                        data["imageWidth"] = result.ImageWidth;
-                        data["imageHeight"] = result.ImageHeight;
-                    }
-                    return new SuccessResponse(message, data);
+                    return new SuccessResponse(message, BuildScreenshotResponseData(result, targetCamera.name, includeImage));
                 }
 
                 if (includeImage && Application.isPlaying)
@@ -632,23 +616,7 @@ namespace MCPForUnity.Editor.Tools
                     AssetDatabase.ImportAsset(result.AssetsRelativePath, ImportAssetOptions.ForceSynchronousImport);
                     string cameraName = Camera.main != null ? Camera.main.name : "composited";
                     string message = $"Screenshot captured to '{result.AssetsRelativePath}' (camera: {cameraName}).";
-
-                    var data = new Dictionary<string, object>
-                    {
-                        { "path", result.AssetsRelativePath },
-                        { "fullPath", result.FullPath },
-                        { "superSize", result.SuperSize },
-                        { "isAsync", false },
-                        { "camera", cameraName },
-                        { "captureSource", "game_view" },
-                    };
-                    if (result.ImageBase64 != null)
-                    {
-                        data["imageBase64"] = result.ImageBase64;
-                        data["imageWidth"] = result.ImageWidth;
-                        data["imageHeight"] = result.ImageHeight;
-                    }
-                    return new SuccessResponse(message, data);
+                    return new SuccessResponse(message, BuildScreenshotResponseData(result, cameraName, includeImage: true));
                 }
 
                 if (includeImage)
@@ -673,23 +641,7 @@ namespace MCPForUnity.Editor.Tools
 
                     AssetDatabase.ImportAsset(result.AssetsRelativePath, ImportAssetOptions.ForceSynchronousImport);
                     string message = $"Screenshot captured to '{result.AssetsRelativePath}' (camera: {targetCamera.name}).";
-
-                    var data = new Dictionary<string, object>
-                    {
-                        { "path", result.AssetsRelativePath },
-                        { "fullPath", result.FullPath },
-                        { "superSize", result.SuperSize },
-                        { "isAsync", false },
-                        { "camera", targetCamera.name },
-                        { "captureSource", "game_view" },
-                    };
-                    if (includeImage && result.ImageBase64 != null)
-                    {
-                        data["imageBase64"] = result.ImageBase64;
-                        data["imageWidth"] = result.ImageWidth;
-                        data["imageHeight"] = result.ImageHeight;
-                    }
-                    return new SuccessResponse(message, data);
+                    return new SuccessResponse(message, BuildScreenshotResponseData(result, targetCamera.name, includeImage));
                 }
 
                 // Default path: use ScreenCapture API if available, camera fallback otherwise
@@ -744,6 +696,31 @@ namespace MCPForUnity.Editor.Tools
             {
                 return new ErrorResponse($"Error capturing screenshot: {e.Message}");
             }
+        }
+
+        private static Dictionary<string, object> BuildScreenshotResponseData(
+            ScreenshotCaptureResult result,
+            string cameraName,
+            bool includeImage)
+        {
+            var data = new Dictionary<string, object>
+            {
+                { "path", result.AssetsRelativePath },
+                { "fullPath", result.FullPath },
+                { "superSize", result.SuperSize },
+                { "isAsync", false },
+                { "camera", cameraName },
+                { "captureSource", "game_view" },
+            };
+
+            if (includeImage && result.ImageBase64 != null)
+            {
+                data["imageBase64"] = result.ImageBase64;
+                data["imageWidth"] = result.ImageWidth;
+                data["imageHeight"] = result.ImageHeight;
+            }
+
+            return data;
         }
 
         private static object CaptureSceneViewScreenshot(

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -236,6 +236,15 @@ namespace MCPForUnity.Runtime.Helpers
             bool includeImage = false,
             int maxResolution = 0)
         {
+            if (!IsScreenCaptureModuleAvailable)
+            {
+                var fallbackCamera = FindAvailableCamera();
+                if (fallbackCamera != null)
+                    return CaptureFromCameraToAssetsFolder(fallbackCamera, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
+
+                throw new InvalidOperationException("ScreenCapture module is unavailable and no fallback camera found.");
+            }
+
             ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, isAsync: false);
             Texture2D tex = null;
             Texture2D downscaled = null;
@@ -247,7 +256,7 @@ namespace MCPForUnity.Runtime.Helpers
                 if (tex == null)
                 {
                     // Fallback to camera-based if ScreenCapture fails
-                    var cam = Camera.main;
+                    var cam = FindAvailableCamera();
                     if (cam != null)
                         return CaptureFromCameraToAssetsFolder(cam, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
                     throw new InvalidOperationException("ScreenCapture.CaptureScreenshotAsTexture returned null and no fallback camera available.");

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -225,6 +225,75 @@ namespace MCPForUnity.Runtime.Helpers
         }
 
         /// <summary>
+        /// Captures a screenshot using ScreenCapture.CaptureScreenshotAsTexture, which captures the
+        /// final composited frame including UI Toolkit overlays, post-processing, etc.
+        /// Falls back to camera-based capture if ScreenCapture is unavailable.
+        /// </summary>
+        public static ScreenshotCaptureResult CaptureComposited(
+            string fileName = null,
+            int superSize = 1,
+            bool ensureUniqueFileName = true,
+            bool includeImage = false,
+            int maxResolution = 0)
+        {
+            ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, isAsync: false);
+            Texture2D tex = null;
+            Texture2D downscaled = null;
+            string imageBase64 = null;
+            int imgW = 0, imgH = 0;
+            try
+            {
+                tex = ScreenCapture.CaptureScreenshotAsTexture(result.SuperSize);
+                if (tex == null)
+                {
+                    // Fallback to camera-based if ScreenCapture fails
+                    var cam = Camera.main;
+                    if (cam != null)
+                        return CaptureFromCameraToAssetsFolder(cam, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
+                    throw new InvalidOperationException("ScreenCapture.CaptureScreenshotAsTexture returned null and no fallback camera available.");
+                }
+
+                int width = tex.width;
+                int height = tex.height;
+
+                byte[] png = tex.EncodeToPNG();
+                File.WriteAllBytes(result.FullPath, png);
+
+                if (includeImage)
+                {
+                    int targetMax = maxResolution > 0 ? maxResolution : 640;
+                    if (width > targetMax || height > targetMax)
+                    {
+                        downscaled = DownscaleTexture(tex, targetMax);
+                        byte[] smallPng = downscaled.EncodeToPNG();
+                        imageBase64 = System.Convert.ToBase64String(smallPng);
+                        imgW = downscaled.width;
+                        imgH = downscaled.height;
+                    }
+                    else
+                    {
+                        imageBase64 = System.Convert.ToBase64String(png);
+                        imgW = width;
+                        imgH = height;
+                    }
+                }
+            }
+            finally
+            {
+                DestroyTexture(tex);
+                DestroyTexture(downscaled);
+            }
+
+            if (includeImage && imageBase64 != null)
+            {
+                return new ScreenshotCaptureResult(
+                    result.FullPath, result.AssetsRelativePath, result.SuperSize, false,
+                    imageBase64, imgW, imgH);
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Renders a camera to a Texture2D without saving to disk. Used for multi-angle captures.
         /// Returns the base64-encoded PNG, downscaled to fit within <paramref name="maxResolution"/>.
         /// </summary>


### PR DESCRIPTION
## Summary

Fix the Play Mode `game_view` screenshot path used when `include_image=true` so the returned inline image includes UI Toolkit overlays.

## Problem

When `manage_scene(action="screenshot", capture_source="game_view", include_image=true)` is used without an explicit camera target, the previous implementation captured the image through camera rendering.

That misses UI Toolkit overlays because UI Toolkit is composited after the camera render.

## Change

- Use `ScreenCapture.CaptureScreenshotAsTexture()` for `game_view` screenshots when:
  - `include_image=true`
  - Play Mode is active
  - no explicit camera target is requested
- Keep existing behavior for:
  - explicit camera screenshots
  - non-Play-Mode `include_image` screenshots
  - screenshots where `include_image` is omitted or `false`

## Validation

- Diff is limited to:
  - `MCPForUnity/Editor/Tools/ManageScene.cs`
  - `MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs`
- No package, lockfile, or unrelated tool changes included
- Branch is based on `beta`

## Notes

This PR intentionally keeps the fix narrow to the inline-image screenshot path.

Closes #1039.

## Summary by Sourcery

Update game view screenshot capture to use composited frame grabs for inline images while preserving existing camera-based workflows.

Bug Fixes:
- Ensure Play Mode game_view screenshots with include_image capture UI Toolkit overlays by using composited frame capture instead of camera rendering when no explicit camera is specified.

Enhancements:
- Introduce a composited screenshot helper that leverages ScreenCapture.CaptureScreenshotAsTexture with a camera-based fallback and optional downscaling/base64 encoding for inline images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a composited screenshot option that captures UI overlays, with optional embedded Base64 image data and automatic downscaling when needed.
  * Screenshot responses now include consistent metadata (path, fullPath, superSize, isAsync, camera/capture source).

* **Bug Fixes**
  * Safer fallback when no explicit camera is set and clearer error messages.
  * Ensures immediate availability of saved screenshots by forcing synchronous asset import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->