### PR TITLE
ci(unity-tests): include MCPForUnity/Runtime/** in trigger paths

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - TestProjects/UnityMCPTests/**
       - MCPForUnity/Editor/**
+      - MCPForUnity/Runtime/**
       - .github/workflows/unity-tests.yml
   # Fork PRs: maintainer applies the 'safe-to-test' label after reviewing
   # the diff. The workflow runs with UNITY_LICENSE in scope against the
@@ -25,6 +26,7 @@ on:
     paths:
       - TestProjects/UnityMCPTests/**
       - MCPForUnity/Editor/**
+      - MCPForUnity/Runtime/**
       - .github/workflows/unity-tests.yml
 
 jobs:


### PR DESCRIPTION
## Summary

Both the `push:` and `pull_request_target:` triggers in `unity-tests.yml` listed `MCPForUnity/Editor/**` in their `paths:` filters but not `MCPForUnity/Runtime/**`. Result: a PR (or branch push) that modified only files under `MCPForUnity/Runtime/**` would silently fail to trigger Unity tests — including the `safe-to-test` label flow on a fork PR.

CodeRabbit flagged this as a low/💤 nitpick on [#1103](https://github.com/CoplayDev/unity-mcp/pull/1103#discussion_r) (paths + types: [labeled] interaction). [#1106](https://github.com/CoplayDev/unity-mcp/pull/1106) made it concrete — applying `safe-to-test` had no effect because the Runtime-only diff was filtered out.

Adding `MCPForUnity/Runtime/**` mirrors the package's asmdef layout: `Editor/` and `Runtime/` are the two assembly roots whose code changes can break Unity compilation. Matches the codebase's "domain symmetry" convention from CLAUDE.md.

## Test plan

- [ ] After this lands, push a Runtime-only commit to a feature branch and verify `Unity Tests` workflow fires (it didn't before).
- [ ] After this lands, label a fork PR that touches only `MCPForUnity/Runtime/**` with `safe-to-test` and verify the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to trigger tests on additional code changes, ensuring enhanced quality assurance coverage for runtime components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->