### PR TITLE
Replace localhost with 127.0.0.1 for correct Codex handshake

### DIFF
--- a/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
+++ b/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
@@ -36,7 +36,7 @@ namespace MCPForUnity.Editor.Helpers
             if (useHttpTransport)
             {
                 // HTTP mode: Use url field
-                string httpUrl = HttpEndpointUtility.GetMcpRpcUrl();
+                string httpUrl = GetCodexHttpUrl();
                 unityMCP["url"] = new TomlString { Value = httpUrl };
 
                 // Enable Codex's Rust MCP client for HTTP/SSE transport
@@ -191,7 +191,7 @@ namespace MCPForUnity.Editor.Helpers
             if (useHttpTransport)
             {
                 // HTTP mode: Use url field
-                string httpUrl = HttpEndpointUtility.GetMcpRpcUrl();
+                string httpUrl = GetCodexHttpUrl();
                 unityMCP["url"] = new TomlString { Value = httpUrl };
             }
             else
@@ -227,6 +227,12 @@ namespace MCPForUnity.Editor.Helpers
             }
 
             return unityMCP;
+        }
+
+        private static string GetCodexHttpUrl()
+        {
+            return HttpEndpointUtility.GetMcpRpcUrl()
+                .Replace("http://localhost:", "http://127.0.0.1:");
         }
 
         /// <summary>

--- a/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
+++ b/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
@@ -231,6 +231,11 @@ namespace MCPForUnity.Editor.Helpers
 
         private static string GetCodexHttpUrl()
         {
+            // Codex has intermittently failed the MCP handshake when configured with hostname-based
+            // loopback URLs such as localhost/::1, even though Unity MCP itself is reachable.
+            // Keep normalizing loopback hosts to 127.0.0.1 for Codex until the client routes them
+            // reliably again. If Codex fixes that behavior in the future, this is the workaround
+            // to revisit or remove before changing shared endpoint generation.
             return HttpEndpointUtility.GetMcpRpcUrl()
                 .Replace("http://localhost:", "http://127.0.0.1:");
         }


### PR DESCRIPTION
## Description
- update Codex HTTP MCP config generation to use `127.0.0.1` instead of `localhost`


## Why
In practice, Unity MCP was reachable and responded correctly, but Codex could fail during the MCP initialize/handshake step when configured with `http://localhost:8080/mcp`.

Using `http://127.0.0.1:8080/mcp` fixes the issue consistently after restarting Codex, which suggests the problem is client-side loopback/hostname resolution behavior in Codex rather than a Unity MCP server issue.


## Type of Change
<!-- Save the type of change you did -->
Save your change type
- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)


## Changes Made
- update Codex HTTP MCP config generation to use `127.0.0.1` instead of `localhost`
- keep the change scoped to `CodexConfigHelper` only
- leave the shared HTTP endpoint logic unchanged for other clients


## Testing/Screenshots/Recordings
- enable HTTP transport for Codex config generation
- verify generated TOML contains:

  `[mcp_servers.unityMCP]`
  `url = "http://127.0.0.1:8080/mcp"`

- restart Codex
- confirm Codex connects to Unity MCP successfully
- confirm no behavior changes for non-Codex clients


## Documentation Updates
<!-- Check if you updated documentation for changes to tools/resources -->
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`


## Related Issues
<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional Notes
<!-- Any other information that reviewers should know -->

## Summary by Sourcery

Update Codex HTTP MCP configuration generation to use a loopback IP address that ensures reliable Codex handshakes.

Bug Fixes:
- Ensure Codex connects reliably to Unity MCP by avoiding hostname resolution issues when using HTTP transport.

Enhancements:
- Introduce a Codex-specific HTTP URL helper to adjust the generated MCP RPC URL without affecting other clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize loopback hostnames by replacing "localhost" with "127.0.0.1" when configuring HTTP/SSE endpoints.
  * Apply this normalization consistently across HTTP transport configuration paths so generated URLs use the loopback IP.
  * No behavior changes for stdio transport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->