### PR TITLE
Pr 1051 unity65 compat

### DIFF
--- a/MCPForUnity/Editor/Helpers/ComponentOps.cs
+++ b/MCPForUnity/Editor/Helpers/ComponentOps.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -6,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Helpers
 {

--- a/MCPForUnity/Editor/Helpers/ComponentOps.cs
+++ b/MCPForUnity/Editor/Helpers/ComponentOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -977,7 +978,7 @@ namespace MCPForUnity.Editor.Helpers
             }
             catch (Exception ex)
             {
-                McpLog.Warn($"Failed to get fileID for sprite '{sprite.name}' (instanceID={sprite.GetInstanceID()}): {ex.Message}");
+                McpLog.Warn($"Failed to get fileID for sprite '{sprite.name}' (instanceID={sprite.GetInstanceIDCompat()}): {ex.Message}");
                 return 0;
             }
         }

--- a/MCPForUnity/Editor/Helpers/GameObjectLookup.cs
+++ b/MCPForUnity/Editor/Helpers/GameObjectLookup.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -155,7 +156,7 @@ namespace MCPForUnity.Editor.Helpers
             if (maxResults > 0)
                 matching = matching.Take(maxResults);
 
-            return matching.Select(go => go.GetInstanceID());
+            return matching.Select(go => go.GetInstanceIDCompat());
         }
 
         private static IEnumerable<int> SearchByPath(string path, bool includeInactive)
@@ -170,7 +171,7 @@ namespace MCPForUnity.Editor.Helpers
                 {
                     if (MatchesPath(go, path))
                     {
-                        yield return go.GetInstanceID();
+                        yield return go.GetInstanceIDCompat();
                     }
                 }
                 yield break;
@@ -187,7 +188,7 @@ namespace MCPForUnity.Editor.Helpers
                 {
                     if (MatchesPath(go, path))
                     {
-                        yield return go.GetInstanceID();
+                        yield return go.GetInstanceIDCompat();
                     }
                 }
             }
@@ -197,7 +198,7 @@ namespace MCPForUnity.Editor.Helpers
                 var found = GameObject.Find(path);
                 if (found != null)
                 {
-                    yield return found.GetInstanceID();
+                    yield return found.GetInstanceIDCompat();
                 }
             }
         }
@@ -230,7 +231,7 @@ namespace MCPForUnity.Editor.Helpers
 
             foreach (var go in results)
             {
-                yield return go.GetInstanceID();
+                yield return go.GetInstanceIDCompat();
             }
         }
 
@@ -254,7 +255,7 @@ namespace MCPForUnity.Editor.Helpers
 
             foreach (var go in matching)
             {
-                yield return go.GetInstanceID();
+                yield return go.GetInstanceIDCompat();
             }
         }
 
@@ -274,7 +275,7 @@ namespace MCPForUnity.Editor.Helpers
             {
                 if (go.GetComponent(componentType) != null)
                 {
-                    yield return go.GetInstanceID();
+                    yield return go.GetInstanceIDCompat();
                     count++;
 
                     if (maxResults > 0 && count >= maxResults)

--- a/MCPForUnity/Editor/Helpers/GameObjectLookup.cs
+++ b/MCPForUnity/Editor/Helpers/GameObjectLookup.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/MCPForUnity/Editor/Helpers/GameObjectLookup.cs
+++ b/MCPForUnity/Editor/Helpers/GameObjectLookup.cs
@@ -7,6 +7,7 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Helpers
 {

--- a/MCPForUnity/Editor/Helpers/GameObjectSerializer.cs
+++ b/MCPForUnity/Editor/Helpers/GameObjectSerializer.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +29,7 @@ namespace MCPForUnity.Editor.Helpers
             return new
             {
                 name = go.name,
-                instanceID = go.GetInstanceID(),
+                instanceID = go.GetInstanceIDCompat(),
                 tag = go.tag,
                 layer = go.layer,
                 activeSelf = go.activeSelf,
@@ -88,7 +89,7 @@ namespace MCPForUnity.Editor.Helpers
                         z = go.transform.right.z,
                     },
                 },
-                parentInstanceID = go.transform.parent?.gameObject.GetInstanceID() ?? 0, // 0 if no parent
+                parentInstanceID = go.transform.parent?.gameObject.GetInstanceIDCompat() ?? 0, // 0 if no parent
                 // Optionally include components, but can be large
                 // components = go.GetComponents<Component>().Select(c => GetComponentData(c)).ToList()
                 // Or just component names:
@@ -144,7 +145,7 @@ namespace MCPForUnity.Editor.Helpers
             var result = new Dictionary<string, object>
             {
                 { "name", obj.name },
-                { "instanceID", obj.GetInstanceID() }
+                { "instanceID", obj.GetInstanceIDCompat() }
             };
             
             if (includeAssetPath)
@@ -164,7 +165,7 @@ namespace MCPForUnity.Editor.Helpers
         public static object GetComponentData(Component c, bool includeNonPublicSerializedFields = true)
         {
             // --- Add Early Logging --- 
-            // McpLog.Info($"[GetComponentData] Starting for component: {c?.GetType()?.FullName ?? "null"} (ID: {c?.GetInstanceID() ?? 0})");
+            // McpLog.Info($"[GetComponentData] Starting for component: {c?.GetType()?.FullName ?? "null"} (ID: {c?.GetInstanceIDCompat() ?? 0})");
             // --- End Early Logging ---
 
             if (c == null) return null;
@@ -174,11 +175,11 @@ namespace MCPForUnity.Editor.Helpers
             if (componentType == typeof(Transform))
             {
                 Transform tr = c as Transform;
-                // McpLog.Info($"[GetComponentData] Manually serializing Transform (ID: {tr.GetInstanceID()})");
+                // McpLog.Info($"[GetComponentData] Manually serializing Transform (ID: {tr.GetInstanceIDCompat()})");
                 return new Dictionary<string, object>
                 {
                     { "typeName", componentType.FullName },
-                    { "instanceID", tr.GetInstanceID() },
+                    { "instanceID", tr.GetInstanceIDCompat() },
                     // Manually extract known-safe properties. Avoid Quaternion 'rotation' and 'lossyScale'.
                     { "position", CreateTokenFromValue(tr.position, typeof(Vector3))?.ToObject<object>() ?? new JObject() },
                     { "localPosition", CreateTokenFromValue(tr.localPosition, typeof(Vector3))?.ToObject<object>() ?? new JObject() },
@@ -188,13 +189,13 @@ namespace MCPForUnity.Editor.Helpers
                     { "right", CreateTokenFromValue(tr.right, typeof(Vector3))?.ToObject<object>() ?? new JObject() },
                     { "up", CreateTokenFromValue(tr.up, typeof(Vector3))?.ToObject<object>() ?? new JObject() },
                     { "forward", CreateTokenFromValue(tr.forward, typeof(Vector3))?.ToObject<object>() ?? new JObject() },
-                    { "parentInstanceID", tr.parent?.gameObject.GetInstanceID() ?? 0 },
-                    { "rootInstanceID", tr.root?.gameObject.GetInstanceID() ?? 0 },
+                    { "parentInstanceID", tr.parent?.gameObject.GetInstanceIDCompat() ?? 0 },
+                    { "rootInstanceID", tr.root?.gameObject.GetInstanceIDCompat() ?? 0 },
                     { "childCount", tr.childCount },
                     // Include standard Object/Component properties
                     { "name", tr.name },
                     { "tag", tr.tag },
-                    { "gameObjectInstanceID", tr.gameObject?.GetInstanceID() ?? 0 }
+                    { "gameObjectInstanceID", tr.gameObject?.GetInstanceIDCompat() ?? 0 }
                 };
             }
             // --- End Special handling for Transform --- 
@@ -233,7 +234,7 @@ namespace MCPForUnity.Editor.Helpers
                     { "enabled", () => cam.enabled },
                     { "name", () => cam.name },
                     { "tag", () => cam.tag },
-                    { "gameObject", () => new { name = cam.gameObject.name, instanceID = cam.gameObject.GetInstanceID() } }
+                    { "gameObject", () => new { name = cam.gameObject.name, instanceID = cam.gameObject.GetInstanceIDCompat() } }
                 };
 
                 foreach (var prop in safeProperties)
@@ -256,7 +257,7 @@ namespace MCPForUnity.Editor.Helpers
                 return new Dictionary<string, object>
                 {
                     { "typeName", componentType.FullName },
-                    { "instanceID", cam.GetInstanceID() },
+                    { "instanceID", cam.GetInstanceIDCompat() },
                     { "properties", cameraProperties }
                 };
             }
@@ -322,7 +323,7 @@ namespace MCPForUnity.Editor.Helpers
                 return new Dictionary<string, object>
                 {
                     { "typeName", componentType.FullName },
-                    { "instanceID", c.GetInstanceID() },
+                    { "instanceID", c.GetInstanceIDCompat() },
                     { "properties", uiDocProperties }
                 };
             }
@@ -331,7 +332,7 @@ namespace MCPForUnity.Editor.Helpers
             var data = new Dictionary<string, object>
             {
                 { "typeName", componentType.FullName },
-                { "instanceID", c.GetInstanceID() }
+                { "instanceID", c.GetInstanceIDCompat() }
             };
 
             // --- Get Cached or Generate Metadata (using new cache key) ---

