### PR TITLE
Fix/restore openclaw

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
@@ -17,7 +17,9 @@ namespace MCPForUnity.Editor.Clients.Configurators
     {
         private const string PluginName = "openclaw-mcp-bridge";
         private const string ServerName = "unityMCP";
-        private const string TransportName = "http";
+        private const string HttpTransportName = "http";
+        private const string StdioTransportName = "stdio";
+        private const string StdioUrl = "stdio://local";
 
         public OpenClawConfigurator() : base(new McpClient
         {
@@ -65,7 +67,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
                 if (matches)
                 {
                     client.SetStatus(McpStatus.Configured);
-                    client.configuredTransport = ResolveTransport(unityServer["url"]?.ToString());
+                    client.configuredTransport = ResolveTransport(unityServer);
                     return client.status;
                 }
 
@@ -90,12 +92,6 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
         public override void Configure()
         {
-            if (!EditorConfigurationCache.Instance.UseHttpTransport)
-            {
-                throw new InvalidOperationException(
-                    "OpenClaw uses HTTP MCP via openclaw-mcp-bridge. Switch transport to HTTP in MCP for Unity settings first.");
-            }
-
             string path = GetConfigPath();
             McpConfigurationHelper.EnsureConfigDirectoryExists(path);
 
@@ -124,12 +120,6 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
         public override string GetManualSnippet()
         {
-            if (!EditorConfigurationCache.Instance.UseHttpTransport)
-            {
-                return "# OpenClaw integration requires HTTP transport.\n"
-                    + "# Switch to HTTP in MCP for Unity settings, then configure OpenClaw again.";
-            }
-
             JObject snippet = new JObject
             {
                 ["plugins"] = new JObject
@@ -159,8 +149,9 @@ namespace MCPForUnity.Editor.Clients.Configurators
             "Install OpenClaw",
             "Install the bridge plugin: npm install -g openclaw-mcp-bridge (or pnpm add -g openclaw-mcp-bridge)",
             "In MCP for Unity, choose OpenClaw and click Configure",
+            "OpenClaw uses the currently selected MCP for Unity transport (HTTP or stdio)",
             "OpenClaw exposes a proxy tool such as unityMCP__call for Unity MCP access",
-            "Restart OpenClaw"
+            "Restart OpenClaw if the plugin does not hot-reload the new config"
         };
 
         private JObject LoadConfig(string path)
@@ -214,14 +205,21 @@ namespace MCPForUnity.Editor.Clients.Configurators
         {
             JObject servers = NormalizeServers(serversToken);
             JObject entry = servers[ServerName] as JObject ?? new JObject();
+            JObject desiredEntry = BuildUnityServerEntry();
 
             entry.Remove("name");
             entry.Remove("prefix");
             entry.Remove("healthCheck");
-            entry["enabled"] = true;
-            entry["url"] = HttpEndpointUtility.GetMcpRpcUrl();
-            entry["transport"] = TransportName;
-            entry["toolPrefix"] = ServerName;
+            entry.Remove("command");
+            entry.Remove("args");
+            entry.Remove("env");
+            entry.Remove("connectTimeoutMs");
+
+            foreach (var property in desiredEntry.Properties())
+            {
+                entry[property.Name] = property.Value.DeepClone();
+            }
+
             servers[ServerName] = entry;
 
             return servers;
@@ -261,11 +259,46 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
         private static JObject BuildUnityServerEntry()
         {
+            ConfiguredTransport transport = HttpEndpointUtility.GetCurrentServerTransport();
+            if (transport == ConfiguredTransport.Stdio)
+            {
+                var (uvxPath, _, packageName) = AssetPathUtility.GetUvxCommandParts();
+                if (string.IsNullOrWhiteSpace(uvxPath))
+                {
+                    throw new InvalidOperationException("uvx not found. Install uv/uvx or set the override in Advanced Settings.");
+                }
+
+                var args = new JArray();
+                foreach (string value in AssetPathUtility.GetUvxDevFlagsList())
+                {
+                    args.Add(value);
+                }
+                foreach (string value in AssetPathUtility.GetBetaServerFromArgsList())
+                {
+                    args.Add(value);
+                }
+                args.Add(packageName);
+                args.Add("--transport");
+                args.Add("stdio");
+
+                return new JObject
+                {
+                    ["enabled"] = true,
+                    ["url"] = StdioUrl,
+                    ["transport"] = StdioTransportName,
+                    ["command"] = uvxPath,
+                    ["args"] = args,
+                    ["toolPrefix"] = ServerName,
+                    ["requestTimeoutMs"] = 60000,
+                    ["connectTimeoutMs"] = 15000
+                };
+            }
+
             return new JObject
             {
                 ["enabled"] = true,
                 ["url"] = HttpEndpointUtility.GetMcpRpcUrl(),
-                ["transport"] = TransportName,
+                ["transport"] = HttpTransportName,
                 ["toolPrefix"] = ServerName,
                 ["requestTimeoutMs"] = 30000
             };
@@ -278,19 +311,31 @@ namespace MCPForUnity.Editor.Clients.Configurators
                 return false;
             }
 
-            string configuredUrl = server["url"]?.ToString();
-            if (string.IsNullOrWhiteSpace(configuredUrl) ||
-                (!UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalMcpRpcUrl()) &&
-                 !UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteMcpRpcUrl())))
+            ConfiguredTransport expectedTransport = HttpEndpointUtility.GetCurrentServerTransport();
+            ConfiguredTransport configuredTransport = ResolveTransport(server);
+            if (configuredTransport != expectedTransport)
             {
                 return false;
             }
 
-            string configuredTransport = server["transport"]?.ToString();
-            if (!string.IsNullOrWhiteSpace(configuredTransport) &&
-                !string.Equals(configuredTransport, TransportName, StringComparison.OrdinalIgnoreCase))
+            if (configuredTransport == ConfiguredTransport.Stdio)
             {
-                return false;
+                string configuredUrl = server["url"]?.ToString();
+                string command = server["command"]?.ToString();
+                if (!UrlsEqual(configuredUrl, StdioUrl) || string.IsNullOrWhiteSpace(command))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                string configuredUrl = server["url"]?.ToString();
+                if (string.IsNullOrWhiteSpace(configuredUrl) ||
+                    (!UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalMcpRpcUrl()) &&
+                     !UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteMcpRpcUrl())))
+                {
+                    return false;
+                }
             }
 
             string toolPrefix = server["toolPrefix"]?.ToString();
@@ -304,8 +349,17 @@ namespace MCPForUnity.Editor.Clients.Configurators
             return enabledToken == null || enabledToken.Type != JTokenType.Boolean || enabledToken.Value<bool>();
         }
 
-        private ConfiguredTransport ResolveTransport(string configuredUrl)
+        private ConfiguredTransport ResolveTransport(JObject server)
         {
+            string configuredTransport = server?["transport"]?.ToString();
+            string configuredUrl = server?["url"]?.ToString();
+
+            if (string.Equals(configuredTransport, StdioTransportName, StringComparison.OrdinalIgnoreCase) ||
+                UrlsEqual(configuredUrl, StdioUrl))
+            {
+                return ConfiguredTransport.Stdio;
+            }
+
             if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteMcpRpcUrl()))
             {
                 return ConfiguredTransport.HttpRemote;

--- a/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
@@ -17,6 +17,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
     {
         private const string PluginName = "openclaw-mcp-bridge";
         private const string ServerName = "unityMCP";
+        private const string TransportName = "http";
 
         public OpenClawConfigurator() : base(new McpClient
         {
@@ -50,21 +51,21 @@ namespace MCPForUnity.Editor.Clients.Configurators
                 }
 
                 JObject root = LoadConfig(path);
-                JObject unityServer = FindUnityServer(root);
+                JObject pluginEntry = root["plugins"]?["entries"]?[PluginName] as JObject;
+                JObject unityServer = FindUnityServer(pluginEntry?["config"]?["servers"]);
 
-                if (unityServer == null)
+                if (pluginEntry == null || unityServer == null || !IsEnabled(pluginEntry) || !IsEnabled(unityServer))
                 {
                     client.SetStatus(McpStatus.NotConfigured);
                     client.configuredTransport = ConfiguredTransport.Unknown;
                     return client.status;
                 }
 
-                string configuredUrl = unityServer["url"]?.ToString();
-                bool matches = UrlMatchesCurrentEndpoint(configuredUrl);
+                bool matches = ServerMatchesCurrentEndpoint(unityServer);
                 if (matches)
                 {
                     client.SetStatus(McpStatus.Configured);
-                    client.configuredTransport = ResolveTransport(configuredUrl);
+                    client.configuredTransport = ResolveTransport(unityServer["url"]?.ToString());
                     return client.status;
                 }
 
@@ -112,17 +113,9 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
             JObject pluginConfig = pluginEntry["config"] as JObject ?? new JObject();
             pluginEntry["config"] = pluginConfig;
-            pluginConfig["servers"] = UpsertUnityServer(pluginConfig["servers"] as JArray ?? new JArray());
-
-            if (pluginConfig["timeout"] == null)
-            {
-                pluginConfig["timeout"] = 30000;
-            }
-
-            if (pluginConfig["retries"] == null)
-            {
-                pluginConfig["retries"] = 1;
-            }
+            pluginConfig.Remove("timeout");
+            pluginConfig.Remove("retries");
+            pluginConfig["servers"] = UpsertUnityServer(pluginConfig["servers"]);
 
             McpConfigurationHelper.WriteAtomicFile(path, root.ToString(Formatting.Indented));
             client.SetStatus(McpStatus.Configured);
@@ -148,9 +141,10 @@ namespace MCPForUnity.Editor.Clients.Configurators
                             ["enabled"] = true,
                             ["config"] = new JObject
                             {
-                                ["servers"] = new JArray(BuildUnityServerEntry()),
-                                ["timeout"] = 30000,
-                                ["retries"] = 1
+                                ["servers"] = new JObject
+                                {
+                                    [ServerName] = BuildUnityServerEntry()
+                                }
                             }
                         }
                     }
@@ -165,6 +159,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
             "Install OpenClaw",
             "Install the bridge plugin: npm install -g openclaw-mcp-bridge (or pnpm add -g openclaw-mcp-bridge)",
             "In MCP for Unity, choose OpenClaw and click Configure",
+            "OpenClaw exposes a proxy tool such as unityMCP__call for Unity MCP access",
             "Restart OpenClaw"
         };
 
