### PR TITLE
fix: enable project-scoped custom tools in stdio mode

### DIFF
--- a/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
+++ b/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
@@ -23,8 +23,26 @@ namespace MCPForUnity.Editor.Services
 
             _cachedTools = new Dictionary<string, ToolMetadata>();
 
+            // Primary scan via TypeCache (fast, but can miss project assemblies in some domain-reload states)
             var toolTypes = TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>();
-            foreach (var type in toolTypes)
+
+            // Fallback scan via AppDomain (slower but exhaustive; mirrors CommandRegistry behaviour)
+            var appDomainTypes = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.IsDynamic)
+                .SelectMany(a =>
+                {
+                    try { return a.GetTypes(); }
+                    catch { return new Type[0]; }
+                })
+                .Where(t => t.GetCustomAttribute<McpForUnityToolAttribute>() != null);
+
+            // Merge both scans, deduplicating by type
+            var allToolTypes = toolTypes
+                .Concat(appDomainTypes)
+                .Distinct()
+                .ToList();
+
+            foreach (var type in allToolTypes)
             {
                 McpForUnityToolAttribute toolAttr;
                 try

--- a/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
+++ b/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
@@ -32,7 +32,11 @@ namespace MCPForUnity.Editor.Services
                 .SelectMany(a =>
                 {
                     try { return a.GetTypes(); }
-                    catch { return new Type[0]; }
+                    catch (Exception ex)
+                    {
+                        McpLog.Warn($"Failed to reflect types from assembly {a.FullName}: {ex.Message}");
+                        return new Type[0];
+                    }
                 })
                 .Where(t => t.GetCustomAttribute<McpForUnityToolAttribute>() != null);
 

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -1049,7 +1049,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
 
                 bool projectScopedTools = EditorPrefs.GetBool(
                     EditorPrefKeys.ProjectScopedToolsLocalHttp,
-                    true  // default to true so stdio behaves like HTTP Local by default
+                    false // must match McpToolsSection toggle default so UI and heartbeat agree
                 );
 
                 var payload = new

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -1047,6 +1047,11 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                 }
                 catch { }
 
+                bool projectScopedTools = EditorPrefs.GetBool(
+                    EditorPrefKeys.ProjectScopedToolsLocalHttp,
+                    true  // default to true so stdio behaves like HTTP Local by default
+                );
+
                 var payload = new
                 {
                     unity_port = currentUnityPort,
@@ -1056,7 +1061,8 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     project_path = Application.dataPath,
                     project_name = projectName,
                     unity_version = Application.unityVersion,
-                    last_heartbeat = DateTime.UtcNow.ToString("O")
+                    last_heartbeat = DateTime.UtcNow.ToString("O"),
+                    project_scoped_tools = projectScopedTools
                 };
                 File.WriteAllText(filePath, JsonConvert.SerializeObject(payload), new System.Text.UTF8Encoding(false));
             }