--- a/MCPForUnity/Editor/Helpers/GameObjectSerializer.cs
+++ b/MCPForUnity/Editor/Helpers/GameObjectSerializer.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +7,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Helpers
 {

--- a/MCPForUnity/Editor/Helpers/UnityObjectIdCompatExtensions.cs
+++ b/MCPForUnity/Editor/Helpers/UnityObjectIdCompatExtensions.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using UnityEngine;
+
+public static class UnityObjectIdCompatExtensions
+{
+    public static int GetInstanceIDCompat(this Object obj)
+    {
+        if (obj == null)
+        {
+            return 0;
+        }
+
+        MethodInfo getInstanceId = typeof(Object).GetMethod("GetInstanceID", BindingFlags.Public | BindingFlags.Instance);
+        if (getInstanceId != null)
+        {
+            object result = getInstanceId.Invoke(obj, null);
+            if (result is int id)
+            {
+                return id;
+            }
+        }
+
+        MethodInfo getEntityId = typeof(Object).GetMethod("GetEntityId", BindingFlags.Public | BindingFlags.Instance);
+        if (getEntityId != null)
+        {
+            object entity = getEntityId.Invoke(obj, null);
+            if (entity != null)
+            {
+                if (int.TryParse(entity.ToString(), out int parsed))
+                {
+                    return parsed;
+                }
+                return entity.GetHashCode();
+            }
+        }
+
+        return obj.GetHashCode();
+    }
+}

--- a/MCPForUnity/Editor/Helpers/UnityObjectIdCompatExtensions.cs.meta
+++ b/MCPForUnity/Editor/Helpers/UnityObjectIdCompatExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f5a407ab8e854d21a4b7fb023697d35

--- a/MCPForUnity/Editor/Helpers/UnityObjectIdCompatExtensions.cs.meta
+++ b/MCPForUnity/Editor/Helpers/UnityObjectIdCompatExtensions.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 4f5a407ab8e854d21a4b7fb023697d35

--- a/MCPForUnity/Editor/Resources/Editor/Selection.cs
+++ b/MCPForUnity/Editor/Resources/Editor/Selection.cs
@@ -1,9 +1,9 @@
-#pragma warning disable 0619
 using System;
 using System.Linq;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Resources.Editor
 {

--- a/MCPForUnity/Editor/Resources/Editor/Selection.cs
+++ b/MCPForUnity/Editor/Resources/Editor/Selection.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Linq;
 using MCPForUnity.Editor.Helpers;
@@ -21,21 +22,21 @@ namespace MCPForUnity.Editor.Resources.Editor
                     activeObject = UnityEditor.Selection.activeObject?.name,
                     activeGameObject = UnityEditor.Selection.activeGameObject?.name,
                     activeTransform = UnityEditor.Selection.activeTransform?.name,
-                    activeInstanceID = UnityEditor.Selection.activeObject?.GetInstanceID() ?? 0,
+                    activeInstanceID = UnityEditor.Selection.activeObject?.GetInstanceIDCompat() ?? 0,
                     count = UnityEditor.Selection.count,
                     objects = UnityEditor.Selection.objects
                         .Select(obj => new
                         {
                             name = obj?.name,
                             type = obj?.GetType().FullName,
-                            instanceID = obj?.GetInstanceID()
+                            instanceID = obj?.GetInstanceIDCompat()
                         })
                         .ToList(),
                     gameObjects = UnityEditor.Selection.gameObjects
                         .Select(go => new
                         {
                             name = go?.name,
-                            instanceID = go?.GetInstanceID()
+                            instanceID = go?.GetInstanceIDCompat()
                         })
                         .ToList(),
                     assetGUIDs = UnityEditor.Selection.assetGUIDs

--- a/MCPForUnity/Editor/Resources/Editor/Windows.cs
+++ b/MCPForUnity/Editor/Resources/Editor/Windows.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;

--- a/MCPForUnity/Editor/Resources/Editor/Windows.cs
+++ b/MCPForUnity/Editor/Resources/Editor/Windows.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
@@ -39,7 +40,7 @@ namespace MCPForUnity.Editor.Resources.Editor
                                 width = window.position.width,
                                 height = window.position.height
                             },
-                            instanceID = window.GetInstanceID()
+                            instanceID = window.GetInstanceIDCompat()
                         });
                     }
                     catch (Exception ex)

--- a/MCPForUnity/Editor/Resources/Editor/Windows.cs
+++ b/MCPForUnity/Editor/Resources/Editor/Windows.cs
@@ -5,6 +5,7 @@ using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Resources.Editor
 {

--- a/MCPForUnity/Editor/Resources/Scene/GameObjectResource.cs
+++ b/MCPForUnity/Editor/Resources/Scene/GameObjectResource.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -84,12 +85,12 @@ namespace MCPForUnity.Editor.Resources.Scene
             var childrenIds = new List<int>();
             foreach (Transform child in transform)
             {
-                childrenIds.Add(child.gameObject.GetInstanceID());
+                childrenIds.Add(child.gameObject.GetInstanceIDCompat());
             }
 
             return new
             {
-                instanceID = go.GetInstanceID(),
+                instanceID = go.GetInstanceIDCompat(),
                 name = go.name,
                 tag = go.tag,
                 layer = go.layer,
@@ -106,7 +107,7 @@ namespace MCPForUnity.Editor.Resources.Scene
                     scale = SerializeVector3(transform.localScale),
                     lossyScale = SerializeVector3(transform.lossyScale)
                 },
-                parent = transform.parent != null ? transform.parent.gameObject.GetInstanceID() : (int?)null,
+                parent = transform.parent != null ? transform.parent.gameObject.GetInstanceIDCompat() : (int?)null,
                 children = childrenIds,
                 componentTypes = componentTypes,
                 path = GameObjectLookup.GetGameObjectPath(go)
@@ -173,7 +174,7 @@ namespace MCPForUnity.Editor.Resources.Scene
                         componentData.Add(new
                         {
                             typeName = component.GetType().FullName,
-                            instanceID = component.GetInstanceID()
+                            instanceID = component.GetInstanceIDCompat()
                         });
                     }
                 }

--- a/MCPForUnity/Editor/Resources/Scene/GameObjectResource.cs
+++ b/MCPForUnity/Editor/Resources/Scene/GameObjectResource.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,6 +5,7 @@ using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Resources.Scene
 {

--- a/MCPForUnity/Editor/Tools/Cameras/CameraConfigure.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraConfigure.cs
@@ -1,10 +1,10 @@
-#pragma warning disable 0619
 using System;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Cameras
 {

--- a/MCPForUnity/Editor/Tools/Cameras/CameraConfigure.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraConfigure.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
@@ -36,7 +37,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Camera '{go.name}' now looking at '{target.name}'.",
-                data = new { instanceID = go.GetInstanceID() }
+                data = new { instanceID = go.GetInstanceIDCompat() }
             };
         }
 
@@ -65,7 +66,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Lens properties set on Camera '{go.name}'.",
-                data = new { instanceID = go.GetInstanceID() }
+                data = new { instanceID = go.GetInstanceIDCompat() }
             };
         }
 
@@ -88,7 +89,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Camera '{go.name}' depth set to {depth}.",
-                data = new { instanceID = go.GetInstanceID(), depth }
+                data = new { instanceID = go.GetInstanceIDCompat(), depth }
             };
         }
 
@@ -116,7 +117,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Targets set on CinemachineCamera '{cmCamera.gameObject.name}'.",
-                data = new { instanceID = cmCamera.gameObject.GetInstanceID() }
+                data = new { instanceID = cmCamera.gameObject.GetInstanceIDCompat() }
             };
         }
 
@@ -147,7 +148,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Lens properties set on CinemachineCamera '{cmCamera.gameObject.name}'.",
-                data = new { instanceID = cmCamera.gameObject.GetInstanceID() }
+                data = new { instanceID = cmCamera.gameObject.GetInstanceIDCompat() }
             };
         }
 
@@ -181,7 +182,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Priority set to {priority} on CinemachineCamera '{cmCamera.gameObject.name}'.",
-                data = new { instanceID = cmCamera.gameObject.GetInstanceID(), priority }
+                data = new { instanceID = cmCamera.gameObject.GetInstanceIDCompat(), priority }
             };
         }
 
@@ -218,7 +219,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Body configured on CinemachineCamera '{go.name}'.",
-                data = new { instanceID = go.GetInstanceID(), body = bodyComponent.GetType().Name }
+                data = new { instanceID = go.GetInstanceIDCompat(), body = bodyComponent.GetType().Name }
             };
         }
 
@@ -253,7 +254,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Aim configured on CinemachineCamera '{go.name}'.",
-                data = new { instanceID = go.GetInstanceID(), aim = aimComponent.GetType().Name }
+                data = new { instanceID = go.GetInstanceIDCompat(), aim = aimComponent.GetType().Name }
             };
         }
 
@@ -288,7 +289,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 message = added
                     ? $"Added noise to CinemachineCamera '{go.name}'."
                     : $"Noise configured on CinemachineCamera '{go.name}'.",
-                data = new { instanceID = go.GetInstanceID(), added }
+                data = new { instanceID = go.GetInstanceIDCompat(), added }
             };
         }
 
@@ -320,7 +321,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Extension '{extTypeName}' added to CinemachineCamera '{go.name}'.",
-                data = new { instanceID = go.GetInstanceID(), extensionType = extTypeName }
+                data = new { instanceID = go.GetInstanceIDCompat(), extensionType = extTypeName }
             };
         }
 
@@ -351,7 +352,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = $"Extension '{extTypeName}' removed from CinemachineCamera '{go.name}'.",
-                data = new { instanceID = go.GetInstanceID() }
+                data = new { instanceID = go.GetInstanceIDCompat() }
             };
         }
 

