### PR TITLE
fix(build): avoid compile-time VisionOS enum references

### DIFF
--- a/MCPForUnity/Editor/Tools/Build/BuildTargetMapping.cs
+++ b/MCPForUnity/Editor/Tools/Build/BuildTargetMapping.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEditor;
 using UnityEditor.Build;
 
@@ -5,6 +6,8 @@ namespace MCPForUnity.Editor.Tools.Build
 {
     public static class BuildTargetMapping
     {
+        private const string VisionOSName = "VisionOS";
+
         public static bool TryResolveBuildTarget(string name, out BuildTarget target)
         {
             if (string.IsNullOrEmpty(name))
@@ -24,12 +27,8 @@ namespace MCPForUnity.Editor.Tools.Build
                 case "webgl": target = BuildTarget.WebGL; return true;
                 case "uwp": target = BuildTarget.WSAPlayer; return true;
                 case "tvos": target = BuildTarget.tvOS; return true;
-                // BuildTarget.VisionOS exists only in Unity 2023.2+ and late 2022.3 patches
-#if UNITY_2023_2_OR_NEWER
-                case "visionos": target = BuildTarget.VisionOS; return true;
-#endif
                 default:
-                    if (System.Enum.TryParse(name, true, out target))
+                    if (Enum.TryParse(name, true, out target))
                         return true;
                     target = default;
                     return false;
@@ -50,10 +49,14 @@ namespace MCPForUnity.Editor.Tools.Build
                 case BuildTarget.WebGL: return BuildTargetGroup.WebGL;
                 case BuildTarget.WSAPlayer: return BuildTargetGroup.WSA;
                 case BuildTarget.tvOS: return BuildTargetGroup.tvOS;
-#if UNITY_2023_2_OR_NEWER
-                case BuildTarget.VisionOS: return BuildTargetGroup.VisionOS;
-#endif
-                default: return BuildTargetGroup.Unknown;
+                default:
+                    if (IsVisionOSTarget(target)
+                        && Enum.TryParse(VisionOSName, true, out BuildTargetGroup visionOSGroup))
+                    {
+                        return visionOSGroup;
+                    }
+
+                    return BuildTargetGroup.Unknown;
             }
         }
 
@@ -67,10 +70,47 @@ namespace MCPForUnity.Editor.Tools.Build
             if (!TryResolveBuildTarget(name, out var buildTarget))
             {
                 namedTarget = default;
-                return $"Unknown build target: '{name}'. Valid targets: windows64, osx, linux64, android, ios, webgl, uwp, tvos, visionos";
+                return GetUnknownBuildTargetMessage(name);
             }
-            namedTarget = GetNamedBuildTarget(buildTarget);
+
+            var targetGroup = GetTargetGroup(buildTarget);
+            if (targetGroup == BuildTargetGroup.Unknown)
+            {
+                namedTarget = default;
+                return IsVisionOSTarget(buildTarget)
+                    ? "VisionOS build target is available, but its BuildTargetGroup is not exposed by this Unity editor installation."
+                    : $"Build target group could not be resolved for target '{buildTarget}'.";
+            }
+
+            namedTarget = NamedBuildTarget.FromBuildTargetGroup(targetGroup);
             return null;
+        }
+
+        public static string GetUnknownBuildTargetMessage(string name)
+        {
+            if (string.Equals(name, "visionos", StringComparison.OrdinalIgnoreCase))
+            {
+                return "VisionOS build target is not available in this Unity editor installation. "
+                    + "Install the visionOS build support module or use a Unity version/configuration that exposes BuildTarget.VisionOS.";
+            }
+
+            return $"Unknown build target: '{name}'. Valid targets: {GetValidTargetsList()}.";
+        }
+
+        private static string GetValidTargetsList()
+        {
+            string validTargets = "windows64, osx, linux64, android, ios, webgl, uwp, tvos";
+            if (Enum.TryParse(VisionOSName, true, out BuildTarget _))
+            {
+                validTargets += ", visionos";
+            }
+
+            return validTargets;
+        }
+
+        private static bool IsVisionOSTarget(BuildTarget target)
+        {
+            return string.Equals(target.ToString(), VisionOSName, StringComparison.OrdinalIgnoreCase);
         }
 
         public static string GetDefaultOutputPath(BuildTarget target, string productName)

