### PR TITLE
feat: add component reference wiring — get_referenceable, set_reference, batch_wire

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageComponents.cs
+++ b/MCPForUnity/Editor/Tools/ManageComponents.cs
@@ -352,9 +352,7 @@ namespace MCPForUnity.Editor.Tools
 
             var previousValue = DescribeObjectReference(property.objectReferenceValue);
 
-            Undo.RecordObject(component, $"Set reference {property.propertyPath}");
-            property.objectReferenceValue = validation.ResolvedObject;
-            serializedObject.ApplyModifiedProperties();
+            ApplyReferenceToProperty(component, serializedObject, property, validation.ResolvedObject);
             EditorUtility.SetDirty(component);
             MarkOwningSceneDirty(targetGo);
 
@@ -474,6 +472,7 @@ namespace MCPForUnity.Editor.Tools
             Undo.SetCurrentGroupName($"Batch wire references on {component.GetType().Name}");
             int succeeded = 0;
             int failed = 0;
+            var serializedObject = new SerializedObject(component);
 
             try
             {
@@ -485,7 +484,7 @@ namespace MCPForUnity.Editor.Tools
                         continue;
                     }
 
-                    var serializedObject = new SerializedObject(component);
+                    serializedObject.Update();
                     var property = serializedObject.FindProperty(validation.PropertyName);
                     if (property == null || property.propertyType != SerializedPropertyType.ObjectReference)
                     {
@@ -500,9 +499,7 @@ namespace MCPForUnity.Editor.Tools
                         continue;
                     }
 
-                    Undo.RecordObject(component, $"Set reference {validation.PropertyName}");
-                    property.objectReferenceValue = validation.ResolvedObject;
-                    serializedObject.ApplyModifiedProperties();
+                    ApplyReferenceToProperty(component, serializedObject, property, validation.ResolvedObject);
                     var successResult = results.FirstOrDefault(r => r.Property == validation.PropertyName);
                     if (successResult != null)
                     {
@@ -732,6 +729,17 @@ namespace MCPForUnity.Editor.Tools
             return true;
         }
 
+        /// <summary>
+        /// Applies a resolved object reference to a SerializedProperty with Undo support.
+        /// Shared by SetReference and BatchWire to avoid duplication.
+        /// </summary>
+        private static void ApplyReferenceToProperty(Component component, SerializedObject serializedObject, SerializedProperty property, UnityEngine.Object resolvedObject)
+        {
+            Undo.RecordObject(component, $"Set reference {property.propertyPath}");
+            property.objectReferenceValue = resolvedObject;
+            serializedObject.ApplyModifiedProperties();
+        }
+
         private static Type GetFieldType(Component component, string propertyName)
         {
             var so = new SerializedObject(component);
@@ -740,23 +748,48 @@ namespace MCPForUnity.Editor.Tools
                 return null;
 
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase;
-            string normalizedName = ParamCoercion.NormalizePropertyName(propertyName);
-            var field = component.GetType().GetField(propertyName, flags)
+
+            // Handle array element paths like "targets.Array.data[0]"
+            string fieldName = propertyName;
+            bool isArrayElement = propertyName.Contains(".Array.data[");
+            if (isArrayElement)
+            {
+                // Extract the root field name before .Array.data[
+                fieldName = propertyName.Substring(0, propertyName.IndexOf(".Array.data["));
+            }
+
+            string normalizedName = ParamCoercion.NormalizePropertyName(fieldName);
+            var field = component.GetType().GetField(fieldName, flags)
                         ?? component.GetType().GetField(normalizedName, flags);
-            return field?.FieldType;
+
+            if (field == null)
+                return null;
+
+            Type fieldType = field.FieldType;
+
+            // For array/list elements, extract the element type
+            if (isArrayElement)
+            {
+                if (fieldType.IsArray)
+                    return fieldType.GetElementType();
+                if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(List<>))
+                    return fieldType.GetGenericArguments()[0];
+            }
+
+            return fieldType;
         }
 
         private static UnityEngine.Object ResolveReference(JObject refParams)
         {
-            var instanceId = refParams["reference_instance_id"]?.Value<int>();
-            if (instanceId.HasValue)
-                return GameObjectLookup.ResolveInstanceID(instanceId.Value);
+            int instanceId = ParamCoercion.CoerceInt(refParams["reference_instance_id"], 0);
+            if (instanceId != 0)
+                return GameObjectLookup.ResolveInstanceID(instanceId);
 
-            var assetPath = refParams["reference_asset_path"]?.Value<string>();
+            string assetPath = ParamCoercion.CoerceString(refParams["reference_asset_path"], null);
             if (!string.IsNullOrEmpty(assetPath))
                 return AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
 
-            var refPath = refParams["reference_path"]?.Value<string>();
+            string refPath = ParamCoercion.CoerceString(refParams["reference_path"], null);
             if (!string.IsNullOrEmpty(refPath))
                 return GameObjectLookup.FindByTarget(new JValue(refPath), "by_path", true) ?? GameObject.Find(refPath);
 

--- a/MCPForUnity/Editor/Tools/ManageComponents.cs
+++ b/MCPForUnity/Editor/Tools/ManageComponents.cs
@@ -13,7 +13,7 @@ namespace MCPForUnity.Editor.Tools
 {
     /// <summary>
     /// Tool for managing components on GameObjects.
-    /// Actions: add, remove, set_property
+    /// Actions: add, remove, set_property, get_referenceable, set_reference, batch_wire
     /// 
     /// This is a focused tool for component lifecycle operations.
     /// For reading component data, use the unity://scene/gameobject/{id}/components resource.
@@ -36,7 +36,7 @@ namespace MCPForUnity.Editor.Tools
             string action = ParamCoercion.CoerceString(@params["action"], null)?.ToLowerInvariant();
             if (string.IsNullOrEmpty(action))
             {
-                return new ErrorResponse("'action' parameter is required (add, remove, set_property).");
+                return new ErrorResponse("'action' parameter is required (add, remove, set_property, get_referenceable, set_reference, batch_wire).");
             }
 
             // Target resolution
@@ -55,7 +55,10 @@ namespace MCPForUnity.Editor.Tools
                     "add" => AddComponent(@params, targetToken, searchMethod),
                     "remove" => RemoveComponent(@params, targetToken, searchMethod),
                     "set_property" => SetProperty(@params, targetToken, searchMethod),
-                    _ => new ErrorResponse($"Unknown action: '{action}'. Supported actions: add, remove, set_property")
+                    "get_referenceable" => GetReferenceable(@params, targetToken, searchMethod),
+                    "set_reference" => SetReference(@params, targetToken, searchMethod),
+                    "batch_wire" => BatchWire(@params, targetToken, searchMethod),
+                    _ => new ErrorResponse($"Unknown action: '{action}'. Supported actions: add, remove, set_property, get_referenceable, set_reference, batch_wire")
                 };
             }
             catch (Exception e)
