### PR TITLE
Fix create_script validator false-positive inside method bodies

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageScript.cs
+++ b/MCPForUnity/Editor/Tools/ManageScript.cs
@@ -2714,12 +2714,18 @@ namespace MCPForUnity.Editor.Tools
             }
             // Second pass: build per-position containing type array
             var containingTypeArr = new string[codeOnly.Length];
+            var braceDepthArr = new int[codeOnly.Length];
+            var typeMemberDepthArr = new int[codeOnly.Length];
             {
                 var stack = new System.Collections.Generic.List<(string name, int openDepth)>();
                 int bd2 = 0;
                 string current = "";
                 for (int i = 0; i < codeOnly.Length; i++)
                 {
+                    containingTypeArr[i] = current;
+                    braceDepthArr[i] = bd2;
+                    typeMemberDepthArr[i] = stack.Count > 0 ? stack[stack.Count - 1].openDepth + 1 : -1;
+
                     if (codeOnly[i] == '{')
                     {
                         if (typeBraceMap.TryGetValue(i, out string tn))
@@ -2738,7 +2744,6 @@ namespace MCPForUnity.Editor.Tools
                             current = stack.Count > 0 ? stack[stack.Count - 1].name : "";
                         }
                     }
-                    containingTypeArr[i] = current;
                 }
             }
 
@@ -2757,6 +2762,8 @@ namespace MCPForUnity.Editor.Tools
                 int paramCount = CountTopLevelParams(sm.Groups[3].Value);
                 string paramTypes = ExtractParamTypes(sm.Groups[3].Value);
                 string containingType = containingTypeArr[sm.Index];
+                if (string.IsNullOrEmpty(containingType)) continue;
+                if (braceDepthArr[sm.Index] != typeMemberDepthArr[sm.Index]) continue;
                 string key = $"{containingType}/{methodName}/{paramCount}/{paramTypes}";
                 if (seen.TryGetValue(key, out _))
                     errors.Add($"ERROR: Duplicate method signature detected: '{methodName}' with {paramCount} parameter(s). This may indicate a corrupted edit.");

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
@@ -379,6 +379,52 @@ public class Derived : Base
         }
 
         [Test]
+        public void DuplicateMethodCheck_LocalFunctionsInDifferentMethods_NotFlagged()
+        {
+            string code = @"using UnityEngine;
+public class Test : MonoBehaviour
+{
+    void Start()
+    {
+        int ClampScore(int value) { return Mathf.Clamp(value, 0, 100); }
+        Debug.Log(ClampScore(10));
+    }
+
+    void Reset()
+    {
+        int ClampScore(int value) { return Mathf.Clamp(value, 0, 100); }
+        Debug.Log(ClampScore(0));
+    }
+}";
+            var errors = CallValidateScriptSyntaxUnity(code);
+            Assert.IsFalse(HasDuplicateMethodError(errors),
+                "Same-signature local functions in different methods are valid C# and should not be flagged as duplicate class methods");
+        }
+
+        [Test]
+        public void DuplicateMethodCheck_RepeatedMethodInvocations_NotFlagged()
+        {
+            string code = @"using UnityEngine;
+public class Test : MonoBehaviour
+{
+    int First()
+    {
+        return Compute();
+    }
+
+    int Second()
+    {
+        return Compute();
+    }
+
+    int Compute() { return 1; }
+}";
+            var errors = CallValidateScriptSyntaxUnity(code);
+            Assert.IsFalse(HasDuplicateMethodError(errors),
+                "Repeated method invocations inside method bodies should not be treated as duplicate method declarations");
+        }
+
+        [Test]
         public void HandleCommand_PathWithCsExtension_StripsFilename()
         {
             // When path ends with .cs (full file path instead of directory),


### PR DESCRIPTION
## Summary
- Fix `ManageScript` duplicate-method validation so it only counts method declarations that are direct members of a type.
- Prevent repeated method calls such as `return Compute();` from being misclassified as duplicate method declarations.
- Add regression coverage for repeated invocations and same-signature local functions in separate method bodies.

## Test plan
- [x] Reproduced on `upstream/beta` with a temporary Unity `-executeMethod` harness: repeated `return Compute();` calls produced duplicate `Compute` diagnostics.
- [x] Verified the same harness passes on this branch with `REPRO_OK`.
- [x] `git diff --check`

## Notes
- This follows up the same validator area fixed in #1045.
- No tool/resource schema or documentation updates are needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate method signature detection to more accurately identify actual duplicate declarations while avoiding false positives from local functions in different scopes and method invocations within method bodies.

* **Tests**
  * Added test coverage for edge cases in duplicate method signature detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->