--- a/MCPForUnity/Editor/Tools/Build/BuildTargetMapping.cs
+++ b/MCPForUnity/Editor/Tools/Build/BuildTargetMapping.cs
@@ -28,8 +28,11 @@ namespace MCPForUnity.Editor.Tools.Build
                 case "uwp": target = BuildTarget.WSAPlayer; return true;
                 case "tvos": target = BuildTarget.tvOS; return true;
                 default:
-                    if (Enum.TryParse(name, true, out target))
+                    if (TryParseDefinedBuildTarget(name, out target))
+                    {
                         return true;
+                    }
+
                     target = default;
                     return false;
             }
@@ -100,7 +103,7 @@ namespace MCPForUnity.Editor.Tools.Build
         private static string GetValidTargetsList()
         {
             string validTargets = "windows64, osx, linux64, android, ios, webgl, uwp, tvos";
-            if (Enum.TryParse(VisionOSName, true, out BuildTarget _))
+            if (TryParseDefinedBuildTarget(VisionOSName, out _))
             {
                 validTargets += ", visionos";
             }
@@ -111,6 +114,18 @@ namespace MCPForUnity.Editor.Tools.Build
         private static bool IsVisionOSTarget(BuildTarget target)
         {
             return string.Equals(target.ToString(), VisionOSName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryParseDefinedBuildTarget(string name, out BuildTarget target)
+        {
+            target = default;
+            if (int.TryParse(name, out _))
+            {
+                return false;
+            }
+
+            return Enum.TryParse(name, true, out target)
+                && Enum.IsDefined(typeof(BuildTarget), target);
         }
 
         public static string GetDefaultOutputPath(BuildTarget target, string productName)

--- a/MCPForUnity/Editor/Tools/ManageBuild.cs
+++ b/MCPForUnity/Editor/Tools/ManageBuild.cs
@@ -64,7 +64,7 @@ namespace MCPForUnity.Editor.Tools
 
             string targetName = p.Get("target");
             if (!BuildTargetMapping.TryResolveBuildTarget(targetName, out var target))
-                return new ErrorResponse($"Unknown target '{targetName}'.");
+                return new ErrorResponse(BuildTargetMapping.GetUnknownBuildTargetMessage(targetName));
 
             var group = BuildTargetMapping.GetTargetGroup(target);
             if (!BuildPipeline.IsBuildTargetSupported(group, target))
@@ -221,7 +221,7 @@ namespace MCPForUnity.Editor.Tools
 
             // Switch platform
             if (!BuildTargetMapping.TryResolveBuildTarget(targetName, out var target))
-                return new ErrorResponse($"Unknown target '{targetName}'.");
+                return new ErrorResponse(BuildTargetMapping.GetUnknownBuildTargetMessage(targetName));
 
             var group = BuildTargetMapping.GetTargetGroup(target);
             if (!BuildPipeline.IsBuildTargetSupported(group, target))
@@ -442,7 +442,7 @@ namespace MCPForUnity.Editor.Tools
                 foreach (var t in targets)
                 {
                     if (!BuildTargetMapping.TryResolveBuildTarget(t, out var bt))
-                        return new ErrorResponse($"Unknown target '{t}' in batch.");
+                        return new ErrorResponse(BuildTargetMapping.GetUnknownBuildTargetMessage(t));
                     var btGroup = BuildTargetMapping.GetTargetGroup(bt);
                     if (!BuildPipeline.IsBuildTargetSupported(btGroup, bt))
                         return new ErrorResponse(

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildTargetMappingTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildTargetMappingTests.cs
@@ -19,6 +19,12 @@ namespace MCPForUnity.Tests.EditMode.Tools
         }
 
         [Test]
+        public void TryResolveBuildTarget_NumericInputDoesNotResolve()
+        {
+            Assert.IsFalse(BuildTargetMapping.TryResolveBuildTarget("5", out _));
+        }
+
+        [Test]
         public void TryResolveNamedBuildTarget_UnknownTargetListsOnlyAvailableTargets()
         {
             string error = BuildTargetMapping.TryResolveNamedBuildTarget("not-a-target", out _);
@@ -46,10 +52,9 @@ namespace MCPForUnity.Tests.EditMode.Tools
             if (visionOSAvailable)
             {
                 Assert.IsTrue(BuildTargetMapping.TryResolveBuildTarget("visionos", out _));
-                if (error != null)
-                {
-                    StringAssert.Contains("VisionOS", error);
-                }
+                Assert.IsTrue(
+                    error == null || error.Contains("VisionOS"),
+                    $"Expected no error or a VisionOS-specific error, got: {error}");
             }
             else
             {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildTargetMappingTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildTargetMappingTests.cs
@@ -1,0 +1,62 @@
+using System;
+using MCPForUnity.Editor.Tools.Build;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace MCPForUnity.Tests.EditMode.Tools
+{
+    [TestFixture]
+    public class BuildTargetMappingTests
+    {
+        [TestCase("windows64", BuildTarget.StandaloneWindows64)]
+        [TestCase("macos", BuildTarget.StandaloneOSX)]
+        [TestCase("linux", BuildTarget.StandaloneLinux64)]
+        [TestCase("tvos", BuildTarget.tvOS)]
+        public void TryResolveBuildTarget_KnownAliasesResolve(string name, BuildTarget expected)
+        {
+            Assert.IsTrue(BuildTargetMapping.TryResolveBuildTarget(name, out var target));
+            Assert.AreEqual(expected, target);
+        }
+
+        [Test]
+        public void TryResolveNamedBuildTarget_UnknownTargetListsOnlyAvailableTargets()
+        {
+            string error = BuildTargetMapping.TryResolveNamedBuildTarget("not-a-target", out _);
+
+            Assert.IsNotNull(error);
+            StringAssert.Contains("windows64", error);
+
+            bool visionOSAvailable = Enum.TryParse("VisionOS", true, out BuildTarget _);
+            if (visionOSAvailable)
+            {
+                StringAssert.Contains("visionos", error);
+            }
+            else
+            {
+                Assert.IsFalse(error.Contains("visionos"));
+            }
+        }
+
+        [Test]
+        public void TryResolveNamedBuildTarget_VisionOSUnavailableReturnsHelpfulError()
+        {
+            bool visionOSAvailable = Enum.TryParse("VisionOS", true, out BuildTarget _);
+            string error = BuildTargetMapping.TryResolveNamedBuildTarget("visionos", out _);
+
+            if (visionOSAvailable)
+            {
+                Assert.IsTrue(BuildTargetMapping.TryResolveBuildTarget("visionos", out _));
+                if (error != null)
+                {
+                    StringAssert.Contains("VisionOS", error);
+                }
+            }
+            else
+            {
+                Assert.IsFalse(BuildTargetMapping.TryResolveBuildTarget("visionos", out _));
+                Assert.IsNotNull(error);
+                StringAssert.Contains("VisionOS build target is not available", error);
+            }
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildTargetMappingTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildTargetMappingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94419cfeebb59e84ea16331766eaad52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Description

Follow-up to #1063.

That PR fixed one part of the VisionOS compatibility problem by moving the direct enum references behind `UNITY_2023_2_OR_NEWER`. New reports in #1112, plus the later comment on #1063, show that this still is not quite safe: some Unity 2023.2.x installations do not expose `BuildTarget.VisionOS` / `BuildTargetGroup.VisionOS`, so the package can still fail to compile before Unity MCP is usable.

This changes the mapping to avoid compile-time references to the VisionOS enum values. VisionOS is now resolved by enum name at runtime, only when the current editor actually exposes it.

## Changes Made

- Remove direct `BuildTarget.VisionOS` and `BuildTargetGroup.VisionOS` references from `BuildTargetMapping`.
- Resolve VisionOS dynamically through `Enum.TryParse`.
- Keep normal build target aliases unchanged.
- Return a specific error when `visionos` is requested but unavailable in the current Unity installation.
- Add EditMode tests for known aliases and VisionOS available/unavailable behavior.

## Testing/Screenshots/Recordings

- `git diff --check`
- Unity `2022.3.4f1` batchmode compile of `TestProjects/UnityMCPTests` completed successfully:
  - `Tundra build success`
  - `Exiting batchmode successfully now!`

I did not run a real VisionOS build locally because I do not have the VisionOS build module/target installed. The positive path is preserved by resolving the enum by name when Unity exposes it.

## Documentation Updates

No tools or resources were added, removed, or modified.

## Related Issues

Fixes #1112
Follow-up to #1063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime support added for VisionOS build target detection across Unity versions.

* **Improvements**
  * Standardized and clarified "unknown build target" messages with more actionable guidance.

* **Tests**
  * Added unit tests covering build target resolution, unknown-target handling, and VisionOS availability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->