@@ -187,98 +182,136 @@ namespace MCPForUnity.Editor.Clients.Configurators
             }
         }
 
-        private JObject FindUnityServer(JObject root)
+        private JObject FindUnityServer(JToken serversToken)
         {
-            JArray servers = root["plugins"]?["entries"]?[PluginName]?["config"]?["servers"] as JArray;
-            if (servers == null)
+            if (serversToken is JObject serverMap)
             {
-                return null;
+                return serverMap[ServerName] as JObject;
             }
 
-            foreach (JToken token in servers)
+            if (serversToken is JArray legacyServers)
             {
-                JObject server = token as JObject;
-                if (server == null)
+                foreach (JToken token in legacyServers)
                 {
-                    continue;
-                }
+                    JObject server = token as JObject;
+                    if (server == null)
+                    {
+                        continue;
+                    }
 
-                string name = server["name"]?.ToString();
-                if (string.Equals(name, ServerName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return server;
+                    string name = server["name"]?.ToString();
+                    if (string.Equals(name, ServerName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return server;
+                    }
                 }
             }
 
             return null;
         }
 
-        private JArray UpsertUnityServer(JArray servers)
+        private JObject UpsertUnityServer(JToken serversToken)
         {
-            JObject existing = null;
-            foreach (JToken token in servers)
+            JObject servers = NormalizeServers(serversToken);
+            JObject entry = servers[ServerName] as JObject ?? new JObject();
+
+            entry.Remove("name");
+            entry.Remove("prefix");
+            entry.Remove("healthCheck");
+            entry["enabled"] = true;
+            entry["url"] = HttpEndpointUtility.GetMcpRpcUrl();
+            entry["transport"] = TransportName;
+            entry["toolPrefix"] = ServerName;
+            servers[ServerName] = entry;
+
+            return servers;
+        }
+
+        private static JObject NormalizeServers(JToken serversToken)
+        {
+            if (serversToken is JObject serverMap)
             {
-                JObject candidate = token as JObject;
-                if (candidate == null)
+                return serverMap;
+            }
+
+            var normalized = new JObject();
+            if (!(serversToken is JArray legacyServers))
+            {
+                return normalized;
+            }
+
+            foreach (JToken token in legacyServers)
+            {
+                if (!(token is JObject legacyServer))
                 {
                     continue;
                 }
 
-                string name = candidate["name"]?.ToString();
-                if (string.Equals(name, ServerName, StringComparison.OrdinalIgnoreCase))
+                string name = legacyServer["name"]?.ToString();
+                if (string.IsNullOrWhiteSpace(name))
                 {
-                    existing = candidate;
-                    break;
+                    continue;
                 }
+
+                normalized[name] = legacyServer;
             }
 
-            JObject entry = existing ?? BuildUnityServerEntry();
-            entry["name"] = ServerName;
-            entry["url"] = HttpEndpointUtility.GetBaseUrl();
-            entry["prefix"] = "unity";
-            entry["healthCheck"] = true;
-
-            if (existing == null)
-            {
-                servers.Add(entry);
-            }
-
-            return servers;
+            return normalized;
         }
 
         private static JObject BuildUnityServerEntry()
         {
             return new JObject
             {
-                ["name"] = ServerName,
-                ["url"] = HttpEndpointUtility.GetBaseUrl(),
-                ["prefix"] = "unity",
-                ["healthCheck"] = true
+                ["enabled"] = true,
+                ["url"] = HttpEndpointUtility.GetMcpRpcUrl(),
+                ["transport"] = TransportName,
+                ["toolPrefix"] = ServerName,
+                ["requestTimeoutMs"] = 30000
             };
         }
 
-        private bool UrlMatchesCurrentEndpoint(string configuredUrl)
+        private bool ServerMatchesCurrentEndpoint(JObject server)
         {
-            if (string.IsNullOrWhiteSpace(configuredUrl))
+            if (server == null)
             {
                 return false;
             }
 
-            string baseUrl = HttpEndpointUtility.GetBaseUrl();
-            string rpcUrl = HttpEndpointUtility.GetMcpRpcUrl();
-            return UrlsEqual(configuredUrl, baseUrl) || UrlsEqual(configuredUrl, rpcUrl);
+            string configuredUrl = server["url"]?.ToString();
+            if (string.IsNullOrWhiteSpace(configuredUrl) ||
+                (!UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalMcpRpcUrl()) &&
+                 !UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteMcpRpcUrl())))
+            {
+                return false;
+            }
+
+            string configuredTransport = server["transport"]?.ToString();
+            if (!string.IsNullOrWhiteSpace(configuredTransport) &&
+                !string.Equals(configuredTransport, TransportName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            string toolPrefix = server["toolPrefix"]?.ToString();
+            return string.IsNullOrWhiteSpace(toolPrefix) ||
+                   string.Equals(toolPrefix, ServerName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsEnabled(JObject entry)
+        {
+            JToken enabledToken = entry["enabled"];
+            return enabledToken == null || enabledToken.Type != JTokenType.Boolean || enabledToken.Value<bool>();
         }
 
         private ConfiguredTransport ResolveTransport(string configuredUrl)
         {
-            if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteBaseUrl()) ||
-                UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteMcpRpcUrl()))
+            if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteMcpRpcUrl()))
             {
                 return ConfiguredTransport.HttpRemote;
             }
 