--- a/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,12 +56,12 @@ namespace MCPForUnity.Editor.Tools.Cameras
 
                     cameraList.Add(new
                     {
-                        instanceID = cm.gameObject.GetInstanceID(),
+                        instanceID = cm.gameObject.GetInstanceIDCompat(),
                         name = cm.gameObject.name,
                         isLive = isLive is bool b && b,
                         priority,
-                        follow = follow != null ? new { name = follow.gameObject.name, instanceID = follow.gameObject.GetInstanceID() } : null,
-                        lookAt = lookAt != null ? new { name = lookAt.gameObject.name, instanceID = lookAt.gameObject.GetInstanceID() } : null,
+                        follow = follow != null ? new { name = follow.gameObject.name, instanceID = follow.gameObject.GetInstanceIDCompat() } : null,
+                        lookAt = lookAt != null ? new { name = lookAt.gameObject.name, instanceID = lookAt.gameObject.GetInstanceIDCompat() } : null,
                         body = body?.GetType().Name,
                         aim = aim?.GetType().Name,
                         noise = noise?.GetType().Name,
@@ -76,7 +77,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                     cam.gameObject.GetComponent(CameraHelpers.CinemachineBrainType) != null;
                 unityCamList.Add(new
                 {
-                    instanceID = cam.gameObject.GetInstanceID(),
+                    instanceID = cam.gameObject.GetInstanceIDCompat(),
                     name = cam.gameObject.name,
                     depth = cam.depth,
                     fieldOfView = cam.fieldOfView,
@@ -102,14 +103,14 @@ namespace MCPForUnity.Editor.Tools.Cameras
                         activeName = nameProp?.GetValue(activeCam) as string;
 
                         if (activeCam is Component activeComp)
-                            activeID = activeComp.gameObject.GetInstanceID();
+                            activeID = activeComp.gameObject.GetInstanceIDCompat();
                     }
 
                     brainInfo = new
                     {
                         exists = true,
                         gameObject = brain.gameObject.name,
-                        instanceID = brain.gameObject.GetInstanceID(),
+                        instanceID = brain.gameObject.GetInstanceIDCompat(),
                         activeCameraName = activeName,
                         activeCameraID = activeID,
                         isBlending = isBlending is bool bl && bl
@@ -147,7 +148,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 var nameProp = activeCam.GetType().GetProperty("Name");
                 activeName = nameProp?.GetValue(activeCam) as string;
                 if (activeCam is Component comp)
-                    activeID = comp.gameObject.GetInstanceID();
+                    activeID = comp.gameObject.GetInstanceIDCompat();
             }
 
             string blendDesc = null;
@@ -163,7 +164,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 data = new
                 {
                     gameObject = brain.gameObject.name,
-                    instanceID = brain.gameObject.GetInstanceID(),
+                    instanceID = brain.gameObject.GetInstanceIDCompat(),
                     activeCameraName = activeName,
                     activeCameraID = activeID,
                     isBlending = isBlending is bool b && b,
@@ -217,7 +218,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             {
                 success = true,
                 message = "Default blend configured on CinemachineBrain.",
-                data = new { instanceID = brain.gameObject.GetInstanceID() }
+                data = new { instanceID = brain.gameObject.GetInstanceIDCompat() }
             };
         }
 
@@ -246,7 +247,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 {
                     success = true,
                     message = $"Set high priority on '{cmCamera.gameObject.name}' (SetCameraOverride not available).",
-                    data = new { instanceID = cmCamera.gameObject.GetInstanceID(), method = "priority" }
+                    data = new { instanceID = cmCamera.gameObject.GetInstanceIDCompat(), method = "priority" }
                 };
             }
 
@@ -273,7 +274,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 {
                     success = true,
                     message = $"Forced via priority (override failed: {ex.Message}).",
-                    data = new { instanceID = cmCamera.gameObject.GetInstanceID(), method = "priority" }
+                    data = new { instanceID = cmCamera.gameObject.GetInstanceIDCompat(), method = "priority" }
                 };
             }
 
@@ -283,7 +284,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 message = $"Camera overridden to '{cmCamera.gameObject.name}'.",
                 data = new
                 {
-                    instanceID = cmCamera.gameObject.GetInstanceID(),
+                    instanceID = cmCamera.gameObject.GetInstanceIDCompat(),
                     overrideId = _overrideId,
                     method = "override"
                 }

--- a/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,11 +14,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
     {
         internal static object ListCameras(JObject @params)
         {
-#if UNITY_2022_2_OR_NEWER
-            var unityCameras = UnityEngine.Object.FindObjectsByType<UnityEngine.Camera>(FindObjectsSortMode.None);
-#else
-            var unityCameras = UnityEngine.Object.FindObjectsOfType<UnityEngine.Camera>();
-#endif
+            var unityCameras = UnityFindObjectsCompat.FindAll<UnityEngine.Camera>();
             var cameraList = new List<object>();
             var unityCamList = new List<object>();
 
@@ -27,11 +22,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             if (CameraHelpers.HasCinemachine)
             {
                 var cmType = CameraHelpers.CinemachineCameraType;
-#if UNITY_2022_2_OR_NEWER
-                var allCm = UnityEngine.Object.FindObjectsByType(cmType, FindObjectsSortMode.None);
-#else
-                var allCm = UnityEngine.Object.FindObjectsOfType(cmType);
-#endif
+                var allCm = UnityFindObjectsCompat.FindAll(cmType);
                 foreach (Component cm in allCm)
                 {
                     var follow = CameraHelpers.GetReflectionProperty(cm, "Follow") as Transform;

--- a/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
@@ -7,6 +7,7 @@ using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Cameras
 {

--- a/MCPForUnity/Editor/Tools/Cameras/CameraCreate.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraCreate.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -6,6 +5,7 @@ using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Cameras
 {

--- a/MCPForUnity/Editor/Tools/Cameras/CameraCreate.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraCreate.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -62,7 +63,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 message = $"Created basic Camera '{name}' (Cinemachine not installed — using Unity Camera).",
                 data = new
                 {
-                    instanceID = go.GetInstanceID(),
+                    instanceID = go.GetInstanceIDCompat(),
                     cinemachine = false,
                     hint = "Install com.unity.cinemachine for presets, blending, and virtual camera features."
                 }
@@ -149,7 +150,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 message = $"Created CinemachineCamera '{name}' with preset '{preset}'.",
                 data = new
                 {
-                    instanceID = go.GetInstanceID(),
+                    instanceID = go.GetInstanceIDCompat(),
                     cinemachine = true,
                     preset,
                     priority,
@@ -173,7 +174,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                     message = $"CinemachineBrain already exists on '{existingBrain.gameObject.name}'.",
                     data = new
                     {
-                        instanceID = existingBrain.gameObject.GetInstanceID(),
+                        instanceID = existingBrain.gameObject.GetInstanceIDCompat(),
                         alreadyExisted = true
                     }
                 };
@@ -241,7 +242,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
                 message = $"CinemachineBrain added to '{cam.gameObject.name}'.",
                 data = new
                 {
-                    instanceID = cam.gameObject.GetInstanceID(),
+                    instanceID = cam.gameObject.GetInstanceIDCompat(),
                     alreadyExisted = false
                 }
             };

--- a/MCPForUnity/Editor/Tools/Cameras/CameraHelpers.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -141,11 +142,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             if (!HasCinemachine || _cmBrainType == null)
                 return null;
 
-#if UNITY_2022_2_OR_NEWER
-            return UnityEngine.Object.FindFirstObjectByType(_cmBrainType) as Component;
-#else
-            return UnityEngine.Object.FindObjectOfType(_cmBrainType) as Component;
-#endif
+            return UnityFindObjectsCompat.FindAny(_cmBrainType) as Component;
         }
 
         internal static UnityEngine.Camera FindMainCamera()
@@ -153,11 +150,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             var main = UnityEngine.Camera.main;
             if (main != null) return main;
 
-#if UNITY_2022_2_OR_NEWER
-            var allCams = UnityEngine.Object.FindObjectsByType<UnityEngine.Camera>(FindObjectsSortMode.None);
-#else
-            var allCams = UnityEngine.Object.FindObjectsOfType<UnityEngine.Camera>();
-#endif
+            var allCams = UnityFindObjectsCompat.FindAll<UnityEngine.Camera>();
             return allCams.Length > 0 ? allCams[0] : null;
         }
 

--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectDelete.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectDelete.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 #nullable disable
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
@@ -24,7 +25,7 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                 if (targetGo != null)
                 {
                     string goName = targetGo.name;
-                    int goId = targetGo.GetInstanceID();
+                    int goId = targetGo.GetInstanceIDCompat();
                     // Note: Undo.DestroyObjectImmediate doesn't work reliably in test context,
                     // so we use Object.DestroyImmediate. This means delete isn't undoable.
                     // TODO: Investigate Undo.DestroyObjectImmediate behavior in Unity 2022+

--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectDelete.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectDelete.cs
@@ -1,10 +1,10 @@
-#pragma warning disable 0619
 #nullable disable
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.GameObjects
 {

--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectDuplicate.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectDuplicate.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 #nullable disable
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
@@ -77,7 +78,7 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                 new
                 {
                     originalName = sourceGo.name,
-                    originalId = sourceGo.GetInstanceID(),
+                    originalId = sourceGo.GetInstanceIDCompat(),
                     duplicatedObject = Helpers.GameObjectSerializer.GetGameObjectData(duplicatedGo)
                 }
             );

--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectDuplicate.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectDuplicate.cs
@@ -1,10 +1,10 @@
-#pragma warning disable 0619
 #nullable disable
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.GameObjects
 {

--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectLookAt.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectLookAt.cs
@@ -1,9 +1,9 @@
-#pragma warning disable 0619
 #nullable disable
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.GameObjects
 {

--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectLookAt.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectLookAt.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 #nullable disable
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
@@ -53,7 +54,7 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                 new
                 {
                     name = targetGo.name,
-                    instanceID = targetGo.GetInstanceID(),
+                    instanceID = targetGo.GetInstanceIDCompat(),
                     rotation = new[] { euler.x, euler.y, euler.z },
                     lookAtPosition = new[] { lookAtPos.Value.x, lookAtPos.Value.y, lookAtPos.Value.z },
                 }

--- a/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 #nullable disable
 using System;
 using System.Collections.Generic;
@@ -68,7 +69,7 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                     if (int.TryParse(searchTerm, out int instanceId))
                     {
                         var allObjects = GetAllSceneObjects(searchInactive);
-                        GameObject obj = allObjects.FirstOrDefault(go => go.GetInstanceID() == instanceId);
+                        GameObject obj = allObjects.FirstOrDefault(go => go.GetInstanceIDCompat() == instanceId);
                         if (obj != null)
                             results.Add(obj);
                     }
@@ -177,7 +178,7 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                     if (int.TryParse(searchTerm, out int id))
                     {
                         var allObjectsId = GetAllSceneObjects(true);
-                        GameObject objById = allObjectsId.FirstOrDefault(go => go.GetInstanceID() == id);
+                        GameObject objById = allObjectsId.FirstOrDefault(go => go.GetInstanceIDCompat() == id);
                         if (objById != null)
                         {
                             results.Add(objById);

--- a/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 #nullable disable
 using System;
 using System.Collections.Generic;
@@ -156,16 +155,9 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                         }
                         else
                         {
-#if UNITY_2023_1_OR_NEWER
-                            var inactive = searchInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude;
-                            searchPoolComp = UnityEngine.Object.FindObjectsByType(componentType, inactive, FindObjectsSortMode.None)
+                            searchPoolComp = UnityFindObjectsCompat.FindAll(componentType, searchInactive)
                                 .Cast<Component>()
                                 .Select(c => c.gameObject);
-#else
-                            searchPoolComp = UnityEngine.Object.FindObjectsOfType(componentType, searchInactive)
-                                .Cast<Component>()
-                                .Select(c => c.gameObject);
-#endif
                         }
                         results.AddRange(searchPoolComp.Where(go => go != null));
                     }

--- a/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Linq;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.GameObjects
 {

--- a/MCPForUnity/Editor/Tools/Graphics/GraphicsHelpers.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/GraphicsHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -109,11 +110,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
             string target = p.Get("target");
             if (string.IsNullOrEmpty(target))
             {
-#if UNITY_2022_2_OR_NEWER
-                var allVolumes = UnityEngine.Object.FindObjectsByType(VolumeType, FindObjectsSortMode.None);
-#else
-                var allVolumes = UnityEngine.Object.FindObjectsOfType(VolumeType);
-#endif
+                var allVolumes = UnityFindObjectsCompat.FindAll(VolumeType);
                 return allVolumes.Length > 0 ? allVolumes[0] as Component : null;
             }
 

--- a/MCPForUnity/Editor/Tools/Graphics/LightBakingOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/LightBakingOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -124,7 +125,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                 {
                     probeName = probe.name,
                     outputPath,
-                    instanceID = go.GetInstanceID()
+                    instanceID = go.GetInstanceIDCompat()
                 }
             };
         }
@@ -274,7 +275,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                 message = $"Created Light Probe Group '{name}' with {positions.Count} probes ({gridX}x{gridY}x{gridZ} grid, spacing {spacing}).",
                 data = new
                 {
-                    instanceID = go.GetInstanceID(),
+                    instanceID = go.GetInstanceIDCompat(),
                     probeCount = positions.Count,
                     gridSize = new[] { gridX, gridY, gridZ },
                     spacing,
@@ -327,7 +328,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                 message = $"Created Reflection Probe '{name}' (mode: {mode}, resolution: {resolution}, HDR: {hdr}).",
                 data = new
                 {
-                    instanceID = go.GetInstanceID(),
+                    instanceID = go.GetInstanceIDCompat(),
                     mode = mode.ToString(),
                     resolution,
                     hdr,
@@ -383,7 +384,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                 message = $"Set {positions.Length} probe positions on '{go.name}'.",
                 data = new
                 {
-                    instanceID = go.GetInstanceID(),
+                    instanceID = go.GetInstanceIDCompat(),
                     probeCount = positions.Length
                 }
             };

--- a/MCPForUnity/Editor/Tools/Graphics/LightBakingOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/LightBakingOps.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Graphics
 {

--- a/MCPForUnity/Editor/Tools/Graphics/RendererFeatureOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/RendererFeatureOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -162,7 +163,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                 {
                     name = displayName,
                     type = featureType.Name,
-                    instanceId = feature.GetInstanceID()
+                    instanceId = feature.GetInstanceIDCompat()
                 }
             };
         }

--- a/MCPForUnity/Editor/Tools/Graphics/RendererFeatureOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/RendererFeatureOps.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Graphics
 {

--- a/MCPForUnity/Editor/Tools/Graphics/SkyboxOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/SkyboxOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
@@ -91,7 +92,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                             : null
                     },
                     sun = sun != null
-                        ? (object)new { name = sun.gameObject.name, instanceID = sun.gameObject.GetInstanceID() }
+                        ? (object)new { name = sun.gameObject.name, instanceID = sun.gameObject.GetInstanceIDCompat() }
                         : null,
                     subtractiveShadowColor = ColorToArray(RenderSettings.subtractiveShadowColor)
                 }
@@ -373,7 +374,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                 data = new
                 {
                     name = go.name,
-                    instanceID = go.GetInstanceID(),
+                    instanceID = go.GetInstanceIDCompat(),
                     lightType = light.type.ToString()
                 }
             };

--- a/MCPForUnity/Editor/Tools/Graphics/SkyboxOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/SkyboxOps.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
@@ -6,6 +5,7 @@ using MCPForUnity.Editor.Helpers;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Graphics
 {

--- a/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -124,7 +125,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
                          (addedEffects.Count > 0 ? $" with effects: {string.Join(", ", addedEffects)}" : ""),
                 data = new
                 {
-                    instanceID = go.GetInstanceID(),
+                    instanceID = go.GetInstanceIDCompat(),
                     isGlobal,
                     weight,
                     priority,
@@ -189,7 +190,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
             {
                 success = true,
                 message = $"Added '{effectName}' to Volume '{(volume as Component)?.gameObject.name}'.",
-                data = new { effect = effectName, volumeInstanceID = (volume as Component)?.gameObject.GetInstanceID() }
+                data = new { effect = effectName, volumeInstanceID = (volume as Component)?.gameObject.GetInstanceIDCompat() }
             };
         }
 
@@ -529,7 +530,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
             return new
             {
                 name = comp.gameObject.name,
-                instance_id = comp.gameObject.GetInstanceID(),
+                instance_id = comp.gameObject.GetInstanceIDCompat(),
                 is_global = isGlobal,
                 weight,
                 priority,

--- a/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -456,11 +455,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
             if (!GraphicsHelpers.HasVolumeSystem)
                 return new { success = true, message = "Volume system not available.", data = new { volumes = new List<object>() } };
 
-#if UNITY_2022_2_OR_NEWER
-            var allVolumes = UnityEngine.Object.FindObjectsByType(GraphicsHelpers.VolumeType, FindObjectsSortMode.None);
-#else
-            var allVolumes = UnityEngine.Object.FindObjectsOfType(GraphicsHelpers.VolumeType);
-#endif
+            var allVolumes = UnityFindObjectsCompat.FindAll(GraphicsHelpers.VolumeType);
             var volumeList = new List<object>();
 
             foreach (Component vol in allVolumes)

--- a/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
@@ -7,6 +7,7 @@ using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Graphics
 {

--- a/MCPForUnity/Editor/Tools/ManageAsset.cs
+++ b/MCPForUnity/Editor/Tools/ManageAsset.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -802,7 +803,7 @@ namespace MCPForUnity.Editor.Tools
                     .Select(comp => new
                     {
                         typeName = comp.GetType().FullName,
-                        instanceID = comp.GetInstanceID(),
+                        instanceID = comp.GetInstanceIDCompat(),
                         // TODO: Add more component-specific details here if needed in the future?
                         //       Requires reflection or specific handling per component type.
                     })
@@ -1104,7 +1105,7 @@ namespace MCPForUnity.Editor.Tools
                 name = Path.GetFileNameWithoutExtension(path),
                 fileName = Path.GetFileName(path),
                 isFolder = AssetDatabase.IsValidFolder(path),
-                instanceID = asset?.GetInstanceID() ?? 0,
+                instanceID = asset?.GetInstanceIDCompat() ?? 0,
                 lastWriteTimeUtc = File.GetLastWriteTimeUtc(
                         Path.Combine(Directory.GetCurrentDirectory(), path)
                     )

--- a/MCPForUnity/Editor/Tools/ManageAsset.cs
+++ b/MCPForUnity/Editor/Tools/ManageAsset.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -16,6 +15,7 @@ using PhysicsMaterialCombine = UnityEngine.PhysicsMaterialCombine;
 #else
 using PhysicsMaterialType = UnityEngine.PhysicMaterial;
 using PhysicsMaterialCombine = UnityEngine.PhysicMaterialCombine;
+using MCPForUnity.Runtime.Helpers;
 #endif
 
 namespace MCPForUnity.Editor.Tools

--- a/MCPForUnity/Editor/Tools/ManageAsset.cs
+++ b/MCPForUnity/Editor/Tools/ManageAsset.cs
@@ -8,14 +8,14 @@ using UnityEditor;
 using UnityEngine;
 using MCPForUnity.Editor.Helpers; // For Response class
 using MCPForUnity.Editor.Tools;
+using MCPForUnity.Runtime.Helpers;
 
 #if UNITY_6000_0_OR_NEWER
 using PhysicsMaterialType = UnityEngine.PhysicsMaterial;
-using PhysicsMaterialCombine = UnityEngine.PhysicsMaterialCombine;  
+using PhysicsMaterialCombine = UnityEngine.PhysicsMaterialCombine;
 #else
 using PhysicsMaterialType = UnityEngine.PhysicMaterial;
 using PhysicsMaterialCombine = UnityEngine.PhysicMaterialCombine;
-using MCPForUnity.Runtime.Helpers;
 #endif
 
 namespace MCPForUnity.Editor.Tools

--- a/MCPForUnity/Editor/Tools/ManageComponents.cs
+++ b/MCPForUnity/Editor/Tools/ManageComponents.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools
 {

--- a/MCPForUnity/Editor/Tools/ManageComponents.cs
+++ b/MCPForUnity/Editor/Tools/ManageComponents.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -118,9 +119,9 @@ namespace MCPForUnity.Editor.Tools
                 message = $"Component '{componentTypeName}' added to '{targetGo.name}'.",
                 data = new
                 {
-                    instanceID = targetGo.GetInstanceID(),
+                    instanceID = targetGo.GetInstanceIDCompat(),
                     componentType = type.FullName,
-                    componentInstanceID = newComponent.GetInstanceID()
+                    componentInstanceID = newComponent.GetInstanceIDCompat()
                 }
             };
         }
@@ -161,7 +162,7 @@ namespace MCPForUnity.Editor.Tools
                 {
                     success = true,
                     message = $"Component '{componentTypeName}' (index {componentIndex.Value}) removed from '{targetGo.name}'.",
-                    data = new { instanceID = targetGo.GetInstanceID(), componentIndex = componentIndex.Value }
+                    data = new { instanceID = targetGo.GetInstanceIDCompat(), componentIndex = componentIndex.Value }
                 };
             }
 
@@ -181,7 +182,7 @@ namespace MCPForUnity.Editor.Tools
                 message = $"Component '{componentTypeName}' removed from '{targetGo.name}'.",
                 data = new
                 {
-                    instanceID = targetGo.GetInstanceID()
+                    instanceID = targetGo.GetInstanceIDCompat()
                 }
             };
         }
@@ -277,7 +278,7 @@ namespace MCPForUnity.Editor.Tools
                         message = $"Some properties failed to set on '{componentType}'.",
                         data = new
                         {
-                            instanceID = targetGo.GetInstanceID(),
+                            instanceID = targetGo.GetInstanceIDCompat(),
                             errors = errors
                         }
                     };
@@ -289,7 +290,7 @@ namespace MCPForUnity.Editor.Tools
                     message = $"Properties set on component '{componentType}' on '{targetGo.name}'.",
                     data = new
                     {
-                        instanceID = targetGo.GetInstanceID()
+                        instanceID = targetGo.GetInstanceIDCompat()
                     }
                 };
             }

