### PR TITLE
Improve python bridge log destination

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -147,6 +147,7 @@ These options apply to the `mcp-for-unity` command (whether run via `uvx`, Docke
 - `UNITY_MCP_HTTP_REMOTE_HOSTED` - Enable remote-hosted mode (`true`, `1`, or `yes`)
 - `UNITY_MCP_DEFAULT_INSTANCE` - Default Unity instance to target (project name, hash, or `Name@hash`)
 - `UNITY_MCP_SKIP_STARTUP_CONNECT=1` - Skip initial Unity connection attempt on startup
+- `UNITY_MCP_LOG_DIR` - Override the rotating server log directory. Default: `%LOCALAPPDATA%\UnityMCP\Logs` (Windows), `~/Library/Application Support/UnityMCP/Logs` (macOS), `$XDG_STATE_HOME/UnityMCP/Logs` (Linux/BSD, defaults to `~/.local/state/UnityMCP/Logs`).
 
 API key authentication (remote-hosted mode):
 

--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -87,10 +87,11 @@ logging.basicConfig(
 )
 logger = logging.getLogger("mcp-for-unity-server")
 
-# Also write logs to a rotating file so logs are available when launched via stdio
+# Also write logs to a rotating file so logs are available when launched via stdio.
+# Location follows OS conventions; override with UNITY_MCP_LOG_DIR.
 try:
-    _log_dir = os.path.join(os.path.expanduser(
-        "~/Library/Application Support/UnityMCP"), "Logs")
+    from utils.log_paths import resolve_log_dir
+    _log_dir = resolve_log_dir()
     os.makedirs(_log_dir, exist_ok=True)
     _file_path = os.path.join(_log_dir, "unity_mcp_server.log")
     _fh = WindowsSafeRotatingFileHandler(

--- a/Server/src/utils/log_paths.py
+++ b/Server/src/utils/log_paths.py
@@ -1,0 +1,44 @@
+"""
+OS-aware log directory resolution
+
+Picks a platform-appropriate location for the rotating server log:
+- Windows: %LOCALAPPDATA%\\UnityMCP\\Logs
+- macOS:   ~/Library/Application Support/UnityMCP/Logs
+- Linux/BSD: $XDG_STATE_HOME/UnityMCP/Logs (default ~/.local/state/UnityMCP/Logs)
+
+UNITY_MCP_LOG_DIR overrides all of the above.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping
+
+
+def resolve_log_dir(
+    *,
+    platform: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Return the absolute log directory path for the current OS.
+    """
+    if platform is None:
+        platform = sys.platform
+    if env is None:
+        env = os.environ
+
+    override = env.get("UNITY_MCP_LOG_DIR")
+    if override:
+        return os.path.expanduser(override)
+
+    if platform == "darwin":
+        return os.path.expanduser("~/Library/Application Support/UnityMCP/Logs")
+
+    if platform == "win32":
+        base = env.get("LOCALAPPDATA") or os.path.expanduser("~/AppData/Local")
+        return os.path.join(base, "UnityMCP", "Logs")
+
+    # Linux/BSD and anything else: XDG_STATE_HOME per freedesktop.org basedir spec.
+    base = env.get("XDG_STATE_HOME") or os.path.expanduser("~/.local/state")
+    return os.path.join(base, "UnityMCP", "Logs")

--- a/Server/tests/test_log_paths.py
+++ b/Server/tests/test_log_paths.py
@@ -1,0 +1,97 @@
+"""Unit tests for utils.log_paths.resolve_log_dir."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from utils.log_paths import resolve_log_dir
+
+
+class TestEnvOverride:
+    def test_override_wins_on_macos(self):
+        path = resolve_log_dir(
+            platform="darwin",
+            env={"UNITY_MCP_LOG_DIR": "/tmp/custom-logs"},
+        )
+        assert path == "/tmp/custom-logs"
+
+    def test_override_wins_on_windows(self):
+        path = resolve_log_dir(
+            platform="win32",
+            env={"UNITY_MCP_LOG_DIR": "/tmp/custom-logs", "LOCALAPPDATA": r"C:\ignored"},
+        )
+        assert path == "/tmp/custom-logs"
+
+    def test_override_wins_on_linux(self):
+        path = resolve_log_dir(
+            platform="linux",
+            env={"UNITY_MCP_LOG_DIR": "/tmp/custom-logs", "XDG_STATE_HOME": "/ignored"},
+        )
+        assert path == "/tmp/custom-logs"
+
+    def test_override_expands_user(self):
+        path = resolve_log_dir(
+            platform="linux",
+            env={"UNITY_MCP_LOG_DIR": "~/my-logs"},
+        )
+        assert path == os.path.expanduser("~/my-logs")
+        assert "~" not in path
+
+
+def _norm(p: str) -> str:
+    """Normalize for cross-host comparison: os.path.expanduser can leave
+    mixed separators when a foreign platform is injected during testing."""
+    return os.path.normpath(p)
+
+
+class TestPlatformDefaults:
+    def test_macos_uses_application_support(self):
+        path = resolve_log_dir(platform="darwin", env={})
+        assert _norm(path).endswith(_norm(
+            "Library/Application Support/UnityMCP/Logs"))
+        assert "~" not in path
+
+    def test_windows_uses_localappdata_env(self):
+        path = resolve_log_dir(
+            platform="win32",
+            env={"LOCALAPPDATA": r"C:\Users\alice\AppData\Local"},
+        )
+        assert _norm(path) == _norm(os.path.join(
+            r"C:\Users\alice\AppData\Local", "UnityMCP", "Logs"))
+
+    def test_windows_falls_back_when_localappdata_missing(self):
+        path = resolve_log_dir(platform="win32", env={})
+        # Fallback expands ~/AppData/Local; assert shape, not the exact user home.
+        assert _norm(path).endswith(_norm("AppData/Local/UnityMCP/Logs"))
+        assert "~" not in path
+
+    def test_linux_uses_xdg_state_home(self):
+        path = resolve_log_dir(
+            platform="linux",
+            env={"XDG_STATE_HOME": "/home/alice/.local/state"},
+        )
+        assert _norm(path) == _norm(os.path.join(
+            "/home/alice/.local/state", "UnityMCP", "Logs"))
+
+    def test_linux_falls_back_to_default_xdg_path(self):
+        path = resolve_log_dir(platform="linux", env={})
+        assert _norm(path).endswith(_norm(".local/state/UnityMCP/Logs"))
+        assert "~" not in path
+
+    @pytest.mark.parametrize("unix_like", ["freebsd", "openbsd", "sunos5"])
+    def test_unknown_unix_variants_follow_linux_branch(self, unix_like):
+        path = resolve_log_dir(
+            platform=unix_like,
+            env={"XDG_STATE_HOME": "/var/state"},
+        )
+        assert _norm(path) == _norm(os.path.join(
+            "/var/state", "UnityMCP", "Logs"))
+
+
+class TestDefaults:
+    def test_no_args_reads_live_environment(self, monkeypatch):
+        """With no args, should read sys.platform and os.environ directly."""
+        monkeypatch.setenv("UNITY_MCP_LOG_DIR", "/tmp/live-env-test")
+        assert resolve_log_dir() == "/tmp/live-env-test"


### PR DESCRIPTION


## Description
There was a hardcoded path to store the logs from the python bridge used by stdio, that resolved to a MacOS-like path. This change allows for this path to be customized by the User and also defaults it to different paths depending on the OS

## Type of Change
Bug fix (non-breaking change)

## Changes Made
Changed logging setup in Server/src/main.py


## Testing/Screenshots/Recordings
Not applicable

## Documentation Updates
<!-- Check if you updated documentation for changes to tools/resources -->
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`

I have updated README.md to include the new env var


## Related Issues
None

## Additional Notes
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the server's log directory via the `UNITY_MCP_LOG_DIR` environment variable.
  * Platform-specific default log locations are now automatically applied (Windows, macOS, and Linux/BSD).

* **Documentation**
  * Updated documentation to describe available log directory configuration options and default paths for each supported platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->