--- a/MCPForUnity/Editor/Windows/Components/Tools/McpToolsSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/Tools/McpToolsSection.cs
@@ -75,7 +75,7 @@ namespace MCPForUnity.Editor.Windows.Components.Tools
             {
                 projectScopedToolsToggle.value = EditorPrefs.GetBool(
                     EditorPrefKeys.ProjectScopedToolsLocalHttp,
-                    true
+                    false
                 );
                 projectScopedToolsToggle.tooltip = "When enabled, register project-scoped tools with HTTP Local and stdio transports. Allows per-project tool customization.";
                 projectScopedToolsToggle.RegisterValueChangedCallback(evt =>

--- a/MCPForUnity/Editor/Windows/Components/Tools/McpToolsSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/Tools/McpToolsSection.cs
@@ -75,9 +75,9 @@ namespace MCPForUnity.Editor.Windows.Components.Tools
             {
                 projectScopedToolsToggle.value = EditorPrefs.GetBool(
                     EditorPrefKeys.ProjectScopedToolsLocalHttp,
-                    false
+                    true
                 );
-                projectScopedToolsToggle.tooltip = "When enabled, register project-scoped tools with HTTP Local transport. Allows per-project tool customization.";
+                projectScopedToolsToggle.tooltip = "When enabled, register project-scoped tools with HTTP Local and stdio transports. Allows per-project tool customization.";
                 projectScopedToolsToggle.RegisterValueChangedCallback(evt =>
                 {
                     EditorPrefs.SetBool(EditorPrefKeys.ProjectScopedToolsLocalHttp, evt.newValue);

--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -884,10 +884,31 @@ Examples:
     if args.http_port:
         logger.info(f"HTTP port override: {http_port}")
 
-    project_scoped_tools = (
+    # Explicit CLI/env overrides always win
+    project_scoped_tools_explicit = (
         bool(args.project_scoped_tools)
         or os.environ.get("UNITY_MCP_PROJECT_SCOPED_TOOLS", "").lower() in ("true", "1", "yes", "on")
     )
+
+    # If not explicitly set, check Unity status files for the default instance
+    project_scoped_tools = project_scoped_tools_explicit
+    if not project_scoped_tools_explicit:
+        try:
+            from transport.legacy.unity_connection import get_unity_connection_pool
+            pool = get_unity_connection_pool()
+            instances = pool.discover_all_instances()
+            # If ANY discovered instance requests project-scoped tools, enable them
+            for inst in instances:
+                if getattr(inst, "project_scoped_tools", False):
+                    project_scoped_tools = True
+                    logger.info(
+                        "Enabling project-scoped tools because Unity instance %s requested it",
+                        inst.id,
+                    )
+                    break
+        except Exception:
+            pass
+
     mcp = create_mcp_server(project_scoped_tools)
 
     # Determine transport mode

--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -890,7 +890,8 @@ Examples:
         or os.environ.get("UNITY_MCP_PROJECT_SCOPED_TOOLS", "").lower() in ("true", "1", "yes", "on")
     )
 
-    # If not explicitly set, check Unity status files for the default instance
+    # If not explicitly set, check Unity status files for the default instance.
+    # In stdio mode there is typically only one instance, so "first match wins" is fine.
     project_scoped_tools = project_scoped_tools_explicit
     if not project_scoped_tools_explicit:
         try:
@@ -907,7 +908,7 @@ Examples:
                     )
                     break
         except Exception:
-            pass
+            logger.debug("Could not discover Unity instances for project-scoped tool default", exc_info=True)
 
     mcp = create_mcp_server(project_scoped_tools)
 

--- a/Server/src/models/models.py
+++ b/Server/src/models/models.py
@@ -42,6 +42,7 @@ class UnityInstanceInfo(BaseModel):
     status: str  # "running", "reloading", "offline"
     last_heartbeat: datetime | None = None
     unity_version: str | None = None
+    project_scoped_tools: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization"""
@@ -53,5 +54,6 @@ class UnityInstanceInfo(BaseModel):
             "port": self.port,
             "status": self.status,
             "last_heartbeat": self.last_heartbeat.isoformat() if self.last_heartbeat else None,
-            "unity_version": self.unity_version
+            "unity_version": self.unity_version,
+            "project_scoped_tools": self.project_scoped_tools,
         }

--- a/Server/src/services/custom_tool_service.py
+++ b/Server/src/services/custom_tool_service.py
@@ -327,6 +327,9 @@ class CustomToolService:
         return registered, replaced
 
     def register_global_tools(self, tools: list[ToolDefinitionModel]) -> None:
+        # Global custom tools are always registered, even when project-scoped tools
+        # are enabled. Project-scoped tools can override globals by name, but
+        # disabling globals entirely would break shared tooling that projects expect.
         builtin_names = self._get_builtin_tool_names()
         for tool in tools:
             if tool.name in builtin_names:

--- a/Server/src/services/custom_tool_service.py
+++ b/Server/src/services/custom_tool_service.py
@@ -327,8 +327,6 @@ class CustomToolService:
         return registered, replaced
 
     def register_global_tools(self, tools: list[ToolDefinitionModel]) -> None:
-        if self._project_scoped_tools:
-            return
         builtin_names = self._get_builtin_tool_names()
         for tool in tools:
             if tool.name in builtin_names:

--- a/Server/src/transport/legacy/port_discovery.py
+++ b/Server/src/transport/legacy/port_discovery.py
@@ -309,7 +309,8 @@ class PortDiscovery:
                     status="reloading" if is_reloading else "running",
                     last_heartbeat=last_heartbeat,
                     # May not be available in current version
-                    unity_version=data.get('unity_version')
+                    unity_version=data.get('unity_version'),
+                    project_scoped_tools=data.get('project_scoped_tools', False),
                 )
 
                 instances_by_port[port] = (instance, freshness)

--- a/docs/migrations/v8_NEW_NETWORKING_SETUP.md
+++ b/docs/migrations/v8_NEW_NETWORKING_SETUP.md
@@ -257,4 +257,5 @@ This was a big change, and it touches all the repo. So a lot of inefficiencies a
 - ~~Think about a structure of the MCP server some more. The `tools`, `resources` and `registry` folders make sense, but everything else just forms part of the high level repo. It's growing, so some thought about how we create modules will help with scalability.~~
   - This was done, Server folder is much more hierarchical and structured.
 - The way we register tools is a good platform for all tools to be defined by C#. Having all tools in the plugin makes it easier for us to maintain, the community to contribute, and users to modify this project to suit their needs. If all tools are registered from the plugin, we can allow users to select the tools they want to use, giving them even more control of their experience.
-  - Of course, we need some testing of this custom tool architecture to know if it can scale to all tools. Also, custom tool registration is only supported with HTTP, so we'll need to support this feature when the stdio protocol is being used.
+  - Of course, we need some testing of this custom tool architecture to know if it can scale to all tools. ~~Also, custom tool registration is only supported with HTTP, so we'll need to support this feature when the stdio protocol is being used.~~
+  - Custom tools now work in both HTTP and stdio transports.


### PR DESCRIPTION
## Description
This PR enables project-scoped custom tools ([McpForUnityTool]) to work when using the stdio transport, not just HTTP Local. Previously, stdio mode had no way to discover or register project-specific custom tools.

## Type of Change
Bug fix (non-breaking change that fixes an issue)

## Changes Made
**ToolDiscoveryService.cs** - Added AppDomain fallback scan in ToolDiscoveryService when TypeCache misses project assemblies after domain reloads
**StdioBridgeHost.cs** - Heartbeat JSON now includes project_scoped_tools flag so the server knows when a Unity instance wants project-scoped tooling
**models.py / port_discovery.py / main.py** — UnityInstanceInfo gains project_scoped_tools; PortDiscovery parses it from status JSON; server auto-enables project-scoped tools on startup when a discovered instance requests it
**custom_tool_service.py** - CustomToolService now registers global custom tools even when project-scoped tools are enabled
**v8_NEW_NETWORKING_SETUP.md** - Updated migration notes to reflect that custom tools now work in both HTTP and stdio transports

## Testing/Screenshots/Recordings
- [x]  Custom tools annotated with [McpForUnityTool] appear in the MCP tool list when using stdio transport
- [x]  No regression in HTTP Local transport custom tool discovery

## Documentation Updates
<!-- Check if you updated documentation for changes to tools/resources -->
- [x] I have added/removed/modified tools or resources
- [x] If yes, I have updated all documentation files using:
  - [x] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [x] Manual updates following the guide at `tools/UPDATE_DOCS.md`

(none of above apply)

## Related Issues
<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional Notes
If you would like to see any changes to this PR, please let me know and I will get to it! :) My personal motivation behind this PR is, Kimi Code plays poorly with HTTP so I'm forced to use stdio with it, and having support for custom MCP's would be nice to have. Changes made by Kimi-k2.6 and human reviewed (and tested in actual project) by me to make sure they make sense and don't introduce possible vulnerabilities or other issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project-scoped tools can be dynamically enabled from Unity instances via heartbeat signals.
  * Custom tools now work with both HTTP and stdio transports.
  * Per-project port discovery added for multi-project setups.

* **Improvements**
  * More resilient tool discovery with a broader scan, fallback and per-assembly error handling.
  * Global tools are now registered alongside project-scoped tools.

* **Documentation**
  * Docs updated to reflect cross-transport custom tool support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->