### PR TITLE
fix: support Unity 2022.2 object lookup compatibility

### DIFF
--- a/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityFindObjectsCompat.cs
@@ -4,11 +4,9 @@ using UObject = UnityEngine.Object;
 namespace MCPForUnity.Runtime.Helpers
 {
     /// <summary>
-    /// Version-compatible wrappers for the Object.FindObjectsOfType / FindObjectsByType family,
-    /// which changed across Unity 2022 → 6.0 → 6.5:
-    ///   Pre-2022.2  : FindObjectsOfType / FindObjectOfType
-    ///   2022.2–6.4  : FindObjectsByType(sortMode) / FindFirstObjectByType
-    ///   6.5+        : FindObjectsByType() (no sort param) / FindAnyObjectByType
+    /// Version-compatible wrappers for the Object.FindObjectsOfType / FindObjectsByType family.
+    /// Unity 2022.2 editor versions do not reliably expose the newer APIs, so we only
+    /// switch to them once 2022.3+ symbols are available.
     /// </summary>
     public static class UnityFindObjectsCompat
     {
@@ -17,10 +15,12 @@ namespace MCPForUnity.Runtime.Helpers
         {
 #if UNITY_6000_5_OR_NEWER
             return UObject.FindObjectsByType<T>();
-#elif UNITY_2022_2_OR_NEWER
+#elif UNITY_2022_3_OR_NEWER
             return UObject.FindObjectsByType<T>(UnityEngine.FindObjectsSortMode.None);
 #else
+#pragma warning disable 618
             return UObject.FindObjectsOfType<T>();
+#pragma warning restore 618
 #endif
         }
 
@@ -29,10 +29,12 @@ namespace MCPForUnity.Runtime.Helpers
         {
 #if UNITY_6000_5_OR_NEWER
             return UObject.FindObjectsByType(type, UnityEngine.FindObjectsInactive.Exclude);
-#elif UNITY_2022_2_OR_NEWER
+#elif UNITY_2022_3_OR_NEWER
             return UObject.FindObjectsByType(type, UnityEngine.FindObjectsSortMode.None);
 #else
+#pragma warning disable 618
             return UObject.FindObjectsOfType(type);
+#pragma warning restore 618
 #endif
         }
 
@@ -47,17 +49,21 @@ namespace MCPForUnity.Runtime.Helpers
                 includeInactive ? UnityEngine.FindObjectsInactive.Include : UnityEngine.FindObjectsInactive.Exclude,
                 UnityEngine.FindObjectsSortMode.None);
 #else
+#pragma warning disable 618
             return UObject.FindObjectsOfType(type, includeInactive);
+#pragma warning restore 618
 #endif
         }
 
         /// <summary>Find any single object of the given runtime type (no ordering guarantee).</summary>
         public static UObject FindAny(Type type)
         {
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             return UObject.FindAnyObjectByType(type);
 #else
+#pragma warning disable 618
             return UObject.FindObjectOfType(type);
+#pragma warning restore 618
 #endif
         }
     }


### PR DESCRIPTION
## Description

Fix a Unity 2022.2 compatibility issue in `UnityFindObjectsCompat`.

Some Unity 2022.2 editor versions do not reliably expose the newer object lookup APIs used by the package. This caused compilation failures in projects using Unity 2022.2.1f1.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Delayed use of `Object.FindObjectsByType(...)` until `UNITY_2022_3_OR_NEWER`
- Delayed use of `Object.FindAnyObjectByType(...)` until `UNITY_2022_3_OR_NEWER`
- Kept `FindObjectsOfType(...)` / `FindObjectOfType(...)` as the fallback path for Unity 2022.2.x
- Added local pragma guards for obsolete fallback APIs to keep the compatibility wrapper warning-clean

## Testing/Screenshots/Recordings

- Reproduced the compile failure on Unity `2022.2.1f1`
- Verified the project compiles cleanly in Unity `2022.2.1f1` after the compatibility change
- Ran `git diff --check`

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`

## Related Issues

Relates to Unity 2022.2.x compilation failures in `UnityFindObjectsCompat`.

## Additional Notes

This change intentionally keeps the fix minimal and only adjusts the version gating for object lookup APIs in the compatibility helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Unity compatibility layer to utilize newer APIs for Unity 2022.3+ while maintaining backward compatibility with older versions.
  * Enhanced code stability with improved warning handling for legacy code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->