### PR TITLE
Fix Unity 6000.6.x object find compatibility

### DIFF
--- a/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraControl.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -13,11 +14,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
     {
         internal static object ListCameras(JObject @params)
         {
-#if UNITY_2022_2_OR_NEWER
-            var unityCameras = UnityEngine.Object.FindObjectsByType<UnityEngine.Camera>(FindObjectsSortMode.None);
-#else
-            var unityCameras = UnityEngine.Object.FindObjectsOfType<UnityEngine.Camera>();
-#endif
+            var unityCameras = UnityFindObjectsCompat.FindAll<UnityEngine.Camera>();
             var cameraList = new List<object>();
             var unityCamList = new List<object>();
 
@@ -25,11 +22,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             if (CameraHelpers.HasCinemachine)
             {
                 var cmType = CameraHelpers.CinemachineCameraType;
-#if UNITY_2022_2_OR_NEWER
-                var allCm = UnityEngine.Object.FindObjectsByType(cmType, FindObjectsSortMode.None);
-#else
-                var allCm = UnityEngine.Object.FindObjectsOfType(cmType);
-#endif
+                var allCm = UnityFindObjectsCompat.FindAll(cmType);
                 foreach (Component cm in allCm)
                 {
                     var follow = CameraHelpers.GetReflectionProperty(cm, "Follow") as Transform;

--- a/MCPForUnity/Editor/Tools/Cameras/CameraHelpers.cs
+++ b/MCPForUnity/Editor/Tools/Cameras/CameraHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -141,11 +142,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             if (!HasCinemachine || _cmBrainType == null)
                 return null;
 
-#if UNITY_2022_2_OR_NEWER
-            return UnityEngine.Object.FindFirstObjectByType(_cmBrainType) as Component;
-#else
-            return UnityEngine.Object.FindObjectOfType(_cmBrainType) as Component;
-#endif
+            return UnityFindObjectsCompat.FindAny(_cmBrainType) as Component;
         }
 
         internal static UnityEngine.Camera FindMainCamera()
@@ -153,11 +150,7 @@ namespace MCPForUnity.Editor.Tools.Cameras
             var main = UnityEngine.Camera.main;
             if (main != null) return main;
 
-#if UNITY_2022_2_OR_NEWER
-            var allCams = UnityEngine.Object.FindObjectsByType<UnityEngine.Camera>(FindObjectsSortMode.None);
-#else
-            var allCams = UnityEngine.Object.FindObjectsOfType<UnityEngine.Camera>();
-#endif
+            var allCams = UnityFindObjectsCompat.FindAll<UnityEngine.Camera>();
             return allCams.Length > 0 ? allCams[0] : null;
         }
 

--- a/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/ManageGameObjectCommon.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Tools;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -154,16 +155,9 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                         }
                         else
                         {
-#if UNITY_2023_1_OR_NEWER
-                            var inactive = searchInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude;
-                            searchPoolComp = UnityEngine.Object.FindObjectsByType(componentType, inactive, FindObjectsSortMode.None)
+                            searchPoolComp = UnityFindObjectsCompat.FindAll(componentType, searchInactive)
                                 .Cast<Component>()
                                 .Select(c => c.gameObject);
-#else
-                            searchPoolComp = UnityEngine.Object.FindObjectsOfType(componentType, searchInactive)
-                                .Cast<Component>()
-                                .Select(c => c.gameObject);
-#endif
                         }
                         results.AddRange(searchPoolComp.Where(go => go != null));
                     }

--- a/MCPForUnity/Editor/Tools/Graphics/GraphicsHelpers.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/GraphicsHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -109,11 +110,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
             string target = p.Get("target");
             if (string.IsNullOrEmpty(target))
             {
-#if UNITY_2022_2_OR_NEWER
-                var allVolumes = UnityEngine.Object.FindObjectsByType(VolumeType, FindObjectsSortMode.None);
-#else
-                var allVolumes = UnityEngine.Object.FindObjectsOfType(VolumeType);
-#endif
+                var allVolumes = UnityFindObjectsCompat.FindAll(VolumeType);
                 return allVolumes.Length > 0 ? allVolumes[0] as Component : null;
             }
 

--- a/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
+++ b/MCPForUnity/Editor/Tools/Graphics/VolumeOps.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -454,11 +455,7 @@ namespace MCPForUnity.Editor.Tools.Graphics
             if (!GraphicsHelpers.HasVolumeSystem)
                 return new { success = true, message = "Volume system not available.", data = new { volumes = new List<object>() } };
 