-            if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalBaseUrl()) ||
-                UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalMcpRpcUrl()))
+            if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalMcpRpcUrl()))
             {
                 return ConfiguredTransport.Http;
             }

--- a/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Models;
 using MCPForUnity.Editor.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using UnityEditor;
 
 namespace MCPForUnity.Editor.Clients.Configurators
 {
@@ -56,7 +58,14 @@ namespace MCPForUnity.Editor.Clients.Configurators
                 JObject pluginEntry = root["plugins"]?["entries"]?[PluginName] as JObject;
                 JObject unityServer = FindUnityServer(pluginEntry?["config"]?["servers"]);
 
-                if (pluginEntry == null || unityServer == null || !IsEnabled(pluginEntry) || !IsEnabled(unityServer))
+                if (pluginEntry == null || unityServer == null)
+                {
+                    client.SetStatus(McpStatus.MissingConfig);
+                    client.configuredTransport = ConfiguredTransport.Unknown;
+                    return client.status;
+                }
+
+                if (!IsEnabled(pluginEntry) || !IsEnabled(unityServer))
                 {
                     client.SetStatus(McpStatus.NotConfigured);
                     client.configuredTransport = ConfiguredTransport.Unknown;
@@ -92,6 +101,9 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
         public override void Configure()
         {
+            if (EditorPrefs.GetBool(EditorPrefKeys.LockCursorConfig, false))
+                return;
+
             string path = GetConfigPath();
             McpConfigurationHelper.EnsureConfigDirectoryExists(path);
 
@@ -109,8 +121,8 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
             JObject pluginConfig = pluginEntry["config"] as JObject ?? new JObject();
             pluginEntry["config"] = pluginConfig;
-            pluginConfig.Remove("timeout");
-            pluginConfig.Remove("retries");
+            pluginConfig.Remove("timeout");  // removed in openclaw-mcp-bridge v2+
+            pluginConfig.Remove("retries");  // removed in openclaw-mcp-bridge v2+
             pluginConfig["servers"] = UpsertUnityServer(pluginConfig["servers"]);
 
             McpConfigurationHelper.WriteAtomicFile(path, root.ToString(Formatting.Indented));
@@ -323,6 +335,16 @@ namespace MCPForUnity.Editor.Clients.Configurators
                 string configuredUrl = server["url"]?.ToString();
                 string command = server["command"]?.ToString();
                 if (!UrlsEqual(configuredUrl, StdioUrl) || string.IsNullOrWhiteSpace(command))
+                {
+                    return false;
+                }
+
+                // Validate the --from package source hasn't drifted (e.g. stable vs prerelease switch)
+                string[] args = (server["args"] as JArray)?.ToObject<string[]>();
+                string configuredSource = McpConfigurationHelper.ExtractUvxUrl(args);
+                string expectedSource = GetExpectedPackageSourceForValidation();
+                if (!string.IsNullOrEmpty(configuredSource) && !string.IsNullOrEmpty(expectedSource) &&
+                    !McpConfigurationHelper.PathsEqual(configuredSource, expectedSource))
                 {
                     return false;
                 }

--- a/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Models;
+using MCPForUnity.Editor.Services;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MCPForUnity.Editor.Clients.Configurators
+{
+    /// <summary>
+    /// Configurator for OpenClaw via the openclaw-mcp-bridge plugin.
+    /// OpenClaw stores config at ~/.openclaw/openclaw.json.
+    /// </summary>
+    public class OpenClawConfigurator : McpClientConfiguratorBase
+    {
+        private const string PluginName = "openclaw-mcp-bridge";
+        private const string ServerName = "unityMCP";
+
+        public OpenClawConfigurator() : base(new McpClient
+        {
+            name = "OpenClaw",
+            windowsConfigPath = BuildConfigPath(),
+            macConfigPath = BuildConfigPath(),
+            linuxConfigPath = BuildConfigPath()
+        })
+        { }
+
+        private static string BuildConfigPath()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".openclaw",
+                "openclaw.json");
+        }
+
+        public override string GetConfigPath() => CurrentOsPath();
+
+        public override McpStatus CheckStatus(bool attemptAutoRewrite = true)
+        {
+            try
+            {
+                string path = GetConfigPath();
+                if (!File.Exists(path))
+                {
+                    client.SetStatus(McpStatus.NotConfigured);
+                    client.configuredTransport = ConfiguredTransport.Unknown;
+                    return client.status;
+                }
+
+                JObject root = LoadConfig(path);
+                JObject unityServer = FindUnityServer(root);
+
+                if (unityServer == null)
+                {
+                    client.SetStatus(McpStatus.NotConfigured);
+                    client.configuredTransport = ConfiguredTransport.Unknown;
+                    return client.status;
+                }
+
+                string configuredUrl = unityServer["url"]?.ToString();
+                bool matches = UrlMatchesCurrentEndpoint(configuredUrl);
+                if (matches)
+                {
+                    client.SetStatus(McpStatus.Configured);
+                    client.configuredTransport = ResolveTransport(configuredUrl);
+                    return client.status;
+                }
+
+                if (attemptAutoRewrite)
+                {
+                    Configure();
+                }
+                else
+                {
+                    client.SetStatus(McpStatus.IncorrectPath);
+                    client.configuredTransport = ConfiguredTransport.Unknown;
+                }
+            }
+            catch (Exception ex)
+            {
+                client.SetStatus(McpStatus.Error, ex.Message);
+                client.configuredTransport = ConfiguredTransport.Unknown;
+            }
+
+            return client.status;
+        }
+
+        public override void Configure()
+        {
+            if (!EditorConfigurationCache.Instance.UseHttpTransport)
+            {
+                throw new InvalidOperationException(
+                    "OpenClaw uses HTTP MCP via openclaw-mcp-bridge. Switch transport to HTTP in MCP for Unity settings first.");
+            }
+
+            string path = GetConfigPath();
+            McpConfigurationHelper.EnsureConfigDirectoryExists(path);
+
+            JObject root = File.Exists(path) ? LoadConfig(path) : new JObject();
+
+            JObject plugins = root["plugins"] as JObject ?? new JObject();
+            root["plugins"] = plugins;
+
+            JObject entries = plugins["entries"] as JObject ?? new JObject();
+            plugins["entries"] = entries;
+
+            JObject pluginEntry = entries[PluginName] as JObject ?? new JObject();
+            entries[PluginName] = pluginEntry;
+            pluginEntry["enabled"] = true;
+
+            JObject pluginConfig = pluginEntry["config"] as JObject ?? new JObject();
+            pluginEntry["config"] = pluginConfig;
+            pluginConfig["servers"] = UpsertUnityServer(pluginConfig["servers"] as JArray ?? new JArray());
+
+            if (pluginConfig["timeout"] == null)
+            {
+                pluginConfig["timeout"] = 30000;
+            }
+
+            if (pluginConfig["retries"] == null)
+            {
+                pluginConfig["retries"] = 1;
+            }
+
+            McpConfigurationHelper.WriteAtomicFile(path, root.ToString(Formatting.Indented));
+            client.SetStatus(McpStatus.Configured);
+            client.configuredTransport = HttpEndpointUtility.GetCurrentServerTransport();
+        }
+
+        public override string GetManualSnippet()
+        {
+            if (!EditorConfigurationCache.Instance.UseHttpTransport)
+            {
+                return "# OpenClaw integration requires HTTP transport.\n"
+                    + "# Switch to HTTP in MCP for Unity settings, then configure OpenClaw again.";
+            }
+
+            JObject snippet = new JObject
+            {
+                ["plugins"] = new JObject
+                {
+                    ["entries"] = new JObject
+                    {
+                        [PluginName] = new JObject
+                        {
+                            ["enabled"] = true,
+                            ["config"] = new JObject
+                            {
+                                ["servers"] = new JArray(BuildUnityServerEntry()),
+                                ["timeout"] = 30000,
+                                ["retries"] = 1
+                            }
+                        }
+                    }
+                }
+            };
+
+            return snippet.ToString(Formatting.Indented);
+        }
+
+        public override IList<string> GetInstallationSteps() => new List<string>
+        {
+            "Install OpenClaw",
+            "Install the bridge plugin: npm install -g openclaw-mcp-bridge (or pnpm add -g openclaw-mcp-bridge)",
+            "In MCP for Unity, choose OpenClaw and click Configure",
+            "Restart OpenClaw"
+        };
+
+        private JObject LoadConfig(string path)
+        {
+            string text = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return new JObject();
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<JObject>(text) ?? new JObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(
+                    $"OpenClaw config contains non-JSON content and cannot be safely auto-edited: {ex.Message}");
+            }
+        }
+
+        private JObject FindUnityServer(JObject root)
+        {
+            JArray servers = root["plugins"]?["entries"]?[PluginName]?["config"]?["servers"] as JArray;
+            if (servers == null)
+            {
+                return null;
+            }
+
+            foreach (JToken token in servers)
+            {
+                JObject server = token as JObject;
+                if (server == null)
+                {
+                    continue;
+                }
+
+                string name = server["name"]?.ToString();
+                if (string.Equals(name, ServerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return server;
+                }
+            }
+
+            return null;
+        }
+
+        private JArray UpsertUnityServer(JArray servers)
+        {
+            JObject existing = null;
+            foreach (JToken token in servers)
+            {
+                JObject candidate = token as JObject;
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                string name = candidate["name"]?.ToString();
+                if (string.Equals(name, ServerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    existing = candidate;
+                    break;
+                }
+            }
+
+            JObject entry = existing ?? BuildUnityServerEntry();
+            entry["name"] = ServerName;
+            entry["url"] = HttpEndpointUtility.GetBaseUrl();
+            entry["prefix"] = "unity";
+            entry["healthCheck"] = true;
+
+            if (existing == null)
+            {
+                servers.Add(entry);
+            }
+
+            return servers;
+        }
+
+        private static JObject BuildUnityServerEntry()
+        {
+            return new JObject
+            {
+                ["name"] = ServerName,
+                ["url"] = HttpEndpointUtility.GetBaseUrl(),
+                ["prefix"] = "unity",
+                ["healthCheck"] = true
+            };
+        }
+
+        private bool UrlMatchesCurrentEndpoint(string configuredUrl)
+        {
+            if (string.IsNullOrWhiteSpace(configuredUrl))
+            {
+                return false;
+            }
+
+            string baseUrl = HttpEndpointUtility.GetBaseUrl();
+            string rpcUrl = HttpEndpointUtility.GetMcpRpcUrl();
+            return UrlsEqual(configuredUrl, baseUrl) || UrlsEqual(configuredUrl, rpcUrl);
+        }
+
+        private ConfiguredTransport ResolveTransport(string configuredUrl)
+        {
+            if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteBaseUrl()) ||
+                UrlsEqual(configuredUrl, HttpEndpointUtility.GetRemoteMcpRpcUrl()))
+            {
+                return ConfiguredTransport.HttpRemote;
+            }
+
+            if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalBaseUrl()) ||
+                UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalMcpRpcUrl()))
+            {
+                return ConfiguredTransport.Http;
+            }
+
+            return ConfiguredTransport.Unknown;
+        }
+    }
+}

