### PR TITLE
Remove AssetOrigin from GeminiCliConfigurator meta

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/GeminiCliConfigurator.cs.meta
+++ b/MCPForUnity/Editor/Clients/Configurators/GeminiCliConfigurator.cs.meta
@@ -9,10 +9,3 @@ MonoImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-AssetOrigin:
-  serializedVersion: 1
-  productId: 329908
-  packageName: MCP for Unity | AI Driven Development
-  packageVersion: 9.0.3
-  assetPath: Assets/MCPForUnity/Editor/Clients/Configurators/GeminiCliConfigurator.cs
-  uploadId: 855486


### PR DESCRIPTION
## Description
Removed AssetOrigin metadata from GeminiCliConfigurator.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up configuration metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->