-#if UNITY_2022_2_OR_NEWER
-            var allVolumes = UnityEngine.Object.FindObjectsByType(GraphicsHelpers.VolumeType, FindObjectsSortMode.None);
-#else
-            var allVolumes = UnityEngine.Object.FindObjectsOfType(GraphicsHelpers.VolumeType);
-#endif
+            var allVolumes = UnityFindObjectsCompat.FindAll(GraphicsHelpers.VolumeType);
             var volumeList = new List<object>();
 
             foreach (Component vol in allVolumes)

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -598,11 +598,7 @@ namespace MCPForUnity.Editor.Tools
                         targetCamera = Camera.main;
                         if (targetCamera == null)
                         {
-#if UNITY_2022_2_OR_NEWER
-                            var allCams = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None);
-#else
-                            var allCams = UnityEngine.Object.FindObjectsOfType<Camera>();
-#endif
+                            var allCams = UnityFindObjectsCompat.FindAll<Camera>();
                             targetCamera = allCams.Length > 0 ? allCams[0] : null;
                         }
                     }
@@ -640,11 +636,7 @@ namespace MCPForUnity.Editor.Tools
 
                 // Default path: use ScreenCapture API if available, camera fallback otherwise
                 bool screenCaptureAvailable = ScreenshotUtility.IsScreenCaptureModuleAvailable;
-#if UNITY_2022_2_OR_NEWER
-                bool hasCameraFallback = Camera.main != null || UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length > 0;
-#else
-                bool hasCameraFallback = Camera.main != null || UnityEngine.Object.FindObjectsOfType<Camera>().Length > 0;
-#endif
+                bool hasCameraFallback = Camera.main != null || UnityFindObjectsCompat.FindAll<Camera>().Length > 0;
 
 #if UNITY_2022_1_OR_NEWER
                 if (!screenCaptureAvailable && !hasCameraFallback)
@@ -819,11 +811,7 @@ namespace MCPForUnity.Editor.Tools
                     // Default: calculate combined bounds of all renderers in the scene
                     Bounds bounds = new Bounds(Vector3.zero, Vector3.zero);
                     bool hasBounds = false;