@@ -300,6 +303,248 @@ namespace MCPForUnity.Editor.Tools
             }
         }
 
+        private static object GetReferenceable(JObject @params, JToken targetToken, string searchMethod)
+        {
+            if (!TryGetComponentAndObjectReferenceProperty(@params, targetToken, searchMethod, "get_referenceable",
+                out GameObject targetGo, out Component component, out SerializedObject serializedObject, out SerializedProperty property, out Type expectedType, out ErrorResponse error))
+            {
+                return error;
+            }
+
+            bool includeScene = ParamCoercion.CoerceBool(@params["include_scene"] ?? @params["includeScene"], true);
+            bool includeAssets = ParamCoercion.CoerceBool(@params["include_assets"] ?? @params["includeAssets"], true);
+            int limit = ParamCoercion.CoerceInt(@params["limit"], 0);
+
+            var sceneObjects = includeScene
+                ? FindReferenceableSceneObjects(expectedType, limit).ToList()
+                : new List<object>();
+            var assets = includeAssets
+                ? FindReferenceableAssets(expectedType, limit).ToList()
+                : new List<object>();
+
+            return new
+            {
+                success = true,
+                message = $"Referenceable targets resolved for property '{property.propertyPath}' on '{component.GetType().Name}'.",
+                data = new
+                {
+                    expected_type = expectedType?.FullName,
+                    current_value = DescribeObjectReference(property.objectReferenceValue),
+                    scene_objects = sceneObjects,
+                    assets = assets
+                }
+            };
+        }
+
+        private static object SetReference(JObject @params, JToken targetToken, string searchMethod)
+        {
+            if (!TryGetComponentAndObjectReferenceProperty(@params, targetToken, searchMethod, "set_reference",
+                out GameObject targetGo, out Component component, out SerializedObject serializedObject, out SerializedProperty property, out Type expectedType, out ErrorResponse error))
+            {
+                return error;
+            }
+
+            var validation = ValidateReferenceAssignment(component, property.propertyPath, expectedType, @params);
+            if (!validation.Success)
+            {
+                return new ErrorResponse(validation.Error);
+            }
+
+            var previousValue = DescribeObjectReference(property.objectReferenceValue);
+
+            Undo.RecordObject(component, $"Set reference {property.propertyPath}");
+            property.objectReferenceValue = validation.ResolvedObject;
+            serializedObject.ApplyModifiedProperties();
+            EditorUtility.SetDirty(component);
+            MarkOwningSceneDirty(targetGo);
+
+            return new
+            {
+                success = true,
+                message = $"Reference '{property.propertyPath}' updated on component '{component.GetType().Name}' on '{targetGo.name}'.",
+                data = new
+                {
+                    property = property.propertyPath,
+                    previous_value = previousValue,
+                    new_value = DescribeObjectReference(validation.ResolvedObject)
+                }
+            };
+        }
+
+        private static object BatchWire(JObject @params, JToken targetToken, string searchMethod)
+        {
+            GameObject targetGo = FindTarget(targetToken, searchMethod);
+            if (targetGo == null)
+            {
+                return new ErrorResponse($"Target GameObject ('{targetToken}') not found using method '{searchMethod ?? "default"}'.");
+            }
+
+            string componentType = ParamCoercion.CoerceString(@params["componentType"] ?? @params["component_type"], null);
+            if (string.IsNullOrEmpty(componentType))
+            {
+                return new ErrorResponse("'componentType' parameter is required for 'batch_wire' action.");
+            }
+
+            Type type = UnityTypeResolver.ResolveComponent(componentType);
+            if (type == null)
+            {
+                return new ErrorResponse($"Component type '{componentType}' not found.");
+            }
+
+            Component component = targetGo.GetComponent(type);
+            if (component == null)
+            {
+                return new ErrorResponse($"Component '{componentType}' not found on '{targetGo.name}'.");
+            }
+
+            JArray references = @params["references"] as JArray;
+            if (references == null || !references.HasValues)
+            {
+                return new ErrorResponse("'references' array is required for 'batch_wire' action.");
+            }
+
+            bool atomic = ParamCoercion.CoerceBool(@params["atomic"], true);
+            var validations = new List<ReferenceAssignmentValidation>();
+            var results = new List<BatchWireResult>();
+
+            foreach (JToken referenceToken in references)
+            {
+                JObject referenceParams = referenceToken as JObject;
+                if (referenceParams == null)
+                {
+                    results.Add(new BatchWireResult
+                    {
+                        Success = false,
+                        Error = "Each reference entry must be an object."
+                    });
+                    continue;
+                }
+
+                string propertyName = ParamCoercion.CoerceString(referenceParams["property_name"] ?? referenceParams["property"], null);
+                if (string.IsNullOrEmpty(propertyName))
+                {
+                    results.Add(new BatchWireResult
+                    {
+                        Success = false,
+                        Error = "Each reference entry requires 'property_name'."
+                    });
+                    continue;
+                }
+
+                Type expectedType = GetFieldType(component, propertyName);
+                if (expectedType == null)
+                {
+                    results.Add(new BatchWireResult
+                    {
+                        Property = propertyName,
+                        Success = false,
+                        Error = $"Property '{propertyName}' was not found or is not an object reference."
+                    });
+                    continue;
+                }
+
+                var validation = ValidateReferenceAssignment(component, propertyName, expectedType, referenceParams);
+                validations.Add(validation);
+                results.Add(new BatchWireResult
+                {
+                    Property = propertyName,
+                    Success = validation.Success,
+                    Error = validation.Error,
+                    NewValue = validation.Success ? DescribeObjectReference(validation.ResolvedObject) : null
+                });
+            }
+
+            if (atomic && results.Any(r => !r.Success))
+            {
+                return new
+                {
+                    success = false,
+                    message = "Batch wire validation failed. No references were applied.",
+                    data = new
+                    {
+                        total = references.Count,
+                        succeeded = 0,
+                        failed = results.Count(r => !r.Success),
+                        results = results.Select(r => r.ToResponse())
+                    }
+                };
+            }
+
+            int undoGroup = Undo.GetCurrentGroup();
+            Undo.SetCurrentGroupName($"Batch wire references on {component.GetType().Name}");
+            int succeeded = 0;
+            int failed = 0;
+
+            try
+            {
+                foreach (var validation in validations)
+                {
+                    if (!validation.Success)
+                    {
+                        failed++;
+                        continue;
+                    }
+
+                    var serializedObject = new SerializedObject(component);
+                    var property = serializedObject.FindProperty(validation.PropertyName);
+                    if (property == null || property.propertyType != SerializedPropertyType.ObjectReference)
+                    {
+                        var result = results.FirstOrDefault(r => r.Property == validation.PropertyName);
+                        if (result != null)
+                        {
+                            result.Success = false;
+                            result.Error = $"Property '{validation.PropertyName}' was not found or is not an object reference during apply.";
+                            result.NewValue = null;
+                        }
+                        failed++;
+                        continue;
+                    }
+
+                    Undo.RecordObject(component, $"Set reference {validation.PropertyName}");
+                    property.objectReferenceValue = validation.ResolvedObject;
+                    serializedObject.ApplyModifiedProperties();
+                    var successResult = results.FirstOrDefault(r => r.Property == validation.PropertyName);
+                    if (successResult != null)
+                    {
+                        successResult.Success = true;
+                        successResult.Error = null;
+                        successResult.NewValue = DescribeObjectReference(property.objectReferenceValue);
+                    }
+                    succeeded++;
+                }
+
+                if (succeeded > 0)
+                {
+                    EditorUtility.SetDirty(component);
+                    MarkOwningSceneDirty(targetGo);
+                }
+            }
+            finally
+            {
+                Undo.CollapseUndoOperations(undoGroup);
+            }
+
+            if (!atomic)
+            {
+                failed = results.Count(r => !r.Success);
+            }
+
+            return new
+            {
+                success = failed == 0,
+                message = failed == 0
+                    ? $"Batch wired {succeeded} reference(s) on component '{component.GetType().Name}'."
+                    : $"Batch wire completed with {failed} failure(s) on component '{component.GetType().Name}'.",
+                data = new
+                {
+                    total = references.Count,
+                    succeeded = succeeded,
+                    failed = failed,
+                    results = results.Select(r => r.ToResponse())
+                }
+            };
+        }
+
         #endregion
 
         #region Helpers