--- a/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs.meta
+++ b/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19f29c88761345158fc766d24e7c18f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MCPForUnity/README.md
+++ b/MCPForUnity/README.md
@@ -17,7 +17,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
    - Install Python and/or uv/uvx if missing so the server can be managed locally.
    - For Claude Code, ensure the `claude` CLI is installed.
 4. Click “Start Bridge” if the Unity Bridge shows “Stopped”.
-5. Use your MCP client (Cursor, VS Code, Windsurf, OpenClaw, Claude Code) to connect.
+5. Use your MCP client (Cursor, VS Code, OpenClaw, Claude Code) to connect.
 
 ---
 

--- a/MCPForUnity/README.md
+++ b/MCPForUnity/README.md
@@ -62,7 +62,9 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
     - The window displays the resolved Claude CLI path when detected.
   - OpenClaw:
     - Uses `~/.openclaw/openclaw.json` and the `openclaw-mcp-bridge` plugin.
+    - MCP for Unity writes `plugins.entries.openclaw-mcp-bridge.config.servers.unityMCP`.
     - OpenClaw requires HTTP transport for MCP for Unity.
+    - The bridge exposes a proxy tool such as `unityMCP__call`.
 
 Notes:
 - The UI shows a status dot and a short status text (e.g., “Configured”, “uv Not Found”, “Claude Not Found”).