-#if UNITY_2022_2_OR_NEWER
-                    var renderers = UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
-#else
-                    var renderers = UnityEngine.Object.FindObjectsOfType<Renderer>();
-#endif
+                    var renderers = UnityFindObjectsCompat.FindAll<Renderer>();
                     foreach (var r in renderers)
                     {
                         if (r == null || !r.gameObject.activeInHierarchy) continue;
@@ -964,11 +952,7 @@ namespace MCPForUnity.Editor.Tools
                     // Default: calculate combined bounds of all renderers in the scene
                     Bounds bounds = new Bounds(Vector3.zero, Vector3.zero);
                     bool hasBounds = false;
-#if UNITY_2022_2_OR_NEWER
-                    var renderers = UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
-#else
-                    var renderers = UnityEngine.Object.FindObjectsOfType<Renderer>();
-#endif
+                    var renderers = UnityFindObjectsCompat.FindAll<Renderer>();
                     foreach (var r in renderers)
                     {
                         if (r == null || !r.gameObject.activeInHierarchy) continue;
@@ -1216,11 +1200,7 @@ namespace MCPForUnity.Editor.Tools
             }
 
             // Search all cameras by name or path
-#if UNITY_2022_2_OR_NEWER
-            var allCams = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None);
-#else
-            var allCams = UnityEngine.Object.FindObjectsOfType<Camera>();
-#endif
+            var allCams = UnityFindObjectsCompat.FindAll<Camera>();
             foreach (var cam in allCams)
             {
                 if (cam.name == cameraRef) return cam;
@@ -1272,11 +1252,7 @@ namespace MCPForUnity.Editor.Tools
                     // Frame entire scene by computing combined bounds of all renderers
                     Bounds allBounds = new Bounds(Vector3.zero, Vector3.zero);
                     bool hasAny = false;
-#if UNITY_2022_2_OR_NEWER
-                    foreach (var r in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None))
-#else
-                    foreach (var r in UnityEngine.Object.FindObjectsOfType<Renderer>())
-#endif
+                    foreach (var r in UnityFindObjectsCompat.FindAll<Renderer>())
                     {
                         if (r == null || !r.gameObject.activeInHierarchy) continue;
                         if (!hasAny) { allBounds = r.bounds; hasAny = true; }

--- a/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
+++ b/MCPForUnity/Editor/Tools/Physics/PhysicsSimulationOps.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 
@@ -138,11 +139,7 @@ namespace MCPForUnity.Editor.Tools.Physics
 
             if (dimension == "2d")
             {
-#if UNITY_2022_2_OR_NEWER
-                var allRb2d = Object.FindObjectsByType<Rigidbody2D>(FindObjectsSortMode.None);
-#else
-                var allRb2d = Object.FindObjectsOfType<Rigidbody2D>();
-#endif
+                var allRb2d = UnityFindObjectsCompat.FindAll<Rigidbody2D>();
                 foreach (var rb2d in allRb2d)
                 {
                     if (results.Count >= maxResults) break;
@@ -165,11 +162,7 @@ namespace MCPForUnity.Editor.Tools.Physics
             }
             else
             {
-#if UNITY_2022_2_OR_NEWER
-                var allRb = Object.FindObjectsByType<Rigidbody>(FindObjectsSortMode.None);
-#else
-                var allRb = Object.FindObjectsOfType<Rigidbody>();
-#endif
+                var allRb = UnityFindObjectsCompat.FindAll<Rigidbody>();
                 foreach (var rb in allRb)
                 {
                     if (results.Count >= maxResults) break;

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -91,11 +91,7 @@ namespace MCPForUnity.Runtime.Helpers
 
             try
             {
-#if UNITY_2022_2_OR_NEWER
-                var cams = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsSortMode.None);
-#else
-                var cams = UnityEngine.Object.FindObjectsOfType<Camera>();
-#endif
+                var cams = UnityFindObjectsCompat.FindAll<Camera>();
                 return cams.FirstOrDefault();
             }
             catch

--- a/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs
@@ -1,0 +1,57 @@
+using System;
+using UObject = UnityEngine.Object;
+
+namespace MCPForUnity.Runtime.Helpers
+{
+    /// <summary>
+    /// Version-compatible wrappers for the Object.FindObjectsOfType / FindObjectsByType family,
+    /// which changed across Unity 2022, Unity 6.0, and Unity 6.5.
+    /// </summary>
+    public static class UnityFindObjectsCompat
+    {
+        public static T[] FindAll<T>() where T : UObject
+        {
+#if UNITY_6000_5_OR_NEWER
+            return UObject.FindObjectsByType<T>();
+#elif UNITY_2022_2_OR_NEWER
+            return UObject.FindObjectsByType<T>(UnityEngine.FindObjectsSortMode.None);
+#else
+            return UObject.FindObjectsOfType<T>();
+#endif
+        }
+
+        public static UObject[] FindAll(Type type)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return UObject.FindObjectsByType(type, UnityEngine.FindObjectsInactive.Exclude);
+#elif UNITY_2022_2_OR_NEWER
+            return UObject.FindObjectsByType(type, UnityEngine.FindObjectsSortMode.None);
+#else
+            return UObject.FindObjectsOfType(type);
+#endif
+        }
+
+        public static UObject[] FindAll(Type type, bool includeInactive)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return UObject.FindObjectsByType(type,
+                includeInactive ? UnityEngine.FindObjectsInactive.Include : UnityEngine.FindObjectsInactive.Exclude);
+#elif UNITY_2023_1_OR_NEWER
+            return UObject.FindObjectsByType(type,
+                includeInactive ? UnityEngine.FindObjectsInactive.Include : UnityEngine.FindObjectsInactive.Exclude,
+                UnityEngine.FindObjectsSortMode.None);
+#else
+            return UObject.FindObjectsOfType(type, includeInactive);
+#endif
+        }
+
+        public static UObject FindAny(Type type)
+        {
+#if UNITY_2022_2_OR_NEWER
+            return UObject.FindAnyObjectByType(type);
+#else
+            return UObject.FindObjectOfType(type);
+#endif
+        }
+    }
+}

--- a/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs.meta
+++ b/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c3a9f12e4b60438d9a1c52ef8d07b3e


### PR DESCRIPTION
## Summary
- Fix package compilation errors in Unity 6000.6.x
- Adds a UnityFindObjectsCompat helper for Object.FindObjectsByType API changes across Unity 2022 and Unity 6.
- Replaces direct FindObjectsByType(..., FindObjectsSortMode.None) calls to avoid Unity 6.5+ deprecation warnings while preserving older Unity support.

## Testing
- Ran git diff --check.
- Verified the same compatibility approach is already present on the beta branch.