### PR TITLE
Add LAN HTTP transport mode

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/OpenClawConfigurator.cs
@@ -387,6 +387,11 @@ namespace MCPForUnity.Editor.Clients.Configurators
                 return ConfiguredTransport.HttpRemote;
             }
 
+            if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetLanMcpRpcUrl()))
+            {
+                return ConfiguredTransport.HttpLan;
+            }
+
             if (UrlsEqual(configuredUrl, HttpEndpointUtility.GetLocalMcpRpcUrl()))
             {
                 return ConfiguredTransport.Http;

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -203,9 +203,14 @@ namespace MCPForUnity.Editor.Clients
                     // Distinguish HTTP Local from HTTP Remote by matching against both URLs
                     string localRpcUrl = HttpEndpointUtility.GetLocalMcpRpcUrl();
                     string remoteRpcUrl = HttpEndpointUtility.GetRemoteMcpRpcUrl();
+                    string lanRpcUrl = HttpEndpointUtility.GetLanMcpRpcUrl();
                     if (!string.IsNullOrEmpty(remoteRpcUrl) && UrlsEqual(configuredUrl, remoteRpcUrl))
                     {
                         client.configuredTransport = Models.ConfiguredTransport.HttpRemote;
+                    }
+                    else if (!string.IsNullOrEmpty(lanRpcUrl) && UrlsEqual(configuredUrl, lanRpcUrl))
+                    {
+                        client.configuredTransport = Models.ConfiguredTransport.HttpLan;
                     }
                     else
                     {
@@ -377,9 +382,14 @@ namespace MCPForUnity.Editor.Clients
                     {
                         // Distinguish HTTP Local from HTTP Remote
                         string remoteRpcUrl = HttpEndpointUtility.GetRemoteMcpRpcUrl();
+                        string lanRpcUrl = HttpEndpointUtility.GetLanMcpRpcUrl();
                         if (!string.IsNullOrEmpty(remoteRpcUrl) && UrlsEqual(url, remoteRpcUrl))
                         {
                             client.configuredTransport = Models.ConfiguredTransport.HttpRemote;
+                        }
+                        else if (!string.IsNullOrEmpty(lanRpcUrl) && UrlsEqual(url, lanRpcUrl))
+                        {
+                            client.configuredTransport = Models.ConfiguredTransport.HttpLan;
                         }
                         else
                         {
@@ -581,15 +591,16 @@ namespace MCPForUnity.Editor.Clients
             string claudePath = MCPServiceLocator.Paths.GetClaudeCliPath();
             RuntimePlatform platform = Application.platform;
             bool isRemoteScope = HttpEndpointUtility.IsRemoteScope();
+            bool isLanScope = HttpEndpointUtility.IsLanScope();
             // Get expected package source for the installed package version (matches what Register() would use)
             string expectedPackageSource = GetExpectedPackageSourceForValidation();
-            return CheckStatusWithProjectDir(projectDir, useHttpTransport, claudePath, platform, isRemoteScope, expectedPackageSource, attemptAutoRewrite, HasClientProjectDirOverride);
+            return CheckStatusWithProjectDir(projectDir, useHttpTransport, claudePath, platform, isRemoteScope, isLanScope, expectedPackageSource, attemptAutoRewrite, HasClientProjectDirOverride);
         }
 
         /// <summary>
         /// Internal thread-safe version of CheckStatus.
         /// Can be called from background threads because all main-thread-only values are passed as parameters.
-        /// projectDir, useHttpTransport, claudePath, platform, isRemoteScope, and expectedPackageSource are REQUIRED
+        /// projectDir, useHttpTransport, claudePath, platform, isRemoteScope, isLanScope, and expectedPackageSource are REQUIRED
         /// (non-nullable where applicable) to enforce thread safety at compile time.
         /// NOTE: attemptAutoRewrite is NOT fully thread-safe because Configure() requires the main thread.
         /// When called from a background thread, pass attemptAutoRewrite=false and handle re-registration
@@ -597,7 +608,7 @@ namespace MCPForUnity.Editor.Clients
         /// </summary>
         internal McpStatus CheckStatusWithProjectDir(
             string projectDir, bool useHttpTransport, string claudePath, RuntimePlatform platform,
-            bool isRemoteScope, string expectedPackageSource,
+            bool isRemoteScope, bool isLanScope, string expectedPackageSource,
             bool attemptAutoRewrite = false, bool hasProjectDirOverride = false)
         {
             try
@@ -647,7 +658,7 @@ namespace MCPForUnity.Editor.Clients
                 {
                     client.configuredTransport = isRemoteScope
                         ? Models.ConfiguredTransport.HttpRemote
-                        : Models.ConfiguredTransport.Http;
+                        : (isLanScope ? Models.ConfiguredTransport.HttpLan : Models.ConfiguredTransport.Http);
                 }
                 else if (registeredWithStdio)
                 {

--- a/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
+++ b/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
@@ -7,7 +7,7 @@ namespace MCPForUnity.Editor.Constants
     internal static class EditorPrefKeys
     {
         internal const string UseHttpTransport = "MCPForUnity.UseHttpTransport";
-        internal const string HttpTransportScope = "MCPForUnity.HttpTransportScope"; // "local" | "remote"
+        internal const string HttpTransportScope = "MCPForUnity.HttpTransportScope"; // "local" | "remote" | "lan"
         internal const string LastLocalHttpServerPid = "MCPForUnity.LocalHttpServer.LastPid";
         internal const string LastLocalHttpServerPort = "MCPForUnity.LocalHttpServer.LastPort";
         internal const string LastLocalHttpServerStartedUtc = "MCPForUnity.LocalHttpServer.LastStartedUtc";
@@ -26,6 +26,8 @@ namespace MCPForUnity.Editor.Constants
 
         internal const string HttpBaseUrl = "MCPForUnity.HttpUrl";
         internal const string HttpRemoteBaseUrl = "MCPForUnity.HttpRemoteUrl";
+        internal const string HttpLanPublicBaseUrl = "MCPForUnity.HttpLanPublicUrl";
+        internal const string HttpLanBindBaseUrl = "MCPForUnity.HttpLanBindUrl";
         internal const string SessionId = "MCPForUnity.SessionId";
         internal const string WebSocketUrlOverride = "MCPForUnity.WebSocketUrl";
         internal const string GitUrlOverride = "MCPForUnity.GitUrlOverride";

--- a/MCPForUnity/Editor/Helpers/HttpEndpointUtility.cs
+++ b/MCPForUnity/Editor/Helpers/HttpEndpointUtility.cs
@@ -19,8 +19,12 @@ namespace MCPForUnity.Editor.Helpers
     {
         private const string LocalPrefKey = EditorPrefKeys.HttpBaseUrl;
         private const string RemotePrefKey = EditorPrefKeys.HttpRemoteBaseUrl;
+        private const string LanPublicPrefKey = EditorPrefKeys.HttpLanPublicBaseUrl;
+        private const string LanBindPrefKey = EditorPrefKeys.HttpLanBindBaseUrl;
         private const string DefaultLocalBaseUrl = "http://127.0.0.1:8080";
         private const string DefaultRemoteBaseUrl = "";
+        private const string DefaultLanPublicBaseUrl = "http://192.168.1.10:8090";
+        private const string DefaultLanBindBaseUrl = "http://0.0.0.0:8090";
 
         /// <summary>
         /// Returns the normalized base URL for the currently active HTTP scope.
@@ -28,7 +32,9 @@ namespace MCPForUnity.Editor.Helpers
         /// </summary>
         public static string GetBaseUrl()
         {
-            return IsRemoteScope() ? GetRemoteBaseUrl() : GetLocalBaseUrl();
+            if (IsRemoteScope()) return GetRemoteBaseUrl();
+            if (IsLanScope()) return GetLanPublicBaseUrl();
+            return GetLocalBaseUrl();
         }
 
         /// <summary>
@@ -39,6 +45,10 @@ namespace MCPForUnity.Editor.Helpers
             if (IsRemoteScope())
             {
                 SaveRemoteBaseUrl(userValue);
+            }
+            else if (IsLanScope())
+            {
+                SaveLanPublicBaseUrl(userValue);
             }
             else
             {
@@ -79,6 +89,47 @@ namespace MCPForUnity.Editor.Helpers
         }
 
         /// <summary>
+        /// Returns the normalized LAN public URL that remote clients should use.
+        /// </summary>
+        public static string GetLanPublicBaseUrl()
+        {
+            string stored = EditorPrefs.GetString(LanPublicPrefKey, DefaultLanPublicBaseUrl);
+            return NormalizeBaseUrl(stored, DefaultLanPublicBaseUrl, remoteScope: false);
+        }
+
+        /// <summary>
+        /// Saves the LAN public URL and keeps the bind URL on 0.0.0.0 with the same port.
+        /// </summary>
+        public static void SaveLanPublicBaseUrl(string userValue)
+        {
+            string normalized = NormalizeBaseUrl(userValue, DefaultLanPublicBaseUrl, remoteScope: false);
+            EditorPrefs.SetString(LanPublicPrefKey, normalized);
+
+            if (Uri.TryCreate(normalized, UriKind.Absolute, out var uri) && uri.Port > 0)
+            {
+                EditorPrefs.SetString(LanBindPrefKey, $"http://0.0.0.0:{uri.Port}");
+            }
+        }
+
+        /// <summary>
+        /// Returns the LAN bind URL used to launch the local server.
+        /// </summary>
+        public static string GetLanBindBaseUrl()
+        {
+            string stored = EditorPrefs.GetString(LanBindPrefKey, DefaultLanBindBaseUrl);
+            return NormalizeBaseUrl(stored, DefaultLanBindBaseUrl, remoteScope: false);
+        }
+
+        /// <summary>
+        /// Returns the URL used to launch/probe/stop the local server process.
+        /// LAN mode binds all interfaces while exposing a separate public client URL.
+        /// </summary>
+        public static string GetLocalServerLaunchBaseUrl()
+        {
+            return IsLanScope() ? GetLanBindBaseUrl() : GetLocalBaseUrl();
+        }
+
+        /// <summary>
         /// Saves a user-provided URL to the remote HTTP pref.
         /// </summary>
         public static void SaveRemoteBaseUrl(string userValue)
@@ -109,6 +160,14 @@ namespace MCPForUnity.Editor.Helpers
         }
 
         /// <summary>
+        /// Builds the LAN public JSON-RPC endpoint (public base + /mcp).
+        /// </summary>
+        public static string GetLanMcpRpcUrl()
+        {
+            return AppendPathSegment(GetLanPublicBaseUrl(), "mcp");
+        }
+
+        /// <summary>
         /// Builds the remote JSON-RPC endpoint (remote base + /mcp).
         /// Returns empty string if no remote URL is configured.
         /// </summary>
@@ -136,6 +195,15 @@ namespace MCPForUnity.Editor.Helpers
         }
 
         /// <summary>
+        /// Returns true if the active HTTP transport scope is "lan".
+        /// </summary>
+        public static bool IsLanScope()
+        {
+            string scope = EditorConfigurationCache.Instance.HttpTransportScope;
+            return string.Equals(scope, "lan", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
         /// Returns the <see cref="ConfiguredTransport"/> that matches the current server-side
         /// transport selection (Stdio, Http, or HttpRemote).
         /// Centralises the 3-way determination so callers avoid duplicated logic.
@@ -144,6 +212,7 @@ namespace MCPForUnity.Editor.Helpers
         {
             bool useHttp = EditorConfigurationCache.Instance.UseHttpTransport;
             if (!useHttp) return ConfiguredTransport.Stdio;
+            if (IsLanScope()) return ConfiguredTransport.HttpLan;
             return IsRemoteScope() ? ConfiguredTransport.HttpRemote : ConfiguredTransport.Http;
         }
 
@@ -246,6 +315,46 @@ namespace MCPForUnity.Editor.Helpers
             }
 
             error = "HTTP Local requires a loopback URL (localhost/127.0.0.1/::1).";
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true when the URL is acceptable for LAN HTTP launch.
+        /// LAN mode intentionally binds all interfaces for trusted private networks.
+        /// </summary>
+        public static bool IsHttpLanUrlAllowedForLaunch(string url, out string error)
+        {
+            error = null;
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                error = "LAN HTTP requires a bind URL such as http://0.0.0.0:8090.";
+                return false;
+            }
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                error = $"Invalid LAN HTTP bind URL: {url}";
+                return false;
+            }
+
+            if (!uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+            {
+                error = "LAN HTTP bind URL must use http://.";
+                return false;
+            }
+
+            if (uri.Port <= 0)
+            {
+                error = "LAN HTTP bind URL requires an explicit port.";
+                return false;
+            }
+
+            if (IsBindAllInterfacesHost(uri.Host))
+            {
+                return true;
+            }
+
+            error = "LAN HTTP server bind host must be 0.0.0.0 or ::.";
             return false;
         }
 

--- a/MCPForUnity/Editor/Models/McpStatus.cs
+++ b/MCPForUnity/Editor/Models/McpStatus.cs
@@ -25,7 +25,8 @@ namespace MCPForUnity.Editor.Models
         Unknown,    // Could not determine transport type
         Stdio,      // Client configured for stdio transport
         Http,       // Client configured for HTTP local transport
-        HttpRemote  // Client configured for HTTP remote-hosted transport
+        HttpRemote, // Client configured for HTTP remote-hosted transport
+        HttpLan     // Client configured for LAN HTTP transport
     }
 }
 

--- a/MCPForUnity/Editor/Services/HttpAutoStartHandler.cs
+++ b/MCPForUnity/Editor/Services/HttpAutoStartHandler.cs
@@ -73,8 +73,12 @@ namespace MCPForUnity.Editor.Services
                 {
                     // For HTTP Local: launch the server process first, then connect the bridge.
                     // This mirrors what the UI "Start Server" button does.
-                    if (!HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(
-                            HttpEndpointUtility.GetLocalBaseUrl(), out string policyError))
+                    string launchBaseUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
+                    string policyError;
+                    bool launchAllowed = HttpEndpointUtility.IsLanScope()
+                        ? HttpEndpointUtility.IsHttpLanUrlAllowedForLaunch(launchBaseUrl, out policyError)
+                        : HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(launchBaseUrl, out policyError);
+                    if (!launchAllowed)
                     {
                         McpLog.Debug($"[HTTP Auto-Start] Local URL blocked by security policy: {policyError}");
                         return;

--- a/MCPForUnity/Editor/Services/McpEditorShutdownCleanup.cs
+++ b/MCPForUnity/Editor/Services/McpEditorShutdownCleanup.cs
@@ -51,6 +51,7 @@ namespace MCPForUnity.Editor.Services
                 bool httpLocalSelected =
                     useHttp &&
                     (string.Equals(scope, "local", StringComparison.OrdinalIgnoreCase)
+                     || string.Equals(scope, "lan", StringComparison.OrdinalIgnoreCase)
                      || (string.IsNullOrEmpty(scope) && MCPServiceLocator.Server.IsLocalUrl()));
 
                 if (httpLocalSelected)

--- a/MCPForUnity/Editor/Services/Server/ServerCommandBuilder.cs
+++ b/MCPForUnity/Editor/Services/Server/ServerCommandBuilder.cs
@@ -30,8 +30,12 @@ namespace MCPForUnity.Editor.Services.Server
                 return false;
             }
 
-            string httpUrl = HttpEndpointUtility.GetLocalBaseUrl();
-            if (!HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(httpUrl, out string localUrlError))
+            string httpUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
+            string localUrlError;
+            bool launchUrlAllowed = HttpEndpointUtility.IsLanScope()
+                ? HttpEndpointUtility.IsHttpLanUrlAllowedForLaunch(httpUrl, out localUrlError)
+                : HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(httpUrl, out localUrlError);
+            if (!launchUrlAllowed)
             {
                 error = string.IsNullOrEmpty(localUrlError)
                     ? $"The configured URL ({httpUrl}) is not allowed for HTTP Local launch."

--- a/MCPForUnity/Editor/Services/ServerManagementService.cs
+++ b/MCPForUnity/Editor/Services/ServerManagementService.cs
@@ -256,7 +256,7 @@ namespace MCPForUnity.Editor.Services
             // If the port is still occupied, don't start and explain why (avoid confusing "refusing to stop" warnings).
             try
             {
-                string httpUrl = HttpEndpointUtility.GetLocalBaseUrl();
+                string httpUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
                 if (Uri.TryCreate(httpUrl, UriKind.Absolute, out var uri) && uri.Port > 0)
                 {
                     var remaining = GetListeningProcessIdsForPort(uri.Port);
@@ -280,7 +280,7 @@ namespace MCPForUnity.Editor.Services
             // Note: Dev mode cache-busting is handled by `uvx --no-cache --refresh` in the generated command.
 
             // Create a per-launch token + pidfile path so Stop can be deterministic without relying on port/PID heuristics.
-            string baseUrlForPid = HttpEndpointUtility.GetLocalBaseUrl();
+            string baseUrlForPid = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
             Uri.TryCreate(baseUrlForPid, UriKind.Absolute, out var uriForPid);
             int portForPid = uriForPid?.Port ?? 0;
             string instanceToken = Guid.NewGuid().ToString("N");
@@ -359,7 +359,7 @@ namespace MCPForUnity.Editor.Services
             int port = 0;
             if (!TryGetPortFromPidFilePath(pidFilePath, out port) || port <= 0)
             {
-                string baseUrl = HttpEndpointUtility.GetLocalBaseUrl();
+                string baseUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
                 if (IsLocalUrl(baseUrl)
                     && Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri)
                     && uri.Port > 0)
@@ -380,7 +380,7 @@ namespace MCPForUnity.Editor.Services
         {
             try
             {
-                string httpUrl = HttpEndpointUtility.GetLocalBaseUrl();
+                string httpUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
                 if (!IsLocalUrl(httpUrl))
                 {
                     return false;
@@ -442,7 +442,7 @@ namespace MCPForUnity.Editor.Services
         {
             try
             {
-                string httpUrl = HttpEndpointUtility.GetLocalBaseUrl();
+                string httpUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
                 if (!IsLocalUrl(httpUrl))
                 {
                     return false;
@@ -543,7 +543,7 @@ namespace MCPForUnity.Editor.Services
 
         private bool StopLocalHttpServerInternal(bool quiet, int? portOverride = null, bool allowNonLocalUrl = false)
         {
-            string httpUrl = HttpEndpointUtility.GetLocalBaseUrl();
+            string httpUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
             if (!allowNonLocalUrl && !IsLocalUrl(httpUrl))
             {
                 if (!quiet)
@@ -898,7 +898,7 @@ namespace MCPForUnity.Editor.Services
         /// </summary>
         public bool IsLocalUrl()
         {
-            string httpUrl = HttpEndpointUtility.GetLocalBaseUrl();
+            string httpUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
             return IsLocalUrl(httpUrl);
         }
 
@@ -933,8 +933,10 @@ namespace MCPForUnity.Editor.Services
                 return false;
             }
 
-            string httpUrl = HttpEndpointUtility.GetLocalBaseUrl();
-            return HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(httpUrl, out _);
+            string httpUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
+            return HttpEndpointUtility.IsLanScope()
+                ? HttpEndpointUtility.IsHttpLanUrlAllowedForLaunch(httpUrl, out _)
+                : HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(httpUrl, out _);
         }
 
         private System.Diagnostics.ProcessStartInfo CreateTerminalProcessStartInfo(string command)

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
@@ -620,6 +620,7 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
                 string claudePath = MCPServiceLocator.Paths.GetClaudeCliPath();
                 RuntimePlatform platform = Application.platform;
                 bool isRemoteScope = HttpEndpointUtility.IsRemoteScope();
+                bool isLanScope = HttpEndpointUtility.IsLanScope();
                 // Get expected package source based on installed package version and overrides.
                 string expectedPackageSource = GetExpectedPackageSourceForCurrentPackage();
                 bool hasProjectDirOverride = ClaudeCliMcpConfigurator.HasClientProjectDirOverride;
@@ -631,7 +632,7 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
                     if (client is ClaudeCliMcpConfigurator claudeConfigurator)
                     {
                         // Use thread-safe version with captured main-thread values
-                        claudeConfigurator.CheckStatusWithProjectDir(projectDir, useHttpTransport, claudePath, platform, isRemoteScope, expectedPackageSource, attemptAutoRewrite: false, hasProjectDirOverride: hasProjectDirOverride);
+                        claudeConfigurator.CheckStatusWithProjectDir(projectDir, useHttpTransport, claudePath, platform, isRemoteScope, isLanScope, expectedPackageSource, attemptAutoRewrite: false, hasProjectDirOverride: hasProjectDirOverride);
                     }
                 }).ContinueWith(t =>
                 {

--- a/MCPForUnity/Editor/Windows/Components/Connection/McpConnectionSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/Connection/McpConnectionSection.cs
@@ -23,6 +23,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
         private enum TransportProtocol
         {
             HTTPLocal,
+            HTTPLan,
             HTTPRemote,
             Stdio
         }
@@ -34,6 +35,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
         private VisualElement versionMismatchWarning;
         private Label versionMismatchText;
         private VisualElement httpUrlRow;
+        private VisualElement lanHttpWarning;
         private VisualElement httpServerControlRow;
         private Foldout manualCommandFoldout;
         private VisualElement httpServerCommandSection;
@@ -92,6 +94,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
             versionMismatchWarning = Root.Q<VisualElement>("version-mismatch-warning");
             versionMismatchText = Root.Q<Label>("version-mismatch-text");
             httpUrlRow = Root.Q<VisualElement>("http-url-row");
+            lanHttpWarning = Root.Q<VisualElement>("lan-http-warning");
             httpServerControlRow = Root.Q<VisualElement>("http-server-control-row");
             manualCommandFoldout = Root.Q<Foldout>("manual-command-foldout");
             httpServerCommandSection = Root.Q<VisualElement>("http-server-command-section");
@@ -144,7 +147,12 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
                     }
                 }
 
-                transportDropdown.value = scope == "remote" ? TransportProtocol.HTTPRemote : TransportProtocol.HTTPLocal;
+                transportDropdown.value = scope switch
+                {
+                    "remote" => TransportProtocol.HTTPRemote,
+                    "lan" => TransportProtocol.HTTPLan,
+                    _ => TransportProtocol.HTTPLocal
+                };
             }
 
             // Set tooltips
@@ -193,7 +201,12 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
 
                 if (useHttp)
                 {
-                    string scope = selected == TransportProtocol.HTTPRemote ? "remote" : "local";
+                    string scope = selected switch
+                    {
+                        TransportProtocol.HTTPRemote => "remote",
+                        TransportProtocol.HTTPLan => "lan",
+                        _ => "local"
+                    };
                     EditorConfigurationCache.Instance.SetHttpTransportScope(scope);
                 }
 
@@ -322,7 +335,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
         {
             var bridgeService = MCPServiceLocator.Bridge;
             bool isRunning = bridgeService.IsRunning;
-            bool showLocalServerControls = IsHttpLocalSelected();
+            bool showLocalServerControls = IsHttpLocalServerSelected();
             bool debugMode = EditorPrefs.GetBool(EditorPrefKeys.DebugLogs, false);
             // EditorConfigurationCache is the source of truth for transport selection after domain reload
             // (EditorPrefs is still used for debugMode and other UI-only state)
@@ -402,7 +415,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
                     bool remoteUrlAllowed = !httpRemoteSelected
                         || HttpEndpointUtility.IsCurrentRemoteUrlAllowed(out remoteUrlError);
 
-                    bool httpLocalSelected = IsHttpLocalSelected();
+                    bool httpLocalSelected = IsHttpLocalServerSelected();
                     string localUrlError = null;
                     bool localUrlAllowed = !httpLocalSelected
                         || TryGetLocalHttpLaunchPolicy(out _, out localUrlError);
@@ -451,10 +464,10 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
             }
 
             bool useHttp = transportDropdown != null && (TransportProtocol)transportDropdown.value != TransportProtocol.Stdio;
-            bool httpLocalSelected = IsHttpLocalSelected();
+            bool httpLocalSelected = IsHttpLocalServerSelected();
             bool isLocalHttpUrlAllowed = TryGetLocalHttpLaunchPolicy(out _, out string localUrlError);
 
-            // Only show the local-server helper UI when HTTP Local is selected.
+            // Only show the local-server helper UI when HTTP Local/LAN is selected.
             if (!useHttp || !httpLocalSelected)
             {
                 httpServerCommandSection.style.display = DisplayStyle.None;
@@ -482,8 +495,10 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
                 httpServerCommandSection.EnableInClassList("http-local-invalid-url", true);
                 if (httpServerCommandHint != null)
                 {
-                    string requirements = HttpEndpointUtility.GetHttpLocalHostRequirementText();
-                    httpServerCommandHint.text = $"⚠ {localUrlError ?? $"HTTP Local requires a loopback URL ({requirements})."}";
+                    string requirements = HttpEndpointUtility.IsLanScope()
+                        ? "0.0.0.0/:: on an explicit port"
+                        : HttpEndpointUtility.GetHttpLocalHostRequirementText();
+                    httpServerCommandHint.text = $"⚠ {localUrlError ?? $"HTTP server launch requires {requirements}."}";
                     httpServerCommandHint.AddToClassList("http-local-url-error");
                 }
                 copyHttpServerCommandButton?.SetEnabled(false);
@@ -528,12 +543,15 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
         private void UpdateHttpFieldVisibility()
         {
             bool useHttp = (TransportProtocol)transportDropdown.value != TransportProtocol.Stdio;
-            bool httpLocalSelected = IsHttpLocalSelected();
+            bool httpLocalSelected = IsHttpLocalServerSelected();
             bool httpRemoteSelected = transportDropdown != null && (TransportProtocol)transportDropdown.value == TransportProtocol.HTTPRemote;
+            bool httpLanSelected = transportDropdown != null && (TransportProtocol)transportDropdown.value == TransportProtocol.HTTPLan;
 
             httpUrlRow.style.display = useHttp ? DisplayStyle.Flex : DisplayStyle.None;
             httpServerControlRow.style.display = useHttp && httpLocalSelected ? DisplayStyle.Flex : DisplayStyle.None;
             unitySocketPortRow.style.display = useHttp ? DisplayStyle.None : DisplayStyle.Flex;
+            if (lanHttpWarning != null)
+                lanHttpWarning.EnableInClassList("visible", httpLanSelected);
 
             // Manual Server Launch foldout only relevant for HTTP Local
             if (manualCommandFoldout != null)
@@ -549,10 +567,22 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
             return transportDropdown != null && (TransportProtocol)transportDropdown.value == TransportProtocol.HTTPLocal;
         }
 
+        private bool IsHttpLanSelected()
+        {
+            return transportDropdown != null && (TransportProtocol)transportDropdown.value == TransportProtocol.HTTPLan;
+        }
+
+        private bool IsHttpLocalServerSelected()
+        {
+            return IsHttpLocalSelected() || IsHttpLanSelected();
+        }
+
         private bool TryGetLocalHttpLaunchPolicy(out string localBaseUrl, out string localUrlError)
         {
-            localBaseUrl = HttpEndpointUtility.GetLocalBaseUrl();
-            return HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(localBaseUrl, out localUrlError);
+            localBaseUrl = HttpEndpointUtility.GetLocalServerLaunchBaseUrl();
+            return IsHttpLanSelected()
+                ? HttpEndpointUtility.IsHttpLanUrlAllowedForLaunch(localBaseUrl, out localUrlError)
+                : HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(localBaseUrl, out localUrlError);
         }
 
         private void SyncUrlFieldToScope()
@@ -575,7 +605,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
                 return;
             }
 
-            bool httpLocalSelected = IsHttpLocalSelected();
+            bool httpLocalSelected = IsHttpLocalServerSelected();
             bool localUrlAllowedForLaunch = TryGetLocalHttpLaunchPolicy(out _, out string localUrlError);
             bool canStartLocalServer = httpLocalSelected && localUrlAllowedForLaunch;
             bool localServerRunning = false;
@@ -628,7 +658,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
             try
             {
                 // Check if a local server is running.
-                bool serverRunning = IsHttpLocalSelected() && MCPServiceLocator.Server.IsLocalHttpServerReachable();
+                bool serverRunning = IsHttpLocalServerSelected() && MCPServiceLocator.Server.IsLocalHttpServerReachable();
 
                 if (serverRunning)
                 {
@@ -801,7 +831,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
                         return;
                     }
 
-                    bool httpLocalSelected = IsHttpLocalSelected();
+                    bool httpLocalSelected = IsHttpLocalServerSelected();
                     if (httpLocalSelected
                         && !TryGetLocalHttpLaunchPolicy(out _, out string localPolicyError))
                     {
@@ -1138,6 +1168,7 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
                 ConfiguredTransport.Stdio => "stdio",
                 ConfiguredTransport.Http => "HTTP Local",
                 ConfiguredTransport.HttpRemote => "HTTP Remote",
+                ConfiguredTransport.HttpLan => "HTTP LAN",
                 _ => "unknown"
             };
         }

--- a/MCPForUnity/Editor/Windows/Components/Connection/McpConnectionSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/Connection/McpConnectionSection.uxml
@@ -17,6 +17,9 @@
                 <ui:Label text="HTTP URL:" class="setting-label" />
                 <ui:TextField name="http-url" class="url-field" />
             </ui:VisualElement>
+            <ui:VisualElement name="lan-http-warning" class="warning-banner">
+                <ui:Label text="LAN HTTP exposes Unity MCP to your local network. Use only on trusted private networks." class="warning-banner-text" />
+            </ui:VisualElement>
             <ui:VisualElement name="api-key-row" style="margin-bottom: 4px;">
                 <ui:VisualElement class="setting-row">
                     <ui:Label text="API Key:" class="setting-label" />


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Save the type of change you did -->
Save your change type
- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Documentation update
- Refactoring (no functional changes)
- Test update

## Changes Made
<!-- List the specific changes in this PR -->


## Testing/Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->


## Documentation Updates
<!-- Check if you updated documentation for changes to tools/resources -->
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`


## Related Issues
<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional Notes
<!-- Any other information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Local Area Network (LAN) HTTP transport option for server connections.
  * Separate LAN public and bind URL settings with distinct persisted values.
  * UI now shows a prominent warning when LAN HTTP is enabled.

* **Bug Fixes / Improvements**
  * LAN-aware validation and launch checks to enforce secure URL requirements.
  * Transport selection, status reporting, and server start/stop behavior now respect the LAN scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->