### PR TITLE
fix: save prefab stage edits using the correct prefab-stage workflow

### DIFF
--- a/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
+++ b/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
@@ -1347,15 +1347,12 @@ namespace MCPForUnity.Editor.Tools.Prefabs
                     return new ErrorResponse("Not currently in prefab editing mode. Open a prefab stage first with open_prefab_stage.");
                 }
 
-                string prefabPath = prefabStage.assetPath;
-                EditorSceneManager.MarkSceneDirty(prefabStage.scene);
-                bool saved = EditorSceneManager.SaveScene(prefabStage.scene);
-                if (!saved)
+                if (!TrySavePrefabStage(prefabStage, out string prefabPath, out string errorMessage))
                 {
-                    return new ErrorResponse($"Failed to save prefab stage for '{prefabPath}'. The file may be read-only or the disk may be full.");
+                    return new ErrorResponse(errorMessage);
                 }
 
-                return new SuccessResponse($"Saved prefab stage changes for '{prefabPath}'.", new { prefabPath, saved });
+                return new SuccessResponse($"Saved prefab stage changes for '{prefabPath}'.", new { prefabPath, saved = true });
             }
             catch (Exception e)
             {
@@ -1375,10 +1372,9 @@ namespace MCPForUnity.Editor.Tools.Prefabs
 
                 if (saveBeforeClose)
                 {
-                    var saveResult = SavePrefabStage();
-                    if (saveResult is ErrorResponse)
+                    if (!TrySavePrefabStage(prefabStage, out _, out string errorMessage))
                     {
-                        return saveResult;
+                        return new ErrorResponse(errorMessage);
                     }
                 }
 
@@ -1390,6 +1386,31 @@ namespace MCPForUnity.Editor.Tools.Prefabs
             {
                 return new ErrorResponse($"Error closing prefab stage: {e.Message}");
             }
+        }
+
+        private static bool TrySavePrefabStage(PrefabStage prefabStage, out string prefabPath, out string errorMessage)
+        {
+            prefabPath = prefabStage.assetPath;
+            errorMessage = null;
+
+            if (prefabStage.prefabContentsRoot == null)
+            {
+                errorMessage = $"Failed to save prefab stage for '{prefabPath}'. The prefab contents root is missing.";
+                return false;
+            }
+
+            bool saved;
+            PrefabUtility.SaveAsPrefabAsset(prefabStage.prefabContentsRoot, prefabPath, out saved);
+            if (!saved)
+            {
+                errorMessage = $"Failed to save prefab stage for '{prefabPath}'. The file may be read-only or the disk may be full.";
+                return false;
+            }
+
+            prefabStage.ClearDirtiness();
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            return true;
         }
 
         #endregion

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManagePrefabsStageTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManagePrefabsStageTests.cs
@@ -151,6 +151,86 @@ namespace MCPForUnityTests.Editor.Tools
             }
         }
 