@@ -416,6 +661,321 @@ namespace MCPForUnity.Editor.Tools
 
             McpLog.Warn($"[ManageComponents] {error}");
             return error;
+        }
+
+        private static bool TryGetComponentAndObjectReferenceProperty(JObject @params, JToken targetToken, string searchMethod, string actionName,
+            out GameObject targetGo, out Component component, out SerializedObject serializedObject, out SerializedProperty property, out Type expectedType, out ErrorResponse error)
+        {
+            targetGo = null;
+            component = null;
+            serializedObject = null;
+            property = null;
+            expectedType = null;
+            error = null;
+
+            targetGo = FindTarget(targetToken, searchMethod);
+            if (targetGo == null)
+            {
+                error = new ErrorResponse($"Target GameObject ('{targetToken}') not found using method '{searchMethod ?? "default"}'.");
+                return false;
+            }
+
+            string componentType = ParamCoercion.CoerceString(@params["componentType"] ?? @params["component_type"], null);
+            if (string.IsNullOrEmpty(componentType))
+            {
+                error = new ErrorResponse($"'componentType' parameter is required for '{actionName}' action.");
+                return false;
+            }
+
+            Type type = UnityTypeResolver.ResolveComponent(componentType);
+            if (type == null)
+            {
+                error = new ErrorResponse($"Component type '{componentType}' not found.");
+                return false;
+            }
+
+            component = targetGo.GetComponent(type);
+            if (component == null)
+            {
+                error = new ErrorResponse($"Component '{componentType}' not found on '{targetGo.name}'.");
+                return false;
+            }
+
+            string propertyName = ParamCoercion.CoerceString(@params["property"] ?? @params["property_name"], null);
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                error = new ErrorResponse($"'property' parameter is required for '{actionName}' action.");
+                return false;
+            }
+
+            serializedObject = new SerializedObject(component);
+            property = serializedObject.FindProperty(propertyName);
+            if (property == null)
+            {
+                error = new ErrorResponse($"Property '{propertyName}' not found on component '{component.GetType().Name}'.");
+                return false;
+            }
+
+            if (property.propertyType != SerializedPropertyType.ObjectReference)
+            {
+                error = new ErrorResponse($"Property '{propertyName}' on component '{component.GetType().Name}' is not an object reference.");
+                return false;
+            }
+
+            expectedType = GetFieldType(component, propertyName);
+            if (expectedType == null)
+            {
+                error = new ErrorResponse($"Unable to determine reference type for property '{propertyName}' on component '{component.GetType().Name}'.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static Type GetFieldType(Component component, string propertyName)
+        {
+            var so = new SerializedObject(component);
+            var prop = so.FindProperty(propertyName);
+            if (prop == null || prop.propertyType != SerializedPropertyType.ObjectReference)
+                return null;
+
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase;
+            string normalizedName = ParamCoercion.NormalizePropertyName(propertyName);
+            var field = component.GetType().GetField(propertyName, flags)
+                        ?? component.GetType().GetField(normalizedName, flags);
+            return field?.FieldType;
+        }
+
+        private static UnityEngine.Object ResolveReference(JObject refParams)
+        {
+            var instanceId = refParams["reference_instance_id"]?.Value<int>();
+            if (instanceId.HasValue)
+                return GameObjectLookup.ResolveInstanceID(instanceId.Value);
+
+            var assetPath = refParams["reference_asset_path"]?.Value<string>();
+            if (!string.IsNullOrEmpty(assetPath))
+                return AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
+
+            var refPath = refParams["reference_path"]?.Value<string>();
+            if (!string.IsNullOrEmpty(refPath))
+                return GameObjectLookup.FindByTarget(new JValue(refPath), "by_path", true) ?? GameObject.Find(refPath);
+
+            return null;
+        }
+
+        private static IEnumerable<object> FindReferenceableSceneObjects(Type expectedType, int limit)
+        {
+            int count = 0;
+            foreach (var gameObject in GameObjectLookup.GetAllSceneObjects(true))
+            {
+                var candidate = ConvertResolvedObject(gameObject, expectedType);
+                if (candidate == null)
+                    continue;
+
+                yield return DescribeObjectReference(candidate);
+                count++;
+                if (limit > 0 && count >= limit)
+                    yield break;
+            }
+        }
+
+        private static IEnumerable<object> FindReferenceableAssets(Type expectedType, int limit)
+        {
+            int count = 0;
+            var seen = new HashSet<int>();
+
+            foreach (string guid in AssetDatabase.FindAssets(BuildAssetSearchFilter(expectedType)))
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                foreach (var candidate in LoadReferenceableAssetsAtPath(assetPath, expectedType))
+                {
+                    if (candidate == null)
+                        continue;
+
+                    int instanceId = candidate.GetInstanceID();
+                    if (!seen.Add(instanceId))
+                        continue;
+
+                    yield return DescribeObjectReference(candidate);
+                    count++;
+                    if (limit > 0 && count >= limit)
+                        yield break;
+                }
+            }
+        }
+
+        private static string BuildAssetSearchFilter(Type expectedType)
+        {
+            if (expectedType == null)
+                return string.Empty;
+
+            if (typeof(Component).IsAssignableFrom(expectedType))
+                return "t:Prefab";
+
+            return $"t:{expectedType.Name}";
+        }
+
+        private static IEnumerable<UnityEngine.Object> LoadReferenceableAssetsAtPath(string assetPath, Type expectedType)
+        {
+            if (typeof(Component).IsAssignableFrom(expectedType))
+            {
+                GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(assetPath);
+                if (prefab == null)
+                    yield break;
+
+                Component component = prefab.GetComponent(expectedType);
+                if (component != null)
+                    yield return component;
+                yield break;
+            }
+
+            foreach (var asset in AssetDatabase.LoadAllAssetsAtPath(assetPath))
+            {
+                if (asset != null && expectedType.IsAssignableFrom(asset.GetType()))
+                    yield return asset;
+            }
+        }
+
+        private static ReferenceAssignmentValidation ValidateReferenceAssignment(Component component, string propertyName, Type expectedType, JObject refParams)
+        {
+            var serializedObject = new SerializedObject(component);
+            var property = serializedObject.FindProperty(propertyName);
+            if (property == null || property.propertyType != SerializedPropertyType.ObjectReference)
+            {
+                return ReferenceAssignmentValidation.Fail(propertyName, $"Property '{propertyName}' was not found or is not an object reference.");
+            }
+
+            bool clear = ParamCoercion.CoerceBool(refParams["clear"], false);
+            if (clear)
+            {
+                return ReferenceAssignmentValidation.Ok(propertyName, null);
+            }
+
+            if (!HasReferenceSelector(refParams))
+            {
+                return ReferenceAssignmentValidation.Fail(propertyName, $"Property '{propertyName}' requires one of: reference_path, reference_asset_path, reference_instance_id, or clear.");
+            }
+
+            UnityEngine.Object resolved = ResolveReference(refParams);
+            if (resolved == null)
+            {
+                return ReferenceAssignmentValidation.Fail(propertyName, $"Failed to resolve reference target for property '{propertyName}'.");
+            }
+
+            UnityEngine.Object converted = ConvertResolvedObject(resolved, expectedType);
+            if (converted == null)
+            {
+                return ReferenceAssignmentValidation.Fail(propertyName,
+                    $"Resolved reference '{resolved.name}' is not assignable to '{expectedType.FullName}' for property '{propertyName}'.");
+            }
+
+            return ReferenceAssignmentValidation.Ok(propertyName, converted);
+        }
+
+        private static bool HasReferenceSelector(JObject refParams)
+        {
+            return refParams["reference_path"] != null
+                   || refParams["reference_asset_path"] != null
+                   || refParams["reference_instance_id"] != null
+                   || ParamCoercion.CoerceBool(refParams["clear"], false);
+        }
+
+        private static UnityEngine.Object ConvertResolvedObject(UnityEngine.Object resolved, Type expectedType)
+        {
+            if (resolved == null || expectedType == null)
+                return null;
+
+            if (expectedType.IsAssignableFrom(resolved.GetType()))
+                return resolved;
+
+            if (resolved is GameObject gameObject)
+            {
+                if (expectedType == typeof(GameObject))
+                    return gameObject;
+
+                if (typeof(Component).IsAssignableFrom(expectedType))
+                    return gameObject.GetComponent(expectedType);
+            }
+
+            if (resolved is Component component)
+            {
+                if (expectedType == typeof(GameObject))
+                    return component.gameObject;
+
+                if (expectedType.IsAssignableFrom(component.GetType()))
+                    return component;
+            }
+
+            return null;
+        }
+
+        private static object DescribeObjectReference(UnityEngine.Object obj)
+        {
+            if (obj == null)
+                return null;
+
+            string assetPath = AssetDatabase.GetAssetPath(obj);
+            GameObject gameObject = obj as GameObject;
+            if (obj is Component component)
+            {
+                gameObject = component.gameObject;
+            }
+
+            return new
+            {
+                instance_id = obj.GetInstanceID(),
+                name = obj.name,
+                type = obj.GetType().FullName,
+                path = gameObject != null ? GameObjectLookup.GetGameObjectPath(gameObject) : null,
+                asset_path = string.IsNullOrEmpty(assetPath) ? null : assetPath
+            };
+        }
+
+        private sealed class ReferenceAssignmentValidation
+        {
+            public string PropertyName { get; private set; }
+            public bool Success { get; private set; }
+            public string Error { get; private set; }
+            public UnityEngine.Object ResolvedObject { get; private set; }
+
+            public static ReferenceAssignmentValidation Ok(string propertyName, UnityEngine.Object resolvedObject)
+            {
+                return new ReferenceAssignmentValidation
+                {
+                    PropertyName = propertyName,
+                    Success = true,
+                    ResolvedObject = resolvedObject
+                };
+            }
+
+            public static ReferenceAssignmentValidation Fail(string propertyName, string error)
+            {
+                return new ReferenceAssignmentValidation
+                {
+                    PropertyName = propertyName,
+                    Success = false,
+                    Error = error
+                };
+            }
+        }
+
+        private sealed class BatchWireResult
+        {
+            public string Property { get; set; }
+            public bool Success { get; set; }
+            public string Error { get; set; }
+            public object NewValue { get; set; }
+
+            public object ToResponse()
+            {
+                return new
+                {
+                    property = Property,
+                    success = Success,
+                    error = Error,
+                    new_value = NewValue
+                };
+            }
         }
 
         #endregion

--- a/Server/src/services/tools/manage_components.py
+++ b/Server/src/services/tools/manage_components.py
@@ -116,6 +116,9 @@ async def manage_components(
     - Remove BoxCollider: action="remove", target=-12345, component_type="BoxCollider"
     - Set single property: action="set_property", target="Enemy", component_type="Rigidbody", property="mass", value=5.0
     - Set multiple properties: action="set_property", target="Enemy", component_type="Rigidbody", properties={"mass": 5.0, "useGravity": false}
+    - List referenceable targets: action="get_referenceable", target="Player", component_type="AudioSource", property="clip"
+    - Set reference (asset): action="set_reference", target="Player", component_type="AudioSource", property="clip", reference_asset_path="Assets/Audio/BGM.mp3"
+    - Wire multiple references: action="batch_wire", target="GameManager", component_type="GameManager", references=[{"property_name": "player", "reference_path": "Player"}]
     """
     unity_instance = await get_unity_instance_from_context(ctx)
 

--- a/Server/src/services/tools/manage_components.py
+++ b/Server/src/services/tools/manage_components.py
@@ -1,6 +1,6 @@
 """
 Tool for managing components on GameObjects in Unity.
-Supports add, remove, and set_property operations.
+Supports add, remove, set_property, get_referenceable, set_reference, and batch_wire operations.
 """
 from typing import Annotated, Any, Literal, Optional
 
@@ -15,8 +15,9 @@ from services.tools.preflight import preflight
 
 @mcp_for_unity_tool(
     description=(
-        "Add, remove, or set properties on components attached to GameObjects. "
-        "Actions: add, remove, set_property. Requires target (instance ID or name) and component_type. "
+        "Add, remove, set properties, inspect referenceable targets, or wire object references on "
+        "components attached to GameObjects. Actions: add, remove, set_property, get_referenceable, "
+        "set_reference, batch_wire. Requires target (instance ID or name) and component_type. "
         "For READING component data, use the mcpforunity://scene/gameobject/{id}/components resource "
         "or mcpforunity://scene/gameobject/{id}/component/{name} for a single component. "
         "For creating/deleting GameObjects themselves, use manage_gameobject instead."
@@ -25,8 +26,10 @@ from services.tools.preflight import preflight
 async def manage_components(
     ctx: Context,
     action: Annotated[
-        Literal["add", "remove", "set_property"],
-        "Action to perform: add (add component), remove (remove component), set_property (set component property)"
+        Literal["add", "remove", "set_property", "get_referenceable", "set_reference", "batch_wire"],
+        "Action to perform: add (add component), remove (remove component), set_property (set component property), "
+        "get_referenceable (list valid object reference targets), set_reference (assign or clear an object reference), "
+        "batch_wire (assign multiple object references)"
     ],
     target: Annotated[
         str | int,
@@ -60,6 +63,42 @@ async def manage_components(
         "Zero-based index to select which component when multiple of the same type exist. "
         "Use the components resource to discover indices. If omitted, targets the first instance."
     ] = None,
+    reference_path: Annotated[
+        Optional[str],
+        "Path to the reference target GameObject (for set_reference or batch_wire)"
+    ] = None,
+    reference_asset_path: Annotated[
+        Optional[str],
+        "Asset path to the reference target asset (for set_reference or batch_wire)"
+    ] = None,
+    reference_instance_id: Annotated[
+        Optional[int],
+        "Instance ID of the reference target object (for set_reference or batch_wire)"
+    ] = None,
+    references: Annotated[
+        Optional[list[dict]],
+        "Batch wiring list for batch_wire, each item containing property_name and one reference selector"
+    ] = None,
+    include_scene: Annotated[
+        Optional[bool],
+        "Whether to include matching scene objects for get_referenceable"
+    ] = True,
+    include_assets: Annotated[
+        Optional[bool],
+        "Whether to include matching project assets for get_referenceable"
+    ] = True,
+    limit: Annotated[
+        Optional[int],
+        "Maximum number of get_referenceable results to return"
+    ] = None,
+    clear: Annotated[
+        Optional[bool],
+        "Clear the object reference instead of assigning a new target"
+    ] = None,
+    atomic: Annotated[
+        Optional[bool],
+        "Whether batch_wire should validate all references before applying any changes"
+    ] = True,
 ) -> dict[str, Any]:
     """
     Manage components on GameObjects.
@@ -68,6 +107,9 @@ async def manage_components(
     - add: Add a new component to a GameObject
     - remove: Remove a component from a GameObject  
     - set_property: Set one or more properties on a component
+    - get_referenceable: List valid reference targets for an object reference property
+    - set_reference: Assign or clear an object reference property
+    - batch_wire: Assign or clear multiple object reference properties
 
     Examples:
     - Add Rigidbody: action="add", target="Player", component_type="Rigidbody"
@@ -84,7 +126,7 @@ async def manage_components(
     if not action:
         return {
             "success": False,
-            "message": "Missing required parameter 'action'. Valid actions: add, remove, set_property"
+            "message": "Missing required parameter 'action'. Valid actions: add, remove, set_property, get_referenceable, set_reference, batch_wire"
         }
 
     if not target:
@@ -130,6 +172,33 @@ async def manage_components(
 
         if action == "add" and properties:
             params["properties"] = properties
+
+        if action in ("get_referenceable", "set_reference", "batch_wire") and property:
+            params["property"] = property
+
+        if action in ("set_reference", "batch_wire"):
+            if reference_path is not None:
+                params["reference_path"] = reference_path
+            if reference_asset_path is not None:
+                params["reference_asset_path"] = reference_asset_path
+            if reference_instance_id is not None:
+                params["reference_instance_id"] = reference_instance_id
+            if clear is not None:
+                params["clear"] = clear
+
+        if action == "get_referenceable":
+            if include_scene is not None:
+                params["include_scene"] = include_scene
+            if include_assets is not None:
+                params["include_assets"] = include_assets
+            if limit is not None:
+                params["limit"] = limit
+
+        if action == "batch_wire":
+            if references is not None:
+                params["references"] = references
+            if atomic is not None:
+                params["atomic"] = atomic
 
         response = await send_with_unity_instance(
             async_send_command_with_retry,

--- a/Server/tests/integration/test_manage_components.py
+++ b/Server/tests/integration/test_manage_components.py
@@ -1,7 +1,8 @@
 """
 Tests for the manage_components tool.
 
-This tool handles component lifecycle operations (add, remove, set_property).
+This tool handles component lifecycle operations (add, remove, set_property)
+and object reference wiring (get_referenceable, set_reference, batch_wire).
 """
 import pytest
 
@@ -240,3 +241,162 @@ async def test_manage_components_target_by_id(monkeypatch):
     assert captured["params"]["target"] == 12345
     assert captured["params"]["searchMethod"] == "by_id"
 
+
+@pytest.mark.asyncio
+async def test_manage_components_get_referenceable(monkeypatch):
+    """get_referenceable forwards property + discovery flags + limit to Unity."""
+    captured = {}
+
+    async def fake_send(cmd, params, **kwargs):
+        captured["cmd"] = cmd
+        captured["params"] = params
+        return {
+            "success": True,
+            "data": {
+                "scene_objects": [{"name": "Player", "instanceID": 1001}],
+                "assets": [{"name": "BGM", "assetPath": "Assets/Audio/BGM.mp3"}],
+            },
+        }
+
+    monkeypatch.setattr(
+        manage_comp_mod,
+        "async_send_command_with_retry",
+        fake_send,
+    )
+
+    resp = await manage_comp_mod.manage_components(
+        ctx=DummyContext(),
+        action="get_referenceable",
+        target="Player",
+        component_type="AudioSource",
+        property="clip",
+        include_scene=True,
+        include_assets=True,
+        limit=50,
+    )
+
+    assert resp.get("success") is True
+    assert captured["cmd"] == "manage_components"
+    assert captured["params"]["action"] == "get_referenceable"
+    assert captured["params"]["componentType"] == "AudioSource"
+    assert captured["params"]["property"] == "clip"
+    assert captured["params"]["include_scene"] is True
+    assert captured["params"]["include_assets"] is True
+    assert captured["params"]["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_manage_components_set_reference_asset_path(monkeypatch):
+    """set_reference forwards reference_asset_path to Unity."""
+    captured = {}
+
+    async def fake_send(cmd, params, **kwargs):
+        captured["params"] = params
+        return {
+            "success": True,
+            "data": {
+                "previous_value": None,
+                "new_value": {"name": "BGM", "assetPath": "Assets/Audio/BGM.mp3"},
+            },
+        }
+
+    monkeypatch.setattr(
+        manage_comp_mod,
+        "async_send_command_with_retry",
+        fake_send,
+    )
+
+    resp = await manage_comp_mod.manage_components(
+        ctx=DummyContext(),
+        action="set_reference",
+        target="Player",
+        component_type="AudioSource",
+        property="clip",
+        reference_asset_path="Assets/Audio/BGM.mp3",
+    )
+
+    assert resp.get("success") is True
+    assert captured["params"]["action"] == "set_reference"
+    assert captured["params"]["property"] == "clip"
+    assert captured["params"]["reference_asset_path"] == "Assets/Audio/BGM.mp3"
+    assert "reference_path" not in captured["params"]
+    assert "reference_instance_id" not in captured["params"]
+
+
+@pytest.mark.asyncio
+async def test_manage_components_set_reference_clear(monkeypatch):
+    """set_reference with clear=True forwards clear flag and omits selectors."""
+    captured = {}
+
+    async def fake_send(cmd, params, **kwargs):
+        captured["params"] = params
+        return {
+            "success": True,
+            "data": {"previous_value": {"name": "BGM"}, "new_value": None},
+        }
+
+    monkeypatch.setattr(
+        manage_comp_mod,
+        "async_send_command_with_retry",
+        fake_send,
+    )
+
+    resp = await manage_comp_mod.manage_components(
+        ctx=DummyContext(),
+        action="set_reference",
+        target="Player",
+        component_type="AudioSource",
+        property="clip",
+        clear=True,
+    )
+
+    assert resp.get("success") is True
+    assert captured["params"]["action"] == "set_reference"
+    assert captured["params"]["clear"] is True
+    assert "reference_path" not in captured["params"]
+    assert "reference_asset_path" not in captured["params"]
+    assert "reference_instance_id" not in captured["params"]
+
+
+@pytest.mark.asyncio
+async def test_manage_components_batch_wire(monkeypatch):
+    """batch_wire forwards references list and atomic flag."""
+    captured = {}
+
+    async def fake_send(cmd, params, **kwargs):
+        captured["params"] = params
+        return {
+            "success": True,
+            "data": {
+                "results": [
+                    {"property": "player", "success": True},
+                    {"property": "bgMusic", "success": True},
+                ]
+            },
+        }
+
+    monkeypatch.setattr(
+        manage_comp_mod,
+        "async_send_command_with_retry",
+        fake_send,
+    )
+
+    references = [
+        {"property_name": "player", "reference_path": "Player"},
+        {"property_name": "bgMusic", "reference_asset_path": "Assets/Audio/BGM.mp3"},
+    ]
+
+    resp = await manage_comp_mod.manage_components(
+        ctx=DummyContext(),
+        action="batch_wire",
+        target="GameManager",
+        component_type="GameManager",
+        references=references,
+        atomic=True,
+    )
+
+    assert resp.get("success") is True
+    assert captured["params"]["action"] == "batch_wire"
+    assert captured["params"]["componentType"] == "GameManager"
+    assert captured["params"]["references"] == references
+    assert captured["params"]["atomic"] is True

--- a/docs/guides/CLI_USAGE.md
+++ b/docs/guides/CLI_USAGE.md
@@ -108,6 +108,25 @@ unity-mcp component remove "Player" Rigidbody
 
 # Set property
 unity-mcp component set "Player" Rigidbody mass 10
+
+# List valid reference targets for an object reference field
+unity-mcp component get_referenceable "Player" AudioSource clip
+
+# Assign an object reference (project asset by path)
+unity-mcp component set_reference "Player" AudioSource clip \
+  --reference_asset_path "Assets/Audio/BGM.mp3"
+
+# Assign an object reference (scene object by hierarchy path)
+unity-mcp component set_reference "MainCamera" CinemachineCamera Follow \
+  --reference_path "Player"
+
+# Clear an object reference
+unity-mcp component set_reference "Player" AudioSource clip --clear
+
+# Wire multiple references on a component atomically
+unity-mcp component batch_wire "GameManager" GameManager --references \
+  '[{"property_name":"player","reference_path":"Player"},
+    {"property_name":"bgMusic","reference_asset_path":"Assets/Audio/BGM.mp3"}]'
 ```
 
 ### Script Operations


### PR DESCRIPTION
## Summary

Extends `manage_components` with 3 new actions for automating object reference field assignment — the programmatic equivalent of drag-and-drop in the Inspector.

### New Actions

| Action | What it does |
|--------|-------------|
| `get_referenceable` | List scene objects and project assets assignable to a reference field |
| `set_reference` | Assign an object reference to a component field |
| `batch_wire` | Wire multiple references in one atomic call |

### Example Usage

```python
# "What can I assign to the Player's AudioSource.clip field?"
manage_components(
    action="get_referenceable",
    target="Player",
    component_type="AudioSource",
    property="clip"
)

# "Set the Main Camera's target to the Player transform"
manage_components(
    action="set_reference",
    target="MainCamera",
    component_type="CinemachineCamera",
    property="Follow",
    reference_path="Player"
)

# "Wire up all references on the GameManager at once"
manage_components(
    action="batch_wire",
    target="GameManager",
    component_type="GameManager",
    references=[
        {"property_name": "player", "reference_path": "Player"},
        {"property_name": "scoreUI", "reference_path": "Canvas/ScoreText"},
        {"property_name": "bgMusic", "reference_asset_path": "Assets/Audio/BGM.mp3"},
    ]
)
```

### Implementation Details

**Python** (`Server/src/services/tools/manage_components.py`):
- Added new parameters: `reference_path`, `reference_asset_path`, `reference_instance_id`, `references`, `clear`, `atomic`, `include_scene`, `include_assets`, `limit`
- Routes through `send_with_unity_instance` same as existing actions

**C#** (`MCPForUnity/Editor/Tools/ManageComponents.cs`):
- `get_referenceable`: resolves field type via reflection, searches scene (`FindObjectsOfType`) and assets (`AssetDatabase.FindAssets`) for matching types
- `set_reference`: uses `SerializedObject` + `SerializedProperty.objectReferenceValue` for correct prefab override tracking and Undo support
- `batch_wire`: atomic mode (default) validates all entries first, then applies all writes in a single Undo group
- Shared helpers: `TryGetComponentAndObjectReferenceProperty`, `ResolveReference`, `ValidateReferenceAssignment`

### Design Decisions

- **Extends existing tool** rather than new top-level tools — follows the `manage_*` multi-action pattern
- **SerializedProperty** for writes (not raw reflection) — correct dirty state, prefab overrides, Undo
- **Undo support** on all mutations via `Undo.RecordObject` + grouped operations for batch
- **Type validation** before assignment — prevents assigning wrong types
- **Three reference selectors**: scene path, asset path, instance ID — covers all common cases
- **Auto-component resolution**: if field expects a Component type but a GameObject is provided, automatically calls `GetComponent`

### Reference Selectors

| Selector | Use Case |
|----------|----------|
| `reference_path` | Scene object by hierarchy path (e.g., "Player/Model") |
| `reference_asset_path` | Project asset (e.g., "Assets/Materials/Red.mat") |
| `reference_instance_id` | Direct instance ID (most precise) |
| `clear=true` | Set reference to null |

## Test plan

- [ ] `get_referenceable` returns correct types for Transform, AudioClip, Material fields
- [ ] `set_reference` with scene object path
- [ ] `set_reference` with project asset path
- [ ] `set_reference` with instance ID
- [ ] `set_reference` with `clear=true`
- [ ] `set_reference` type mismatch returns error
- [ ] `batch_wire` atomic success (all valid)
- [ ] `batch_wire` atomic failure (one invalid, none applied)
- [ ] `batch_wire` non-atomic partial success
- [ ] Undo works after set_reference and batch_wire
- [ ] Prefab override tracking works correctly

## Summary by Sourcery

Extend the manage_components tool to support querying and assigning Unity object reference fields, including batch wiring of multiple references.

New Features:
- Add get_referenceable action to list valid scene objects and assets for a given object reference property.
- Add set_reference action to assign or clear a single object reference on a component property with proper Unity editor integration.
- Add batch_wire action to validate and apply multiple reference assignments in one call, with optional atomic behavior.

Enhancements:
- Enhance manage_components Python wrapper with parameters for reference paths, asset paths, instance IDs, batch reference lists, and query controls for referenceable targets.