--- a/MCPForUnity/Editor/Tools/ManageMaterial.cs
+++ b/MCPForUnity/Editor/Tools/ManageMaterial.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
@@ -417,7 +418,7 @@ namespace MCPForUnity.Editor.Tools
                 materialFolder = $"{sceneDir}/Materials";
             }
 
-            string matPath = $"{materialFolder}/{safeName}_{go.GetInstanceID()}_mat.mat";
+            string matPath = $"{materialFolder}/{safeName}_{go.GetInstanceIDCompat()}_mat.mat";
             matPath = AssetPathUtility.SanitizeAssetPath(matPath);
             if (matPath == null)
             {

--- a/MCPForUnity/Editor/Tools/ManageMaterial.cs
+++ b/MCPForUnity/Editor/Tools/ManageMaterial.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
@@ -6,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools
 {

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -599,11 +598,7 @@ namespace MCPForUnity.Editor.Tools
                         targetCamera = Camera.main;
                         if (targetCamera == null)
                         {
-#if UNITY_2022_2_OR_NEWER
-                            var allCams = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None);
-#else
-                            var allCams = UnityEngine.Object.FindObjectsOfType<Camera>();
-#endif
+                            var allCams = UnityFindObjectsCompat.FindAll<Camera>();
                             targetCamera = allCams.Length > 0 ? allCams[0] : null;
                         }
                     }