+        [Test]
+        public void SavePrefabStage_PersistsPrefabContentChanges()
+        {
+            string prefabPath = CreateTestPrefab("SaveStageRoot");
+
+            try
+            {
+                AssertOpenPrefabStage(prefabPath);
+
+                var stage = PrefabStageUtility.GetCurrentPrefabStage();
+                Assert.IsNotNull(stage, "Expected prefab stage to be open.");
+
+                var child = new GameObject("SavedChild");
+                child.transform.SetParent(stage.prefabContentsRoot.transform, false);
+
+                var saveResult = ToJObject(ManagePrefabs.HandleCommand(new JObject
+                {
+                    ["action"] = "save_prefab_stage"
+                }));
+
+                Assert.IsTrue(saveResult.Value<bool>("success"), $"Expected save to succeed but got: {saveResult}");
+                Assert.AreEqual(prefabPath, saveResult["data"].Value<string>("prefabPath"));
+
+                StageUtility.GoToMainStage();
+
+                GameObject reloaded = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+                Assert.IsNotNull(reloaded.transform.Find("SavedChild"), "Saved prefab should contain the new child after save_prefab_stage.");
+            }
+            finally
+            {
+                StageUtility.GoToMainStage();
+                SafeDeleteAsset(prefabPath);
+            }
+        }
+
+        [Test]
+        public void ClosePrefabStage_SaveBeforeClose_PersistsChanges()
+        {
+            string prefabPath = CreateTestPrefab("CloseSaveRoot");
+
+            try
+            {
+                AssertOpenPrefabStage(prefabPath);
+
+                var stage = PrefabStageUtility.GetCurrentPrefabStage();
+                Assert.IsNotNull(stage, "Expected prefab stage to be open.");
+
+                var child = new GameObject("CloseSavedChild");
+                child.transform.SetParent(stage.prefabContentsRoot.transform, false);
+
+                var closeResult = ToJObject(ManagePrefabs.HandleCommand(new JObject
+                {
+                    ["action"] = "close_prefab_stage",
+                    ["saveBeforeClose"] = true
+                }));
+
+                Assert.IsTrue(closeResult.Value<bool>("success"), $"Expected close with save to succeed but got: {closeResult}");
+                Assert.IsNull(PrefabStageUtility.GetCurrentPrefabStage(), "Prefab stage should be closed after close_prefab_stage.");
+
+                GameObject reloaded = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+                Assert.IsNotNull(reloaded.transform.Find("CloseSavedChild"), "Saved prefab should contain the new child after close_prefab_stage(saveBeforeClose: true).");
+            }
+            finally
+            {
+                StageUtility.GoToMainStage();
+                SafeDeleteAsset(prefabPath);
+            }
+        }
+
+        private static void AssertOpenPrefabStage(string prefabPath)
+        {
+            var openResult = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "open_prefab_stage",
+                ["prefabPath"] = prefabPath
+            }));
+
+            Assert.IsTrue(openResult.Value<bool>("success"), $"Expected open to succeed but got: {openResult}");
+        }
+
         private static string CreateTestPrefab(string rootName)
         {
             string prefabPath = Path.Combine(TempDirectory, $"{rootName}.prefab").Replace('\\', '/');


### PR DESCRIPTION
## Description
Fixes prefab-stage saving so `save_prefab_stage` writes the prefab asset instead of trying to save the preview scene.

## Type of Change
Save your change type
- Bug fix (non-breaking change that fixes an issue)
- Test update

## Changes Made
- changed `save_prefab_stage` to save `prefabStage.prefabContentsRoot` back to `prefabStage.assetPath`
- reused the same save path from `close_prefab_stage(saveBeforeClose: true)`
- added focused EditMode regressions for explicit save and save-before-close persistence

## Testing/Screenshots/Recordings
- Ran Unity EditMode tests in batch mode with `-testFilter ManagePrefabsStageTests`
- Result: 7 passed, 0 failed

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`

## Related Issues
Fixes #1055

## Additional Notes
- Kept the change narrow to prefab-stage save behavior only.
- Did not change unrelated prefab editing flows or headless prefab modification behavior.

## Summary by Sourcery

Fix prefab stage saving to correctly persist changes to the underlying prefab asset and reuse a shared save workflow for explicit saves and save-before-close.

Bug Fixes:
- Ensure save_prefab_stage writes modifications from the prefab stage back to the prefab asset instead of attempting to save the preview scene.
- Ensure close_prefab_stage with saveBeforeClose persists prefab content changes reliably.

Enhancements:
- Introduce a shared TrySavePrefabStage helper to centralize prefab stage save behavior across commands.

Tests:
- Add EditMode tests to verify save_prefab_stage persists prefab child changes to disk.
- Add EditMode tests to verify close_prefab_stage with saveBeforeClose correctly saves and closes the prefab stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined prefab stage save workflow to enhance reliability when persisting changes made during prefab editing sessions. Changes now save correctly when you save or close the prefab stage.
  * Improved error handling with clearer diagnostic messages when prefab save operations encounter issues, including permission problems and missing content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->