### PR TITLE
calling TestRunStatus.MarkFinished() to trigger callbacks

### DIFF
--- a/MCPForUnity/Editor/Services/TestJobManager.cs
+++ b/MCPForUnity/Editor/Services/TestJobManager.cs
@@ -502,6 +502,7 @@ namespace MCPForUnity.Editor.Services
                         {
                             _currentJobId = null;
                         }
+                        TestRunStatus.MarkFinished();
                         shouldPersist = true;
                     }
                 }

--- a/MCPForUnity/Editor/Services/TestJobManager.cs
+++ b/MCPForUnity/Editor/Services/TestJobManager.cs
@@ -501,8 +501,11 @@ namespace MCPForUnity.Editor.Services
                         if (_currentJobId == jobId)
                         {
                             _currentJobId = null;
+                            // Keep TestRunStatus in sync: when initialization times out, neither
+                            // RunStarted nor RunFinished fires, so the running flag would otherwise leak.
+                            // Only clear it if this job is still the active one — a newer job may have taken over.
+                            TestRunStatus.MarkFinished();
                         }
-                        TestRunStatus.MarkFinished();
                         shouldPersist = true;
                     }
                 }


### PR DESCRIPTION
## Description
When a PlayMode test job fails to initialize (test runner never reaches `RunStarted`), `TestJobManager.GetJob` auto-fails the job after `InitializationTimeoutMs` — but only updates the job record, not `TestRunStatus`. Because `TestRunStatus.MarkStarted(...)` was called synchronously at run dispatch and the `RunStarted`/`RunFinished` callbacks never fire, `TestRunStatus._isRunning` stays `true` forever.

Downstream effect: `EditorStateCache` reports `tests.is_running: true`, `advice.blocking_reasons: ["running_tests"]`, and `advice.ready_for_tools: false`. Every subsequent `run_tests`, `refresh_unity`, and any other tool that gates on readiness returns `busy: tests_running`. The only recovery is restarting Unity — neither a Test Runner UI cancel nor `manage_editor stop` clears the flag because neither path invokes `TestRunStatus.MarkFinished`.

## Type of Change
Bug fix (non-breaking change that fixes an issue)

## Changes Made
One line, in `TestJobManager.GetJob`, inside the auto-fail block (right after `_currentJobId = null;`):

```csharp
TestRunStatus.MarkFinished();
```

Symmetrical to the existing clear paths in `TestRunnerService.RunFinished` (line 204) and `TestRunnerService.ExecuteAsync`'s catch block (line 129). Keeps `TestRunStatus` and the job record in sync under all completion paths.

## Repro

1. Call `run_tests` right after a domain reload (e.g., immediately after `refresh_unity`) or while Unity is unfocused enough to miss its test-init window.
2. Wait for `editor_state.tests.started_unix_ms + 15s`.
3. `get_test_job` returns `status: failed, error: "Test job failed to initialize (tests did not start within timeout)"`.
4. `editor_state` now shows `tests.is_running: true` with `tests.current_job_id: null` and `tests.started_by: "unknown"` — permanently stuck.
5. Every subsequent `run_tests` returns `busy: tests_running`.

## Summary by Sourcery

Bug Fixes:
- Clear the running-test status via TestRunStatus.MarkFinished when a test job fails to initialize and is auto-failed, preventing the editor from remaining permanently stuck in a tests-running state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where test jobs that time out during initialization were not being properly finalized before state was saved. Timed-out jobs are now correctly marked finished so test run data is recorded and persisted reliably when initialization delays occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->