--- a/MCPForUnity/README.md
+++ b/MCPForUnity/README.md
@@ -17,7 +17,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
    - Install Python and/or uv/uvx if missing so the server can be managed locally.
    - For Claude Code, ensure the `claude` CLI is installed.
 4. Click “Start Bridge” if the Unity Bridge shows “Stopped”.
-5. Use your MCP client (Cursor, VS Code, Windsurf, Claude Code) to connect.
+5. Use your MCP client (Cursor, VS Code, Windsurf, OpenClaw, Claude Code) to connect.
 
 ---
 
@@ -60,6 +60,9 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
     - Register with Claude Code / Unregister MCP for Unity with Claude Code.
     - If the CLI isn’t found, click “Choose Claude Install Location”.
     - The window displays the resolved Claude CLI path when detected.
+  - OpenClaw:
+    - Uses `~/.openclaw/openclaw.json` and the `openclaw-mcp-bridge` plugin.
+    - OpenClaw requires HTTP transport for MCP for Unity.
 
 Notes:
 - The UI shows a status dot and a short status text (e.g., “Configured”, “uv Not Found”, “Claude Not Found”).

--- a/MCPForUnity/README.md
+++ b/MCPForUnity/README.md
@@ -63,7 +63,7 @@ The window has four areas: Server Status, Unity Bridge, MCP Client Configuration
   - OpenClaw:
     - Uses `~/.openclaw/openclaw.json` and the `openclaw-mcp-bridge` plugin.
     - MCP for Unity writes `plugins.entries.openclaw-mcp-bridge.config.servers.unityMCP`.
