### PR TITLE
fix(build): guard BuildTarget.VisionOS with UNITY_2023_2_OR_NEWER

### DIFF
--- a/MCPForUnity/Editor/Tools/Build/BuildTargetMapping.cs
+++ b/MCPForUnity/Editor/Tools/Build/BuildTargetMapping.cs
@@ -24,8 +24,8 @@ namespace MCPForUnity.Editor.Tools.Build
                 case "webgl": target = BuildTarget.WebGL; return true;
                 case "uwp": target = BuildTarget.WSAPlayer; return true;
                 case "tvos": target = BuildTarget.tvOS; return true;
-                // VisionOS requires a late 2022.3 patch or Unity 6+; guard broadly
-#if UNITY_2022_3_OR_NEWER
+                // BuildTarget.VisionOS exists only in Unity 2023.2+ and late 2022.3 patches
+#if UNITY_2023_2_OR_NEWER
                 case "visionos": target = BuildTarget.VisionOS; return true;
 #endif
                 default:
@@ -50,7 +50,7 @@ namespace MCPForUnity.Editor.Tools.Build
                 case BuildTarget.WebGL: return BuildTargetGroup.WebGL;
                 case BuildTarget.WSAPlayer: return BuildTargetGroup.WSA;
                 case BuildTarget.tvOS: return BuildTargetGroup.tvOS;
-#if UNITY_2022_3_OR_NEWER
+#if UNITY_2023_2_OR_NEWER
                 case BuildTarget.VisionOS: return BuildTargetGroup.VisionOS;
 #endif
                 default: return BuildTargetGroup.Unknown;


### PR DESCRIPTION
BuildTarget.VisionOS does not exist in Unity 2022.3.0 - 2022.3.17 or 2023.1.x, so UNITY_2022_3_OR_NEWER causes CS0117 compile errors on those versions. Tighten the guard to UNITY_2023_2_OR_NEWER, where the enum is guaranteed to exist.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Save the type of change you did -->
Save your change type
- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Documentation update
- Refactoring (no functional changes)
- Test update

## Changes Made
<!-- List the specific changes in this PR -->


## Testing/Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->


## Documentation Updates
<!-- Check if you updated documentation for changes to tools/resources -->
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`


## Related Issues
<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional Notes
<!-- Any other information that reviewers should know -->

## Summary by Sourcery

Bug Fixes:
- Prevent compilation errors on Unity 2022.3.x and 2023.1.x by guarding VisionOS mappings with UNITY_2023_2_OR_NEWER instead of UNITY_2022_3_OR_NEWER.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system compatibility: VisionOS support now requires Unity 2023.2 or newer (previously 2022.3 or newer).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->