@@ -641,11 +636,7 @@ namespace MCPForUnity.Editor.Tools
 
                 // Default path: use ScreenCapture API if available, camera fallback otherwise
                 bool screenCaptureAvailable = ScreenshotUtility.IsScreenCaptureModuleAvailable;
-#if UNITY_2022_2_OR_NEWER
-                bool hasCameraFallback = Camera.main != null || UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length > 0;
-#else
-                bool hasCameraFallback = Camera.main != null || UnityEngine.Object.FindObjectsOfType<Camera>().Length > 0;
-#endif
+                bool hasCameraFallback = Camera.main != null || UnityFindObjectsCompat.FindAll<Camera>().Length > 0;
 
 #if UNITY_2022_1_OR_NEWER
                 if (!screenCaptureAvailable && !hasCameraFallback)
@@ -820,11 +811,7 @@ namespace MCPForUnity.Editor.Tools
                     // Default: calculate combined bounds of all renderers in the scene
                     Bounds bounds = new Bounds(Vector3.zero, Vector3.zero);
                     bool hasBounds = false;
-#if UNITY_2022_2_OR_NEWER
-                    var renderers = UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
-#else
-                    var renderers = UnityEngine.Object.FindObjectsOfType<Renderer>();
-#endif
+                    var renderers = UnityFindObjectsCompat.FindAll<Renderer>();
                     foreach (var r in renderers)
                     {
                         if (r == null || !r.gameObject.activeInHierarchy) continue;
@@ -965,11 +952,7 @@ namespace MCPForUnity.Editor.Tools
                     // Default: calculate combined bounds of all renderers in the scene
                     Bounds bounds = new Bounds(Vector3.zero, Vector3.zero);
                     bool hasBounds = false;
-#if UNITY_2022_2_OR_NEWER
-                    var renderers = UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
-#else
-                    var renderers = UnityEngine.Object.FindObjectsOfType<Renderer>();
-#endif
+                    var renderers = UnityFindObjectsCompat.FindAll<Renderer>();
                     foreach (var r in renderers)
                     {
                         if (r == null || !r.gameObject.activeInHierarchy) continue;
@@ -1217,11 +1200,7 @@ namespace MCPForUnity.Editor.Tools
             }
 
             // Search all cameras by name or path
-#if UNITY_2022_2_OR_NEWER
-            var allCams = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None);
-#else
-            var allCams = UnityEngine.Object.FindObjectsOfType<Camera>();
-#endif
+            var allCams = UnityFindObjectsCompat.FindAll<Camera>();
             foreach (var cam in allCams)
             {
                 if (cam.name == cameraRef) return cam;
@@ -1273,11 +1252,7 @@ namespace MCPForUnity.Editor.Tools
                     // Frame entire scene by computing combined bounds of all renderers
                     Bounds allBounds = new Bounds(Vector3.zero, Vector3.zero);
                     bool hasAny = false;
-#if UNITY_2022_2_OR_NEWER
-                    foreach (var r in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None))
-#else
-                    foreach (var r in UnityEngine.Object.FindObjectsOfType<Renderer>())
-#endif
+                    foreach (var r in UnityFindObjectsCompat.FindAll<Renderer>())
                     {
                         if (r == null || !r.gameObject.activeInHierarchy) continue;
                         if (!hasAny) { allBounds = r.bounds; hasAny = true; }

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -2008,7 +2009,7 @@ namespace MCPForUnity.Editor.Tools
             var d = new Dictionary<string, object>
             {
                 { "name", go.name },
-                { "instanceID", go.GetInstanceID() },
+                { "instanceID", go.GetInstanceIDCompat() },
                 { "activeSelf", go.activeSelf },
                 { "activeInHierarchy", go.activeInHierarchy },
                 { "tag", go.tag },

--- a/MCPForUnity/Editor/Tools/ManageUI.cs
+++ b/MCPForUnity/Editor/Tools/ManageUI.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -1033,7 +1034,7 @@ namespace MCPForUnity.Editor.Tools
                     return new ErrorResponse("UIDocument has no PanelSettings assigned.");
 
                 var panelSettings = uiDoc.panelSettings;
-                int psId = panelSettings.GetInstanceID();
+                int psId = panelSettings.GetInstanceIDCompat();
 
                 // Check if we already have a persistent RT assigned to this PanelSettings.
                 // If the RT exists and its size matches, the panel has been rendering into it.

--- a/MCPForUnity/Editor/Tools/ManageUI.cs
+++ b/MCPForUnity/Editor/Tools/ManageUI.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/MCPForUnity/Editor/Tools/Physics/JointOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/JointOps.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -6,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Physics
 {

--- a/MCPForUnity/Editor/Tools/Physics/JointOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/JointOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -140,8 +141,8 @@ namespace MCPForUnity.Editor.Tools.Physics
                 data = new
                 {
                     jointType = jointComponentType.Name,
-                    instanceID = joint.GetInstanceID(),
-                    gameObjectInstanceID = go.GetInstanceID()
+                    instanceID = joint.GetInstanceIDCompat(),
+                    gameObjectInstanceID = go.GetInstanceIDCompat()
                 }
             };
         }
@@ -312,7 +313,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                 {
                     jointType = joint.GetType().Name,
                     configured,
-                    instanceID = joint.GetInstanceID()
+                    instanceID = joint.GetInstanceIDCompat()
                 }
             };
         }
@@ -397,7 +398,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                 data = new
                 {
                     removedCount,
-                    gameObjectInstanceID = go.GetInstanceID()
+                    gameObjectInstanceID = go.GetInstanceIDCompat()
                 }
             };
         }

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsQueryOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsQueryOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
@@ -79,7 +80,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { hitInfo.normal.x, hitInfo.normal.y, hitInfo.normal.z },
                     distance = hitInfo.distance,
                     gameObject = hitInfo.collider.gameObject.name,
-                    instanceID = hitInfo.collider.gameObject.GetInstanceID(),
+                    instanceID = hitInfo.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = hitInfo.collider.GetType().Name
                 }
             };
@@ -122,7 +123,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { hit.normal.x, hit.normal.y },
                     distance = hit.distance,
                     gameObject = hit.collider.gameObject.name,
-                    instanceID = hit.collider.gameObject.GetInstanceID(),
+                    instanceID = hit.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = hit.collider.GetType().Name
                 }
             };
@@ -289,7 +290,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                 colliders.Add(new
                 {
                     gameObject = col.gameObject.name,
-                    instanceID = col.gameObject.GetInstanceID(),
+                    instanceID = col.gameObject.GetInstanceIDCompat(),
                     collider_type = col.GetType().Name
                 });
             }
@@ -310,7 +311,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                 colliders.Add(new
                 {
                     gameObject = col.gameObject.name,
-                    instanceID = col.gameObject.GetInstanceID(),
+                    instanceID = col.gameObject.GetInstanceIDCompat(),
                     collider_type = col.GetType().Name
                 });
             }
@@ -464,7 +465,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { hitInfo.normal.x, hitInfo.normal.y, hitInfo.normal.z },
                     distance = hitInfo.distance,
                     gameObject = hitInfo.collider.gameObject.name,
-                    instanceID = hitInfo.collider.gameObject.GetInstanceID(),
+                    instanceID = hitInfo.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = hitInfo.collider.GetType().Name
                 }
             };
@@ -553,7 +554,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { hit.normal.x, hit.normal.y },
                     distance = hit.distance,
                     gameObject = hit.collider.gameObject.name,
-                    instanceID = hit.collider.gameObject.GetInstanceID(),
+                    instanceID = hit.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = hit.collider.GetType().Name
                 }
             };
@@ -619,7 +620,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { h.normal.x, h.normal.y, h.normal.z },
                     distance = h.distance,
                     gameObject = h.collider.gameObject.name,
-                    instanceID = h.collider.gameObject.GetInstanceID(),
+                    instanceID = h.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = h.collider.GetType().Name
                 });
             }
@@ -657,7 +658,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { h.normal.x, h.normal.y },
                     distance = h.distance,
                     gameObject = h.collider.gameObject.name,
-                    instanceID = h.collider.gameObject.GetInstanceID(),
+                    instanceID = h.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = h.collider.GetType().Name
                 });
             }
@@ -739,7 +740,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { hitInfo.normal.x, hitInfo.normal.y, hitInfo.normal.z },
                     distance = hitInfo.distance,
                     gameObject = hitInfo.collider.gameObject.name,
-                    instanceID = hitInfo.collider.gameObject.GetInstanceID(),
+                    instanceID = hitInfo.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = hitInfo.collider.GetType().Name
                 }
             };
@@ -782,7 +783,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     normal = new[] { hit.normal.x, hit.normal.y },
                     distance = hit.distance,
                     gameObject = hit.collider.gameObject.name,