-    - OpenClaw requires HTTP transport for MCP for Unity.
+    - OpenClaw follows the currently selected MCP for Unity transport (`HTTP` or `stdio`).
     - The bridge exposes a proxy tool such as `unityMCP__call`.
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 * **Unity 2021.3 LTS+** — [Download Unity](https://unity.com/download)
 * **Python 3.10+** and **uv** — [Install uv](https://docs.astral.sh/uv/getting-started/installation/)
-* **An MCP Client** — [Claude Desktop](https://claude.ai/download) | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [Windsurf](https://windsurf.com)
+* **An MCP Client** — [Claude Desktop](https://claude.ai/download) | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [Windsurf](https://windsurf.com) | [OpenClaw](https://openclaw.ai)
 
 ### 1. Install the Unity Package
 
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. Click **Start Server** (launches HTTP server on `localhost:8080`)
 3. Select your MCP Client from the dropdown and click **Configure**
 4. Look for 🟢 "Connected ✓"
-5. **Connect your client:** Some clients (Cursor, Windsurf, Antigravity) require enabling an MCP toggle in settings, while others (Claude Desktop, Claude Code) auto-connect after configuration.
+5. **Connect your client:** Some clients (Cursor, Windsurf, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings, while others (Claude Desktop, Claude Code) auto-connect after configuration.
 
 **That's it!** Try a prompt like: *"Create a red, blue and yellow cube"* or *"Build a simple player controller"*
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. Click **Start Server** (launches HTTP server on `localhost:8080`)
 3. Select your MCP Client from the dropdown and click **Configure**
 4. Look for 🟢 "Connected ✓"
-5. **Connect your client:** Some clients (Cursor, Windsurf, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled. Others (Claude Desktop, Claude Code) auto-connect after configuration.
+5. **Connect your client:** Some clients (Cursor, Windsurf, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Others (Claude Desktop, Claude Code) auto-connect after configuration.
 
 **That's it!** Try a prompt like: *"Create a red, blue and yellow cube"* or *"Build a simple player controller"*
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 * **Unity 2021.3 LTS+** — [Download Unity](https://unity.com/download)
 * **Python 3.10+** and **uv** — [Install uv](https://docs.astral.sh/uv/getting-started/installation/)
-* **An MCP Client** — [Claude Desktop](https://claude.ai/download) | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [Windsurf](https://windsurf.com) | [OpenClaw](https://openclaw.ai)
+* **An MCP Client** — [Claude Desktop](https://claude.ai/download) | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [OpenClaw](https://openclaw.ai)
 
 ### 1. Install the Unity Package
 
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. Click **Start Server** (launches HTTP server on `localhost:8080`)
 3. Select your MCP Client from the dropdown and click **Configure**
 4. Look for 🟢 "Connected ✓"
-5. **Connect your client:** Some clients (Cursor, Windsurf, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Others (Claude Desktop, Claude Code) auto-connect after configuration.
+5. **Connect your client:** Some clients (Cursor, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Others (Claude Desktop, Claude Code) auto-connect after configuration.
 
 **That's it!** Try a prompt like: *"Create a red, blue and yellow cube"* or *"Build a simple player controller"*
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. Click **Start Server** (launches HTTP server on `localhost:8080`)
 3. Select your MCP Client from the dropdown and click **Configure**
 4. Look for 🟢 "Connected ✓"
-5. **Connect your client:** Some clients (Cursor, Windsurf, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings, while others (Claude Desktop, Claude Code) auto-connect after configuration.
+5. **Connect your client:** Some clients (Cursor, Windsurf, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled. Others (Claude Desktop, Claude Code) auto-connect after configuration.
 
 **That's it!** Try a prompt like: *"Create a red, blue and yellow cube"* or *"Build a simple player controller"*
 

--- a/docs/guides/MCP_CLIENT_CONFIGURATORS.md
+++ b/docs/guides/MCP_CLIENT_CONFIGURATORS.md
@@ -170,9 +170,10 @@ Some clients cannot be handled by the generic JSON configurator alone.
 - Uses a custom configurator (`OpenClawConfigurator`) because OpenClaw MCP is plugin-driven.
 - Config file path is `~/.openclaw/openclaw.json`.
 - Unity MCP is configured through `plugins.entries.openclaw-mcp-bridge.config.servers.unityMCP`.
-- The bridge expects the MCP JSON-RPC endpoint URL (`http://127.0.0.1:<port>/mcp`), not just the HTTP base URL.
+- When Unity MCP is set to HTTP, the bridge expects the MCP JSON-RPC endpoint URL (`http://127.0.0.1:<port>/mcp`), not just the HTTP base URL.
+- When Unity MCP is set to stdio, the configurator writes a `uvx ... mcp-for-unity --transport stdio` subprocess entry.
 - The bridge exposes a single proxy tool such as `unityMCP__call`, which then forwards to Unity MCP tool names.
-- OpenClaw support is HTTP-only (via `openclaw-mcp-bridge`).
+- OpenClaw support follows the currently selected MCP for Unity transport (via `openclaw-mcp-bridge`).
 
 ---
 

--- a/docs/guides/MCP_CLIENT_CONFIGURATORS.md
+++ b/docs/guides/MCP_CLIENT_CONFIGURATORS.md
@@ -5,7 +5,7 @@ This guide explains how MCP client configurators work in this repo and how to ad
 It covers:
 
 - **Typical JSON-file clients** (Cursor, VSCode GitHub Copilot, VSCode Insiders, GitHub Copilot CLI, Windsurf, Kiro, Trae, Antigravity, etc.).
-- **Special clients** like **Claude CLI** and **Codex** that require custom logic.
+- **Special clients** like **Claude CLI**, **Codex**, and **OpenClaw** that require custom logic.
 - **How to add a new configurator class** so it shows up automatically in the MCP for Unity window.
 
 ## Quick example: JSON-file configurator
@@ -164,6 +164,13 @@ Some clients cannot be handled by the generic JSON configurator alone.
   - Overrides `Configure` / `GetManualSnippet` to:
     - Guard against HTTP mode.
     - Provide clear error text if HTTP is enabled.
+
+### OpenClaw (plugin-based)
+
+- Uses a custom configurator (`OpenClawConfigurator`) because OpenClaw MCP is plugin-driven.
+- Config file path is `~/.openclaw/openclaw.json`.
+- Unity MCP is configured through `plugins.entries.openclaw-mcp-bridge.config.servers`.
+- OpenClaw support is HTTP-only (via `openclaw-mcp-bridge`).
 
 ---
 

--- a/docs/guides/MCP_CLIENT_CONFIGURATORS.md
+++ b/docs/guides/MCP_CLIENT_CONFIGURATORS.md
@@ -169,7 +169,9 @@ Some clients cannot be handled by the generic JSON configurator alone.
 
 - Uses a custom configurator (`OpenClawConfigurator`) because OpenClaw MCP is plugin-driven.
 - Config file path is `~/.openclaw/openclaw.json`.
-- Unity MCP is configured through `plugins.entries.openclaw-mcp-bridge.config.servers`.
+- Unity MCP is configured through `plugins.entries.openclaw-mcp-bridge.config.servers.unityMCP`.
+- The bridge expects the MCP JSON-RPC endpoint URL (`http://127.0.0.1:<port>/mcp`), not just the HTTP base URL.
+- The bridge exposes a single proxy tool such as `unityMCP__call`, which then forwards to Unity MCP tool names.
 - OpenClaw support is HTTP-only (via `openclaw-mcp-bridge`).
 
 ---

--- a/docs/i18n/README-zh.md
+++ b/docs/i18n/README-zh.md
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. 点击 **Start Server**（会在 `localhost:8080` 启动 HTTP 服务器）
 3. 从下拉菜单选择你的 MCP Client，然后点击 **Configure**
 4. 查找 🟢 "Connected ✓"
-5. **连接你的客户端：** 一些客户端（Cursor、Windsurf、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件。OpenClaw 还需要启用 `openclaw-mcp-bridge` 插件；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
+5. **连接你的客户端：** 一些客户端（Cursor、Windsurf、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件。OpenClaw 还需要启用 `openclaw-mcp-bridge` 插件，并会跟随 MCP for Unity 当前选择的传输方式（HTTP 或 stdio）；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
 
 **就这些！** 试试这样的提示词：*"Create a red, blue and yellow cube"* 或 *"Build a simple player controller"*
 

--- a/docs/i18n/README-zh.md
+++ b/docs/i18n/README-zh.md
@@ -46,7 +46,7 @@
 
 * **Unity 2021.3 LTS+** — [下载 Unity](https://unity.com/download)
 * **Python 3.10+** 和 **uv** — [安装 uv](https://docs.astral.sh/uv/getting-started/installation/)
-* **一个 MCP 客户端** — [Claude Desktop](https://claude.ai/download) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [Windsurf](https://windsurf.com) | [OpenClaw](https://openclaw.ai)
+* **一个 MCP 客户端** — [Claude Desktop](https://claude.ai/download) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [OpenClaw](https://openclaw.ai)
 
 ### 1. 安装 Unity 包
 
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. 点击 **Start Server**（会在 `localhost:8080` 启动 HTTP 服务器）
 3. 从下拉菜单选择你的 MCP Client，然后点击 **Configure**
 4. 查找 🟢 "Connected ✓"
-5. **连接你的客户端：** 一些客户端（Cursor、Windsurf、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件。OpenClaw 还需要启用 `openclaw-mcp-bridge` 插件，并会跟随 MCP for Unity 当前选择的传输方式（HTTP 或 stdio）；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
+5. **连接你的客户端：** 一些客户端（Cursor、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件。OpenClaw 还需要启用 `openclaw-mcp-bridge` 插件，并会跟随 MCP for Unity 当前选择的传输方式（HTTP 或 stdio）；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
 
 **就这些！** 试试这样的提示词：*"Create a red, blue and yellow cube"* 或 *"Build a simple player controller"*
 

--- a/docs/i18n/README-zh.md
+++ b/docs/i18n/README-zh.md
@@ -46,7 +46,7 @@
 
 * **Unity 2021.3 LTS+** — [下载 Unity](https://unity.com/download)
 * **Python 3.10+** 和 **uv** — [安装 uv](https://docs.astral.sh/uv/getting-started/installation/)
-* **一个 MCP 客户端** — [Claude Desktop](https://claude.ai/download) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [Windsurf](https://windsurf.com)
+* **一个 MCP 客户端** — [Claude Desktop](https://claude.ai/download) | [Cursor](https://www.cursor.com/en/downloads) | [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview) | [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | [Windsurf](https://windsurf.com) | [OpenClaw](https://openclaw.ai)
 
 ### 1. 安装 Unity 包
 
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. 点击 **Start Server**（会在 `localhost:8080` 启动 HTTP 服务器）
 3. 从下拉菜单选择你的 MCP Client，然后点击 **Configure**
 4. 查找 🟢 "Connected ✓"
-5. **连接你的客户端：** 一些客户端（Cursor、Windsurf、Antigravity）需要在设置里启用 MCP 开关；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
+5. **连接你的客户端：** 一些客户端（Cursor、Windsurf、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
 
 **就这些！** 试试这样的提示词：*"Create a red, blue and yellow cube"* 或 *"Build a simple player controller"*
 

--- a/docs/i18n/README-zh.md
+++ b/docs/i18n/README-zh.md
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. 点击 **Start Server**（会在 `localhost:8080` 启动 HTTP 服务器）
 3. 从下拉菜单选择你的 MCP Client，然后点击 **Configure**
 4. 查找 🟢 "Connected ✓"
-5. **连接你的客户端：** 一些客户端（Cursor、Windsurf、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
+5. **连接你的客户端：** 一些客户端（Cursor、Windsurf、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件。OpenClaw 还需要启用 `openclaw-mcp-bridge` 插件；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
 
 **就这些！** 试试这样的提示词：*"Create a red, blue and yellow cube"* 或 *"Build a simple player controller"*
 


### PR DESCRIPTION
Restore the openclaw PR that was reverted at #901

## Summary by Sourcery

Add first-class OpenClaw MCP client support and documentation to MCP for Unity.

New Features:
- Introduce an OpenClaw MCP client configurator that integrates with the openclaw-mcp-bridge plugin and supports both HTTP and stdio transports.

Enhancements:
- Teach the MCP client configurators guide about OpenClaw as a special plugin-based client, including how it proxies tools and follows the selected transport.
- Update MCP for Unity README (English and Chinese) to list OpenClaw as a supported MCP client and describe its configuration and plugin requirements in the setup flow.

Documentation:
- Expand user-facing documentation to cover OpenClaw setup, configuration paths, and behavior alongside other supported MCP clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenClaw as a supported MCP client with automatic configuration management and transport selection support (HTTP/stdio).

* **Documentation**
  * Updated quick-start guides and configuration instructions for OpenClaw setup.
  * Added OpenClaw documentation to guides and Chinese localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->