### PR TITLE
fix: unblock beta compile and gate releases on test success

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -13,9 +13,21 @@ on:
       - "MCPForUnity/**"
 
 jobs:
+  unity_tests:
+    name: Unity tests gate
+    if: github.actor != 'github-actions[bot]'
+    uses: ./.github/workflows/unity-tests.yml
+    secrets: inherit
+
+  python_tests:
+    name: Python tests gate
+    if: github.actor != 'github-actions[bot]'
+    uses: ./.github/workflows/python-tests.yml
+
   update_unity_beta_version:
     name: Update Unity package to beta version
     runs-on: ubuntu-latest
+    needs: [unity_tests, python_tests]
     # Avoid running when the workflow's own automation merges the PR
     # created by this workflow (prevents a version-bump loop).
     if: github.actor != 'github-actions[bot]'
@@ -143,6 +155,7 @@ jobs:
   publish_pypi_prerelease:
     name: Publish beta to PyPI (pre-release)
     runs-on: ubuntu-latest
+    needs: [unity_tests, python_tests]
     # Avoid double-publish when the bot merges the version bump PR
     if: github.actor != 'github-actions[bot]'
     environment:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,7 +6,19 @@ on:
     paths:
       - Server/**
       - .github/workflows/python-tests.yml
+  pull_request:
+    branches: [main, beta]
+    paths:
+      - Server/**
+      - .github/workflows/python-tests.yml
   workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to test (defaults to the triggering ref)."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   test:
@@ -15,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,23 @@ on:
         required: true
 
 jobs:
+  unity_tests:
+    name: Unity tests gate
+    uses: ./.github/workflows/unity-tests.yml
+    with:
+      ref: beta
+    secrets: inherit
+
+  python_tests:
+    name: Python tests gate
+    uses: ./.github/workflows/python-tests.yml
+    with:
+      ref: beta
+
   bump:
     name: Bump version, tag, and create release
     runs-on: ubuntu-latest
+    needs: [unity_tests, python_tests]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -31,6 +31,8 @@ jobs:
   testAllModes:
     name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: >
       github.event_name != 'pull_request_target' ||
       (github.event.pull_request.head.repo.full_name != github.repository &&
@@ -50,6 +52,7 @@ jobs:
         with:
           lfs: true
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: Detect Unity license secrets
         id: detect
@@ -130,7 +133,7 @@ jobs:
           fi
 
       - uses: actions/upload-artifact@v4
-        if: always() && steps.detect.outputs.unity_ok == 'true'
+        if: always() && steps.detect.outputs.unity_ok == 'true' && steps.tests.outcome != 'skipped'
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -2,8 +2,26 @@ name: Unity Tests
 
 on:
   workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to test (defaults to the triggering ref)."
+        type: string
+        required: false
+        default: ""
   push:
     branches: ["**"]
+    paths:
+      - TestProjects/UnityMCPTests/**
+      - MCPForUnity/Editor/**
+      - .github/workflows/unity-tests.yml
+  # Fork PRs: maintainer applies the 'safe-to-test' label after reviewing
+  # the diff. The workflow runs with UNITY_LICENSE in scope against the
+  # PR's head SHA. Re-pushed commits do NOT auto-trigger — maintainer must
+  # remove and re-apply the label to re-run after additional review.
+  pull_request_target:
+    types: [labeled]
+    branches: [main, beta]
     paths:
       - TestProjects/UnityMCPTests/**
       - MCPForUnity/Editor/**
@@ -13,6 +31,10 @@ jobs:
   testAllModes:
     name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (github.event.pull_request.head.repo.full_name != github.repository &&
+       github.event.label.name == 'safe-to-test')
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
 
       - name: Detect Unity license secrets
         id: detect

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -598,11 +598,14 @@ namespace MCPForUnity.Editor.Tools
                 {
                     if (!Application.isBatchMode) EnsureGameView();
 
+                    string folderOverride = ScreenshotPreferences.Resolve(cmd.outputFolder);
                     ScreenshotCaptureResult result = ScreenshotUtility.CaptureFromCameraToProjectFolder(
                         targetCamera, fileName, resolvedSuperSize, ensureUniqueFileName: true,
-                        includeImage: includeImage, maxResolution: maxResolution);
+                        includeImage: includeImage, maxResolution: maxResolution,
+                        folderOverride: folderOverride);
 
-                    AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
+                    if (ScreenshotUtility.IsUnderAssets(result.ProjectRelativePath))
+                        AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
                     string message = $"Screenshot captured to '{result.ProjectRelativePath}' (camera: {targetCamera.name}).";
                     return new SuccessResponse(message, BuildScreenshotResponseData(result, targetCamera.name, includeImage));
                 }
@@ -611,11 +614,14 @@ namespace MCPForUnity.Editor.Tools
                 {
                     if (!Application.isBatchMode) EnsureGameView();
 
+                    string folderOverride = ScreenshotPreferences.Resolve(cmd.outputFolder);
                     ScreenshotCaptureResult result = ScreenshotUtility.CaptureComposited(
                         fileName, resolvedSuperSize, ensureUniqueFileName: true,
-                        includeImage: true, maxResolution: maxResolution);
+                        includeImage: true, maxResolution: maxResolution,
+                        folderOverride: folderOverride);
 
-                    AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
+                    if (ScreenshotUtility.IsUnderAssets(result.ProjectRelativePath))
+                        AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
                     string cameraName = Camera.main != null ? Camera.main.name : "composited";
                     string message = $"Screenshot captured to '{result.ProjectRelativePath}' (camera: {cameraName}).";
                     return new SuccessResponse(message, BuildScreenshotResponseData(result, cameraName, includeImage: true));

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -598,12 +598,12 @@ namespace MCPForUnity.Editor.Tools
                 {
                     if (!Application.isBatchMode) EnsureGameView();
 
-                    ScreenshotCaptureResult result = ScreenshotUtility.CaptureFromCameraToAssetsFolder(
+                    ScreenshotCaptureResult result = ScreenshotUtility.CaptureFromCameraToProjectFolder(
                         targetCamera, fileName, resolvedSuperSize, ensureUniqueFileName: true,
                         includeImage: includeImage, maxResolution: maxResolution);
 
-                    AssetDatabase.ImportAsset(result.AssetsRelativePath, ImportAssetOptions.ForceSynchronousImport);
-                    string message = $"Screenshot captured to '{result.AssetsRelativePath}' (camera: {targetCamera.name}).";
+                    AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
+                    string message = $"Screenshot captured to '{result.ProjectRelativePath}' (camera: {targetCamera.name}).";
                     return new SuccessResponse(message, BuildScreenshotResponseData(result, targetCamera.name, includeImage));
                 }
 
@@ -615,9 +615,9 @@ namespace MCPForUnity.Editor.Tools
                         fileName, resolvedSuperSize, ensureUniqueFileName: true,
                         includeImage: true, maxResolution: maxResolution);
 
-                    AssetDatabase.ImportAsset(result.AssetsRelativePath, ImportAssetOptions.ForceSynchronousImport);
+                    AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
                     string cameraName = Camera.main != null ? Camera.main.name : "composited";
-                    string message = $"Screenshot captured to '{result.AssetsRelativePath}' (camera: {cameraName}).";
+                    string message = $"Screenshot captured to '{result.ProjectRelativePath}' (camera: {cameraName}).";
                     return new SuccessResponse(message, BuildScreenshotResponseData(result, cameraName, includeImage: true));
                 }
 
@@ -747,7 +747,7 @@ namespace MCPForUnity.Editor.Tools
         {
             var data = new Dictionary<string, object>
             {
-                { "path", result.AssetsRelativePath },
+                { "path", result.ProjectRelativePath },
                 { "fullPath", result.FullPath },
                 { "superSize", result.SuperSize },
                 { "isAsync", false },

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -252,12 +252,12 @@ namespace MCPForUnity.Runtime.Helpers
             {
                 var fallbackCamera = FindAvailableCamera();
                 if (fallbackCamera != null)
-                    return CaptureFromCameraToAssetsFolder(fallbackCamera, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
+                    return CaptureFromCameraToProjectFolder(fallbackCamera, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
 
                 throw new InvalidOperationException("ScreenCapture module is unavailable and no fallback camera found.");
             }
 
-            ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, isAsync: false);
+            ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride: null, isAsync: false);
             Texture2D tex = null;
             Texture2D downscaled = null;
             string imageBase64 = null;
@@ -270,7 +270,7 @@ namespace MCPForUnity.Runtime.Helpers
                     // Fallback to camera-based if ScreenCapture fails
                     var cam = FindAvailableCamera();
                     if (cam != null)
-                        return CaptureFromCameraToAssetsFolder(cam, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
+                        return CaptureFromCameraToProjectFolder(cam, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
                     throw new InvalidOperationException("ScreenCapture.CaptureScreenshotAsTexture returned null and no fallback camera available.");
                 }
 
@@ -308,7 +308,7 @@ namespace MCPForUnity.Runtime.Helpers
             if (includeImage && imageBase64 != null)
             {
                 return new ScreenshotCaptureResult(
-                    result.FullPath, result.AssetsRelativePath, result.SuperSize, false,
+                    result.FullPath, result.ProjectRelativePath, result.SuperSize, false,
                     imageBase64, imgW, imgH);
             }
             return result;

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -246,18 +246,20 @@ namespace MCPForUnity.Runtime.Helpers
             int superSize = 1,
             bool ensureUniqueFileName = true,
             bool includeImage = false,
-            int maxResolution = 0)
+            int maxResolution = 0,
+            string folderOverride = null)
         {
             if (!IsScreenCaptureModuleAvailable)
             {
                 var fallbackCamera = FindAvailableCamera();
                 if (fallbackCamera != null)
-                    return CaptureFromCameraToProjectFolder(fallbackCamera, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
+                    return CaptureFromCameraToProjectFolder(fallbackCamera, fileName, superSize, ensureUniqueFileName,
+                        includeImage, maxResolution, folderOverride: folderOverride);
 
                 throw new InvalidOperationException("ScreenCapture module is unavailable and no fallback camera found.");
             }
 
-            ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride: null, isAsync: false);
+            ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride: folderOverride, isAsync: false);
             Texture2D tex = null;
             Texture2D downscaled = null;
             string imageBase64 = null;
@@ -270,7 +272,8 @@ namespace MCPForUnity.Runtime.Helpers
                     // Fallback to camera-based if ScreenCapture fails
                     var cam = FindAvailableCamera();
                     if (cam != null)
-                        return CaptureFromCameraToProjectFolder(cam, fileName, superSize, ensureUniqueFileName, includeImage, maxResolution);
+                        return CaptureFromCameraToProjectFolder(cam, fileName, superSize, ensureUniqueFileName,
+                            includeImage, maxResolution, folderOverride: folderOverride);
                     throw new InvalidOperationException("ScreenCapture.CaptureScreenshotAsTexture returned null and no fallback camera available.");
                 }
 


### PR DESCRIPTION
## Summary

Two related changes responding to the broken 9.6.9-beta.5 publish (issue #1100):

- **fix:** align `CaptureComposited` with the renamed `Project*`-folder API. PR #1040 added `CaptureComposited` referencing the old `CaptureFromCameraToAssetsFolder` / `AssetsRelativePath` names and called `PrepareCaptureResult` without the now-required `folderOverride` arg. Renames into the `Project*` equivalents in `ScreenshotUtility.cs`, plus the matching call sites in `ManageScene.cs`. Closes #1100.
- **ci:** gate releases on test success and run tests on PRs.
  - `beta-release.yml` and `release.yml` publish/bump jobs now `needs: [unity_tests, python_tests]` via `workflow_call`. The whole release halts before any irreversible commit/tag/push if either fails. Previously PyPI shipped 28s after push, before Unity Tests had even compiled the project.
  - `python-tests.yml` now has a `pull_request` trigger; runs on every PR (no secrets).
  - `unity-tests.yml` now has `pull_request_target: types: [labeled]` gated on a `safe-to-test` label and the PR being from a fork. Maintainers review the diff, apply the label, and unity-tests runs with `UNITY_LICENSE` against the PR's head SHA. Re-pushed commits do NOT auto-trigger; maintainer must remove and re-apply the label to re-run after additional review.

In-repo PRs continue to be tested via the existing `push` trigger, so no labeling friction for collaborator branches.

## Maintainer setup

After this lands, create a `safe-to-test` label in the repo (Issues/PRs → Labels → New). That's the entire one-time setup; the rest is automatic.

## Test plan

- [ ] Verify Unity recompiles cleanly after the rename (test project compiles without the four CS errors from #1100).
- [ ] Push a no-op commit to a beta-targeted branch and confirm `unity-tests` and `python-tests` jobs both run before any release/publish job starts.
- [ ] Open a fork PR (or simulate one) without the label — confirm `unity-tests` does NOT run.
- [ ] Apply `safe-to-test` to a fork PR — confirm `unity-tests` runs against the PR's head SHA.
- [ ] Push a new commit to the labeled fork PR — confirm `unity-tests` does NOT auto-rerun.
- [ ] Manually dispatch `release.yml` on `main` and confirm it runs `unity_tests` + `python_tests` against `beta` before `bump` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshot capture now returns project-relative paths for more consistent image import and reporting.

* **Chores**
  * CI/CD updated with dedicated Unity and Python test gates that must pass before version bumps or beta publishes.
  * Test workflows now support reusable invocation and expanded triggers, and checkout logic respects invoked refs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->