-                    instanceID = hit.collider.gameObject.GetInstanceID(),
+                    instanceID = hit.collider.gameObject.GetInstanceIDCompat(),
                     collider_type = hit.collider.GetType().Name
                 }
             };

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsQueryOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsQueryOps.cs
@@ -1,9 +1,9 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Physics
 {

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsRigidbodyOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsRigidbodyOps.cs
@@ -1,10 +1,10 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Physics
 {

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsRigidbodyOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsRigidbodyOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
@@ -65,7 +66,7 @@ namespace MCPForUnity.Editor.Tools.Physics
             var data = new Dictionary<string, object>
             {
                 ["target"] = go.name,
-                ["instanceID"] = go.GetInstanceID(),
+                ["instanceID"] = go.GetInstanceIDCompat(),
                 ["dimension"] = "3d",
                 ["mass"] = rb.mass,
 #if UNITY_6000_0_OR_NEWER
@@ -113,7 +114,7 @@ namespace MCPForUnity.Editor.Tools.Physics
             var data = new Dictionary<string, object>
             {
                 ["target"] = go.name,
-                ["instanceID"] = go.GetInstanceID(),
+                ["instanceID"] = go.GetInstanceIDCompat(),
                 ["dimension"] = "2d",
                 ["mass"] = rb2d.mass,
                 ["gravityScale"] = rb2d.gravityScale,

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Physics
 {

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
@@ -140,11 +139,7 @@ namespace MCPForUnity.Editor.Tools.Physics
 
             if (dimension == "2d")
             {
-#if UNITY_2022_2_OR_NEWER
-                var allRb2d = Object.FindObjectsByType<Rigidbody2D>(FindObjectsSortMode.None);
-#else
-                var allRb2d = Object.FindObjectsOfType<Rigidbody2D>();
-#endif
+                var allRb2d = UnityFindObjectsCompat.FindAll<Rigidbody2D>();
                 foreach (var rb2d in allRb2d)
                 {
                     if (results.Count >= maxResults) break;
@@ -167,11 +162,7 @@ namespace MCPForUnity.Editor.Tools.Physics
             }
             else
             {
-#if UNITY_2022_2_OR_NEWER
-                var allRb = Object.FindObjectsByType<Rigidbody>(FindObjectsSortMode.None);
-#else
-                var allRb = Object.FindObjectsOfType<Rigidbody>();
-#endif
+                var allRb = UnityFindObjectsCompat.FindAll<Rigidbody>();
                 foreach (var rb in allRb)
                 {
                     if (results.Count >= maxResults) break;

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
@@ -97,7 +98,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     results.Add(new
                     {
                         name = go.name,
-                        instanceID = go.GetInstanceID(),
+                        instanceID = go.GetInstanceIDCompat(),
                         position = new[] { rb2d.position.x, rb2d.position.y },
 #if UNITY_6000_0_OR_NEWER
                         velocity = new[] { rb2d.linearVelocity.x, rb2d.linearVelocity.y },
@@ -116,7 +117,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     results.Add(new
                     {
                         name = go.name,
-                        instanceID = go.GetInstanceID(),
+                        instanceID = go.GetInstanceIDCompat(),
                         position = new[] { rb.position.x, rb.position.y, rb.position.z },
 #if UNITY_6000_0_OR_NEWER
                         velocity = new[] { rb.linearVelocity.x, rb.linearVelocity.y, rb.linearVelocity.z },
@@ -152,7 +153,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     results.Add(new
                     {
                         name = rb2d.gameObject.name,
-                        instanceID = rb2d.gameObject.GetInstanceID(),
+                        instanceID = rb2d.gameObject.GetInstanceIDCompat(),
                         position = new[] { rb2d.position.x, rb2d.position.y },
 #if UNITY_6000_0_OR_NEWER
                         velocity = new[] { rb2d.linearVelocity.x, rb2d.linearVelocity.y },
@@ -179,7 +180,7 @@ namespace MCPForUnity.Editor.Tools.Physics
                     results.Add(new
                     {
                         name = rb.gameObject.name,
-                        instanceID = rb.gameObject.GetInstanceID(),
+                        instanceID = rb.gameObject.GetInstanceIDCompat(),
                         position = new[] { rb.position.x, rb.position.y, rb.position.z },
 #if UNITY_6000_0_OR_NEWER
                         velocity = new[] { rb.linearVelocity.x, rb.linearVelocity.y, rb.linearVelocity.z },

--- a/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
+++ b/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,6 +8,7 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Prefabs
 {

--- a/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
+++ b/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -162,7 +163,7 @@ namespace MCPForUnity.Editor.Tools.Prefabs
                     new
                     {
                         prefabPath = finalPath,
-                        instanceId = result.GetInstanceID(),
+                        instanceId = result.GetInstanceIDCompat(),
                         instanceName = result.name,
                         wasUnlinked = unlinkIfInstance && objectValidation.shouldUnlink,
                         wasReplaced = replaceExisting && fileExistedAtPath,
@@ -1234,7 +1235,7 @@ namespace MCPForUnity.Editor.Tools.Prefabs
 
             string name = transform.gameObject.name;
             string path = string.IsNullOrEmpty(parentPath) ? name : $"{parentPath}/{name}";
-            int instanceId = transform.gameObject.GetInstanceID();
+            int instanceId = transform.gameObject.GetInstanceIDCompat();
             bool activeSelf = transform.gameObject.activeSelf;
             int childCount = transform.childCount;
             var componentTypes = PrefabUtilityHelper.GetComponentTypeNames(transform.gameObject);

--- a/MCPForUnity/Editor/Tools/ProBuilder/ManageProBuilder.cs
+++ b/MCPForUnity/Editor/Tools/ProBuilder/ManageProBuilder.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using MCPForUnity.Editor.Helpers;
 using UnityEditor;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.ProBuilder
 {

--- a/MCPForUnity/Editor/Tools/ProBuilder/ManageProBuilder.cs
+++ b/MCPForUnity/Editor/Tools/ProBuilder/ManageProBuilder.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -595,7 +596,7 @@ namespace MCPForUnity.Editor.Tools.ProBuilder
             return new SuccessResponse($"Created ProBuilder {shapeTypeStr}: {go.name}", new
             {
                 gameObjectName = go.name,
-                instanceId = go.GetInstanceID(),
+                instanceId = go.GetInstanceIDCompat(),
                 shapeType = shapeTypeStr,
                 faceCount = GetFaceCount(pbMesh),
                 vertexCount = GetVertexCount(pbMesh),
@@ -899,7 +900,7 @@ namespace MCPForUnity.Editor.Tools.ProBuilder
             return new SuccessResponse($"Created poly shape: {go.name}", new
             {
                 gameObjectName = go.name,
-                instanceId = go.GetInstanceID(),
+                instanceId = go.GetInstanceIDCompat(),
                 pointCount = points.Count,
                 extrudeHeight,
                 faceCount = GetFaceCount(pbMesh),
@@ -2294,7 +2295,7 @@ namespace MCPForUnity.Editor.Tools.ProBuilder
             var data = new Dictionary<string, object>
             {
                 ["gameObjectName"] = pbMesh.gameObject.name,
-                ["instanceId"] = pbMesh.gameObject.GetInstanceID(),
+                ["instanceId"] = pbMesh.gameObject.GetInstanceIDCompat(),
                 ["faceCount"] = GetFaceCount(pbMesh),
                 ["vertexCount"] = GetVertexCount(pbMesh),
                 ["bounds"] = new

--- a/MCPForUnity/Editor/Tools/Vfx/ParticleControl.cs
+++ b/MCPForUnity/Editor/Tools/Vfx/ParticleControl.cs
@@ -1,9 +1,9 @@
-#pragma warning disable 0619
 using System;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Vfx
 {

--- a/MCPForUnity/Editor/Tools/Vfx/ParticleControl.cs
+++ b/MCPForUnity/Editor/Tools/Vfx/ParticleControl.cs
@@ -1,3 +1,4 @@
+#pragma warning disable 0619
 using System;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
@@ -90,7 +91,7 @@ namespace MCPForUnity.Editor.Tools.Vfx
                 success = true,
                 message = $"ParticleSystem ready on '{go.name}'",
                 target = go.name,
-                targetId = go.GetInstanceID(),
+                targetId = go.GetInstanceIDCompat(),
                 createdGameObject,
                 addedParticleSystem,
                 assignedMaterial = renderer?.sharedMaterial?.name

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -91,11 +91,7 @@ namespace MCPForUnity.Runtime.Helpers
 
             try
             {
-#if UNITY_2022_2_OR_NEWER
-                var cams = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None);
-#else
-                var cams = UnityEngine.Object.FindObjectsOfType<Camera>();
-#endif
+                var cams = UnityFindObjectsCompat.FindAll<Camera>();
                 return cams.FirstOrDefault();
             }
             catch

--- a/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs
@@ -1,0 +1,64 @@
+using System;
+using UObject = UnityEngine.Object;
+
+namespace MCPForUnity.Runtime.Helpers
+{
+    /// <summary>
+    /// Version-compatible wrappers for the Object.FindObjectsOfType / FindObjectsByType family,
+    /// which changed across Unity 2022 → 6.0 → 6.5:
+    ///   Pre-2022.2  : FindObjectsOfType / FindObjectOfType
+    ///   2022.2–6.4  : FindObjectsByType(sortMode) / FindFirstObjectByType
+    ///   6.5+        : FindObjectsByType() (no sort param) / FindAnyObjectByType
+    /// </summary>
+    public static class UnityFindObjectsCompat
+    {
+        /// <summary>Find all active objects of type T.</summary>
+        public static T[] FindAll<T>() where T : UObject
+        {
+#if UNITY_6000_5_OR_NEWER
+            return UObject.FindObjectsByType<T>();
+#elif UNITY_2022_2_OR_NEWER
+            return UObject.FindObjectsByType<T>(UnityEngine.FindObjectsSortMode.None);
+#else
+            return UObject.FindObjectsOfType<T>();
+#endif
+        }
+
+        /// <summary>Find all active objects of the given runtime type.</summary>
+        public static UObject[] FindAll(Type type)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return UObject.FindObjectsByType(type, UnityEngine.FindObjectsInactive.Exclude);
+#elif UNITY_2022_2_OR_NEWER
+            return UObject.FindObjectsByType(type, UnityEngine.FindObjectsSortMode.None);
+#else
+            return UObject.FindObjectsOfType(type);
+#endif
+        }
+
+        /// <summary>Find all objects of the given runtime type, optionally including inactive.</summary>
+        public static UObject[] FindAll(Type type, bool includeInactive)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return UObject.FindObjectsByType(type,
+                includeInactive ? UnityEngine.FindObjectsInactive.Include : UnityEngine.FindObjectsInactive.Exclude);
+#elif UNITY_2023_1_OR_NEWER
+            return UObject.FindObjectsByType(type,
+                includeInactive ? UnityEngine.FindObjectsInactive.Include : UnityEngine.FindObjectsInactive.Exclude,
+                UnityEngine.FindObjectsSortMode.None);
+#else
+            return UObject.FindObjectsOfType(type, includeInactive);
+#endif
+        }
+
+        /// <summary>Find any single object of the given runtime type (no ordering guarantee).</summary>
+        public static UObject FindAny(Type type)
+        {
+#if UNITY_2022_2_OR_NEWER
+            return UObject.FindAnyObjectByType(type);
+#else
+            return UObject.FindObjectOfType(type);
+#endif
+        }
+    }
+}

--- a/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs.meta
+++ b/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c3a9f12e4b60438d9a1c52ef8d07b3e

--- a/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs
@@ -30,6 +30,7 @@ public static class UnityObjectIdCompatExtensions
                 {
                     return parsed;
                 }
+
                 return entity.GetHashCode();
             }
         }

--- a/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs
@@ -1,40 +1,30 @@
-using System.Reflection;
 using UnityEngine;
 
-public static class UnityObjectIdCompatExtensions
+namespace MCPForUnity.Runtime.Helpers
 {
-    private static readonly MethodInfo GetInstanceIdMethod = typeof(Object).GetMethod("GetInstanceID", BindingFlags.Public | BindingFlags.Instance);
-    private static readonly MethodInfo GetEntityIdMethod = typeof(Object).GetMethod("GetEntityId", BindingFlags.Public | BindingFlags.Instance);
-
-    public static int GetInstanceIDCompat(this Object obj)
+    /// <summary>
+    /// Version-gated wrapper for <see cref="Object.GetInstanceID"/>, which was removed in Unity 6.5
+    /// in favor of <see cref="Object.GetEntityId"/>. Returns a session-scoped int handle that
+    /// callers can use for in-process comparisons and wire-format compatibility with older readers.
+    /// For deserialization round-trips on Unity 6.5+, prefer the full <c>entityID</c> field.
+    /// </summary>
+    public static class UnityObjectIdCompatExtensions
     {
-        if (obj == null)
+        public static int GetInstanceIDCompat(this Object obj)
         {
-            return 0;
-        }
-
-        if (GetInstanceIdMethod != null)
-        {
-            object result = GetInstanceIdMethod.Invoke(obj, null);
-            if (result is int id)
+            if (obj == null)
             {
-                return id;
+                return 0;
             }
-        }
 
-        if (GetEntityIdMethod != null)
-        {
-            object entity = GetEntityIdMethod.Invoke(obj, null);
-            if (entity != null)
-            {
-                if (int.TryParse(entity.ToString(), out int parsed))
-                {
-                    return parsed;
-                }
-            }
+#if UNITY_6000_5_OR_NEWER
+            // GetInstanceID() is obsolete-as-error on Unity 6.5+. Truncate the EntityId's
+            // underlying ulong to int; this is lossy but stable within a session and
+            // preserves the int-shaped wire format that older consumers expect.
+            return (int)EntityId.ToULong(obj.GetEntityId());
+#else
+            return obj.GetInstanceID();
+#endif
         }
-
-        Debug.LogWarning($"[UnityObjectIdCompatExtensions] Failed to resolve Unity object ID for '{obj.name}'. Returning 0.");
-        return 0;
     }
 }

--- a/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 
 public static class UnityObjectIdCompatExtensions
 {
+    private static readonly MethodInfo GetInstanceIdMethod = typeof(Object).GetMethod("GetInstanceID", BindingFlags.Public | BindingFlags.Instance);
+    private static readonly MethodInfo GetEntityIdMethod = typeof(Object).GetMethod("GetEntityId", BindingFlags.Public | BindingFlags.Instance);
+
     public static int GetInstanceIDCompat(this Object obj)
     {
         if (obj == null)
@@ -10,31 +13,28 @@ public static class UnityObjectIdCompatExtensions
             return 0;
         }
 
-        MethodInfo getInstanceId = typeof(Object).GetMethod("GetInstanceID", BindingFlags.Public | BindingFlags.Instance);
-        if (getInstanceId != null)
+        if (GetInstanceIdMethod != null)
         {
-            object result = getInstanceId.Invoke(obj, null);
+            object result = GetInstanceIdMethod.Invoke(obj, null);
             if (result is int id)
             {
                 return id;
             }
         }
 
-        MethodInfo getEntityId = typeof(Object).GetMethod("GetEntityId", BindingFlags.Public | BindingFlags.Instance);
-        if (getEntityId != null)
+        if (GetEntityIdMethod != null)
         {
-            object entity = getEntityId.Invoke(obj, null);
+            object entity = GetEntityIdMethod.Invoke(obj, null);
             if (entity != null)
             {
                 if (int.TryParse(entity.ToString(), out int parsed))
                 {
                     return parsed;
                 }
-
-                return entity.GetHashCode();
             }
         }
 
-        return obj.GetHashCode();
+        Debug.LogWarning($"[UnityObjectIdCompatExtensions] Failed to resolve Unity object ID for '{obj.name}'. Returning 0.");
+        return 0;
     }
 }

--- a/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs.meta
+++ b/MCPForUnity/Runtime/Helpers/UnityObjectIdCompatExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ea8b580f3e80459cab9019f71d0ccb6

--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -295,7 +295,7 @@ namespace MCPForUnity.Runtime.Serialization
                     writer.WritePropertyName("name");
                     writer.WriteValue(value.name);
                     writer.WritePropertyName("instanceID");
-                    writer.WriteValue(value.GetInstanceID());
+                    writer.WriteValue(GetObjectId(value));
                     writer.WritePropertyName("isAssetWithoutPath");
                     writer.WriteValue(true);
                     writer.WriteEndObject();
@@ -308,7 +308,7 @@ namespace MCPForUnity.Runtime.Serialization
                 writer.WritePropertyName("name");
                 writer.WriteValue(value.name);
                 writer.WritePropertyName("instanceID");
-                writer.WriteValue(value.GetInstanceID());
+                writer.WriteValue(GetObjectId(value));
                 writer.WriteEndObject();
             }
 #else
@@ -317,7 +317,7 @@ namespace MCPForUnity.Runtime.Serialization
             writer.WritePropertyName("name");
             writer.WriteValue(value.name);
             writer.WritePropertyName("instanceID");
-            writer.WriteValue(value.GetInstanceID());
+            writer.WriteValue(GetObjectId(value));
              writer.WritePropertyName("warning");
             writer.WriteValue("UnityEngineObjectConverter running in non-Editor mode, asset path unavailable.");
             writer.WriteEndObject();
@@ -466,6 +466,15 @@ namespace MCPForUnity.Runtime.Serialization
                     return false;
             }
             return true;
+        }
+
+        private static int GetObjectId(UnityEngine.Object value)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return value.GetEntityId();
+#else
+            return value.GetInstanceID();
+#endif
         }
     }
 }

--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -1,6 +1,8 @@
+#pragma warning disable 0619
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor; // Required for AssetDatabase and EditorUtility
@@ -294,8 +296,7 @@ namespace MCPForUnity.Runtime.Serialization
                     writer.WriteStartObject();
                     writer.WritePropertyName("name");
                     writer.WriteValue(value.name);
-                    writer.WritePropertyName("instanceID");
-                    writer.WriteValue(GetObjectId(value));
+                    WriteSerializedObjectId(writer, value);
                     writer.WritePropertyName("isAssetWithoutPath");
                     writer.WriteValue(true);
                     writer.WriteEndObject();
@@ -307,8 +308,7 @@ namespace MCPForUnity.Runtime.Serialization
                 writer.WriteStartObject();
                 writer.WritePropertyName("name");
                 writer.WriteValue(value.name);
-                writer.WritePropertyName("instanceID");
-                writer.WriteValue(GetObjectId(value));
+                WriteSerializedObjectId(writer, value);
                 writer.WriteEndObject();
             }
 #else
@@ -316,8 +316,7 @@ namespace MCPForUnity.Runtime.Serialization
             writer.WriteStartObject();
             writer.WritePropertyName("name");
             writer.WriteValue(value.name);
-            writer.WritePropertyName("instanceID");
-            writer.WriteValue(GetObjectId(value));
+            WriteSerializedObjectId(writer, value);
              writer.WritePropertyName("warning");
             writer.WriteValue("UnityEngineObjectConverter running in non-Editor mode, asset path unavailable.");
             writer.WriteEndObject();
@@ -373,6 +372,36 @@ namespace MCPForUnity.Runtime.Serialization
                         if (asset != null) return asset;
                     }
                     UnityEngine.Debug.LogWarning($"[UnityEngineObjectConverter] Could not load asset with GUID '{guidToken}' as type '{objectType.Name}'.");
+                    return null;
+                }
+
+                // Try to resolve by entityID (Unity 6.5+)
+                if (jo.TryGetValue("entityID", out JToken entityIdToken) && entityIdToken.Type == JTokenType.String)
+                {
+                    string serializedEntityId = entityIdToken.ToString();
+                    if (TryResolveEntityIdToObject(serializedEntityId, out UnityEngine.Object entityObj) && entityObj != null)
+                    {
+                        if (objectType.IsAssignableFrom(entityObj.GetType()))
+                        {
+                            return entityObj;
+                        }
+
+                        if (objectType == typeof(Transform) && entityObj is GameObject entityGo)
+                        {
+                            return entityGo.transform;
+                        }
+
+                        if (typeof(Component).IsAssignableFrom(objectType) && entityObj is GameObject entityGameObj)
+                        {
+                            var component = entityGameObj.GetComponent(objectType);
+                            if (component != null)
+                            {
+                                return component;
+                            }
+                        }
+                    }
+
+                    UnityEngine.Debug.LogWarning($"[UnityEngineObjectConverter] Could not resolve entityID '{serializedEntityId}' to a valid {objectType.Name}.");
                     return null;
                 }
 
@@ -435,7 +464,7 @@ namespace MCPForUnity.Runtime.Serialization
                 }
 
                 // Object format not recognized
-                UnityEngine.Debug.LogWarning($"[UnityEngineObjectConverter] JSON object missing 'instanceID', 'guid', or 'path' field for {objectType.Name} deserialization. Object: {jo.ToString(Formatting.None)}");
+                UnityEngine.Debug.LogWarning($"[UnityEngineObjectConverter] JSON object missing 'instanceID', 'entityID', 'guid', or 'path' field for {objectType.Name} deserialization. Object: {jo.ToString(Formatting.None)}");
                 return null;
             }
 
@@ -468,18 +497,74 @@ namespace MCPForUnity.Runtime.Serialization
             return true;
         }
 
-        private static int GetObjectId(UnityEngine.Object value)
+        private static void WriteSerializedObjectId(JsonWriter writer, UnityEngine.Object value)
         {
 #if UNITY_6000_5_OR_NEWER
-            // Unity 6.5 deprecates GetInstanceID in favor of GetEntityId, but this package
-            // still serializes the identifier as "instanceID" (int) for backward compatibility.
-            // Suppress the transitional obsolete cast warning until upstream migrates schema.
-#pragma warning disable 0619
-            return value.GetEntityId();
-#pragma warning restore 0619
+            writer.WritePropertyName("entityID");
+            writer.WriteValue(value.GetEntityId().ToString());
 #else
-            return value.GetInstanceID();
+            writer.WritePropertyName("instanceID");
+            writer.WriteValue(value.GetInstanceIDCompat());
 #endif
+        }
+
+        private static bool TryResolveEntityIdToObject(string serializedEntityId, out UnityEngine.Object obj)
+        {
+            obj = null;
+#if UNITY_EDITOR && UNITY_6000_5_OR_NEWER
+            if (string.IsNullOrWhiteSpace(serializedEntityId))
+            {
+                return false;
+            }
+
+            MethodInfo[] methods = typeof(UnityEditor.EditorUtility).GetMethods(BindingFlags.Public | BindingFlags.Static);
+            foreach (MethodInfo method in methods)
+            {
+                if (method.Name != "EntityIdToObject")
+                {
+                    continue;
+                }
+
+                ParameterInfo[] parameters = method.GetParameters();
+                if (parameters.Length != 1)
+                {
+                    continue;
+                }
+
+                Type paramType = parameters[0].ParameterType;
+                object arg = null;
+
+                if (paramType == typeof(int))
+                {
+                    if (!int.TryParse(serializedEntityId, out int parsedInt))
+                    {
+                        continue;
+                    }
+                    arg = parsedInt;
+                }
+                else
+                {
+                    MethodInfo parseMethod = paramType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string) }, null);
+                    if (parseMethod != null)
+                    {
+                        arg = parseMethod.Invoke(null, new object[] { serializedEntityId });
+                    }
+                }
+
+                if (arg == null)
+                {
+                    continue;
+                }
+
+                object result = method.Invoke(null, new[] { arg });
+                if (result is UnityEngine.Object resolved)
+                {
+                    obj = resolved;
+                    return true;
+                }
+            }
+#endif
+            return false;
         }
     }
 }

--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -471,7 +471,12 @@ namespace MCPForUnity.Runtime.Serialization
         private static int GetObjectId(UnityEngine.Object value)
         {
 #if UNITY_6000_5_OR_NEWER
+            // Unity 6.5 deprecates GetInstanceID in favor of GetEntityId, but this package
+            // still serializes the identifier as "instanceID" (int) for backward compatibility.
+            // Suppress the transitional obsolete cast warning until upstream migrates schema.
+#pragma warning disable 0619
             return value.GetEntityId();
+#pragma warning restore 0619
 #else
             return value.GetInstanceID();
 #endif

--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -1,8 +1,8 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Reflection;
 using UnityEngine;
+using MCPForUnity.Runtime.Helpers;
 #if UNITY_EDITOR
 using UnityEditor; // Required for AssetDatabase and EditorUtility
 #endif
@@ -374,34 +374,41 @@ namespace MCPForUnity.Runtime.Serialization
                     return null;
                 }
 
-                // Try to resolve by entityID (Unity 6.5+)
+#if UNITY_6000_5_OR_NEWER
+                // Try to resolve by entityID (Unity 6.5+). Falls through to instanceID/guid/path on failure.
                 if (jo.TryGetValue("entityID", out JToken entityIdToken) && entityIdToken.Type == JTokenType.String)
                 {
                     string serializedEntityId = entityIdToken.ToString();
-                    if (TryResolveEntityIdToObject(serializedEntityId, out UnityEngine.Object entityObj) && entityObj != null)
+                    if (ulong.TryParse(serializedEntityId, out ulong rawEntityId))
                     {
-                        if (objectType.IsAssignableFrom(entityObj.GetType()))
+                        EntityId eid = EntityId.FromULong(rawEntityId);
+                        UnityEngine.Object entityObj = UnityEditor.EditorUtility.EntityIdToObject(eid);
+                        if (entityObj != null)
                         {
-                            return entityObj;
-                        }
-
-                        if (objectType == typeof(Transform) && entityObj is GameObject entityGo)
-                        {
-                            return entityGo.transform;
-                        }
-
-                        if (typeof(Component).IsAssignableFrom(objectType) && entityObj is GameObject entityGameObj)
-                        {
-                            var component = entityGameObj.GetComponent(objectType);
-                            if (component != null)
+                            if (objectType.IsAssignableFrom(entityObj.GetType()))
                             {
-                                return component;
+                                return entityObj;
+                            }
+
+                            if (objectType == typeof(Transform) && entityObj is GameObject entityGo)
+                            {
+                                return entityGo.transform;
+                            }
+
+                            if (typeof(Component).IsAssignableFrom(objectType) && entityObj is GameObject entityGameObj)
+                            {
+                                var component = entityGameObj.GetComponent(objectType);
+                                if (component != null)
+                                {
+                                    return component;
+                                }
                             }
                         }
                     }
 
-                    UnityEngine.Debug.LogWarning($"[UnityEngineObjectConverter] Could not resolve entityID '{serializedEntityId}' to a valid {objectType.Name}.");
+                    UnityEngine.Debug.LogWarning($"[UnityEngineObjectConverter] Could not resolve entityID '{serializedEntityId}' to a valid {objectType.Name}. Falling back to instanceID/guid/path.");
                 }
+#endif
 
                 // Try to resolve by instanceID
                 if (jo.TryGetValue("instanceID", out JToken idToken) && idToken.Type == JTokenType.Integer)
@@ -497,86 +504,15 @@ namespace MCPForUnity.Runtime.Serialization
 
         private static void WriteSerializedObjectId(JsonWriter writer, UnityEngine.Object value)
         {
+            // Always emit instanceID so older consumers keep working.
             writer.WritePropertyName("instanceID");
             writer.WriteValue(value.GetInstanceIDCompat());
 #if UNITY_6000_5_OR_NEWER
+            // Additionally emit entityID on Unity 6.5+ as the stable ulong form
+            // (per Unity docs, EntityId.ToString() is NOT a stable serialization format).
             writer.WritePropertyName("entityID");
-            writer.WriteValue(value.GetEntityId().ToString());
+            writer.WriteValue(EntityId.ToULong(value.GetEntityId()).ToString());
 #endif
-        }
-
-        private static bool TryResolveEntityIdToObject(string serializedEntityId, out UnityEngine.Object obj)
-        {
-            obj = null;
-#if UNITY_EDITOR && UNITY_6000_5_OR_NEWER
-            if (string.IsNullOrWhiteSpace(serializedEntityId))
-            {
-                return false;
-            }
-
-            MethodInfo[] methods = typeof(UnityEditor.EditorUtility).GetMethods(BindingFlags.Public | BindingFlags.Static);
-            foreach (MethodInfo method in methods)
-            {
-                if (method.Name != "EntityIdToObject")
-                {
-                    continue;
-                }
-
-                ParameterInfo[] parameters = method.GetParameters();
-                if (parameters.Length != 1)
-                {
-                    continue;
-                }
-
-                Type paramType = parameters[0].ParameterType;
-                object arg = null;
-
-                if (paramType == typeof(int))
-                {
-                    if (!int.TryParse(serializedEntityId, out int parsedInt))
-                    {
-                        continue;
-                    }
-                    arg = parsedInt;
-                }
-                else
-                {
-                    MethodInfo parseMethod = paramType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string) }, null);
-                    if (parseMethod != null)
-                    {
-                        try
-                        {
-                            arg = parseMethod.Invoke(null, new object[] { serializedEntityId });
-                        }
-                        catch
-                        {
-                            continue;
-                        }
-                    }
-                }
-
-                if (arg == null)
-                {
-                    continue;
-                }
-
-                object result = null;
-                try
-                {
-                    result = method.Invoke(null, new[] { arg });
-                }
-                catch
-                {
-                    continue;
-                }
-                if (result is UnityEngine.Object resolved)
-                {
-                    obj = resolved;
-                    return true;
-                }
-            }
-#endif
-            return false;
         }
     }
 }

