### PR TITLE
Fix MCP main window reopening logic and remove profiler warning

### DIFF
--- a/MCPForUnity/Editor/MenuItems/MCPForUnityMenu.cs
+++ b/MCPForUnity/Editor/MenuItems/MCPForUnityMenu.cs
@@ -10,14 +10,7 @@ namespace MCPForUnity.Editor.MenuItems
         [MenuItem("Window/MCP For Unity/Toggle MCP Window %#m", priority = 1)]
         public static void ToggleMCPWindow()
         {
-            if (MCPForUnityEditorWindow.HasAnyOpenWindow())
-            {
-                MCPForUnityEditorWindow.CloseAllOpenWindows();
-            }
-            else
-            {
-                MCPForUnityEditorWindow.ShowWindow();
-            }
+            MCPForUnityEditorWindow.ShowWindow();
         }
 
         [MenuItem("Window/MCP For Unity/Local Setup Window", priority = 2)]

--- a/MCPForUnity/Editor/Tools/Profiler/Operations/SessionOps.cs
+++ b/MCPForUnity/Editor/Tools/Profiler/Operations/SessionOps.cs
@@ -21,7 +21,6 @@ namespace MCPForUnity.Editor.Tools.Profiler
 
             UProfiler.enabled = true;
 
-            bool recording = false;
             if (!string.IsNullOrEmpty(logFile))
             {
                 string dir = Path.GetDirectoryName(logFile);
@@ -30,7 +29,6 @@ namespace MCPForUnity.Editor.Tools.Profiler
 
                 UProfiler.logFile = logFile;
                 UProfiler.enableBinaryLog = true;
-                recording = true;
             }
 
             if (enableCallstacks)

--- a/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -73,8 +73,42 @@ namespace MCPForUnity.Editor.Windows
 
         public static void ShowWindow()
         {
-            var window = GetWindow<MCPForUnityEditorWindow>("MCP For Unity");
+            var existingWindows = UnityEngine.Resources.FindObjectsOfTypeAll<MCPForUnityEditorWindow>();
+            MCPForUnityEditorWindow window = null;
+
+            if (existingWindows.Length > 0)
+            {
+                window = existingWindows[0];
+
+                // If multiple instances exist, keep one and close the extras to avoid stale hidden tabs.
+                for (int i = 1; i < existingWindows.Length; i++)
+                {
+                    try
+                    {
+                        existingWindows[i].Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        McpLog.Warn($"Error closing duplicate MCP window: {ex.Message}");
+                    }
+                }
+            }
+            else
+            {
+                window = GetWindow<MCPForUnityEditorWindow>("MCP For Unity");
+            }
+
+            window.titleContent = new GUIContent("MCP For Unity");
             window.minSize = new Vector2(500, 340);
+
+            if (window.position.width < 100 || window.position.height < 100)
+            {
+                window.position = new Rect(120, 120, 900, 700);
+            }
+
+            window.Show();
+            window.ShowTab();
+            window.Focus();
         }
 
         // Helper to check and manage open windows from other classes
@@ -125,6 +159,7 @@ namespace MCPForUnity.Editor.Windows
                 return;
             }
 
+            rootVisualElement.Clear();
             visualTree.CloneTree(rootVisualElement);
 
             // Load main window USS


### PR DESCRIPTION
## Summary

This PR fixes an issue where `Window > MCP For Unity > Toggle MCP Window` could fail to show the main MCP window even though other MCP windows, such as `Local Setup Window` and `Edit EditorPrefs`, still opened normally.

It also removes an unrelated compiler warning in the profiler session tool.

## What changed

- Make `Toggle MCP Window` always route through `MCPForUnityEditorWindow.ShowWindow()`
- Reuse one existing `MCPForUnityEditorWindow` instance when present
- Close duplicate stale MCP window instances to avoid hidden/broken tabs interfering with reopen behavior
- Restore a sane default window rect when the existing window has an invalid or tiny size
- Explicitly call `Show()`, `ShowTab()`, and `Focus()` when reopening the main MCP window
- Clear an unused local variable in `SessionOps` to remove CS0219

## Root cause

The previous menu action behaved like a true toggle:
- if Unity thought an MCP window was already open, it would close it
- otherwise it would open one

In practice, hidden or stale editor window instances could remain in Unity's window state. That made the toggle path unreliable and could leave the main MCP window effectively inaccessible, while other MCP windows still worked.

## Files changed

- `MCPForUnity/Editor/MenuItems/MCPForUnityMenu.cs`
- `MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs`
- `MCPForUnity/Editor/Tools/Profiler/Operations/SessionOps.cs`

## Validation

Validated locally in Unity by reproducing the issue and confirming that:
- `Local Setup Window` opened
- `Edit EditorPrefs` opened
- the main `MCP For Unity` window did not reopen reliably before the fix
- the main `MCP For Unity` window reopened correctly after the fix

Also confirmed:
- no diff format issues via `git diff --check`
- CS0219 warning in `SessionOps` is removed

## Notes

This PR intentionally keeps the fix narrow and does not change the main window UI structure or runtime behavior beyond reopening/recovery behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI element duplication that could occur when the MCP editor window was reopened or refreshed
  * Improved window instance management to ensure stable operation

* **Refactor**
  * Simplified MCP window opening behavior
  * Removed unused code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->