--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -1,4 +1,3 @@
-#pragma warning disable 0619
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -402,7 +401,6 @@ namespace MCPForUnity.Runtime.Serialization
                     }
 
                     UnityEngine.Debug.LogWarning($"[UnityEngineObjectConverter] Could not resolve entityID '{serializedEntityId}' to a valid {objectType.Name}.");
-                    return null;
                 }
 
                 // Try to resolve by instanceID
@@ -499,12 +497,11 @@ namespace MCPForUnity.Runtime.Serialization
 
         private static void WriteSerializedObjectId(JsonWriter writer, UnityEngine.Object value)
         {
+            writer.WritePropertyName("instanceID");
+            writer.WriteValue(value.GetInstanceIDCompat());
 #if UNITY_6000_5_OR_NEWER
             writer.WritePropertyName("entityID");
             writer.WriteValue(value.GetEntityId().ToString());
-#else
-            writer.WritePropertyName("instanceID");
-            writer.WriteValue(value.GetInstanceIDCompat());
 #endif
         }
 
@@ -547,7 +544,14 @@ namespace MCPForUnity.Runtime.Serialization
                     MethodInfo parseMethod = paramType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string) }, null);
                     if (parseMethod != null)
                     {
-                        arg = parseMethod.Invoke(null, new object[] { serializedEntityId });
+                        try
+                        {
+                            arg = parseMethod.Invoke(null, new object[] { serializedEntityId });
+                        }
+                        catch
+                        {
+                            continue;
+                        }
                     }
                 }
 
@@ -556,7 +560,15 @@ namespace MCPForUnity.Runtime.Serialization
                     continue;
                 }
 
-                object result = method.Invoke(null, new[] { arg });
+                object result = null;
+                try
+                {
+                    result = method.Invoke(null, new[] { arg });
+                }
+                catch
+                {
+                    continue;
+                }
                 if (result is UnityEngine.Object resolved)
                 {
                     obj = resolved;


### PR DESCRIPTION
Pickup on #1051 for cleanup

## Summary by Sourcery

Add Unity 6.5+ compatible object identification and find-object helpers while preserving backward-compatible instanceID-based serialization.

Enhancements:
- Introduce compatibility wrappers for Unity object ID access and object-finding APIs, replacing direct GetInstanceID and FindObjectsOfType/FindObjectsByType calls across editor and runtime tools.
- Extend UnityEngine.Object JSON serialization to emit and consume stable entityID values on Unity 6.5+ while maintaining instanceID fields for older consumers.
- Standardize use of the new helpers in camera, physics, graphics, prefab, ProBuilder, asset, and selection tooling to smooth upgrades across Unity versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced compatibility across Unity versions by introducing standardized object identification helpers that abstract version-specific APIs, eliminating conditional compilation branches throughout the codebase.
  * Improved serialization to support newer Unity's entity system while maintaining backward compatibility with older versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->