### PR TITLE
fix(roslyn): install missing System.Runtime.CompilerServices.Unsafe v6 + surface inner errors

### DIFF
--- a/MCPForUnity/Editor/Setup/RoslynInstaller.cs
+++ b/MCPForUnity/Editor/Setup/RoslynInstaller.cs
@@ -13,10 +13,14 @@ namespace MCPForUnity.Editor.Setup
 
         private static readonly (string packageId, string version, string dllPath, string dllName)[] NuGetEntries =
         {
-            ("microsoft.codeanalysis.common",    "4.12.0", "lib/netstandard2.0/Microsoft.CodeAnalysis.dll",       "Microsoft.CodeAnalysis.dll"),
-            ("microsoft.codeanalysis.csharp",    "4.12.0", "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.dll","Microsoft.CodeAnalysis.CSharp.dll"),
-            ("system.collections.immutable",     "8.0.0",  "lib/netstandard2.0/System.Collections.Immutable.dll", "System.Collections.Immutable.dll"),
-            ("system.reflection.metadata",       "8.0.0",  "lib/netstandard2.0/System.Reflection.Metadata.dll",   "System.Reflection.Metadata.dll"),
+            ("microsoft.codeanalysis.common",         "4.12.0", "lib/netstandard2.0/Microsoft.CodeAnalysis.dll",                   "Microsoft.CodeAnalysis.dll"),
+            ("microsoft.codeanalysis.csharp",         "4.12.0", "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.dll",            "Microsoft.CodeAnalysis.CSharp.dll"),
+            ("system.collections.immutable",          "8.0.0",  "lib/netstandard2.0/System.Collections.Immutable.dll",             "System.Collections.Immutable.dll"),
+            ("system.reflection.metadata",            "8.0.0",  "lib/netstandard2.0/System.Reflection.Metadata.dll",               "System.Reflection.Metadata.dll"),
+            // Transitive dep of Microsoft.CodeAnalysis.* on netstandard2.0. Without it, Roslyn's StringTable
+            // static cctor throws FileNotFoundException for v6.0.0.0 and every Roslyn entry point fails to
+            // initialize. Unity ships a v4.x of this assembly which does NOT satisfy the v6 reference.
+            ("system.runtime.compilerservices.unsafe","6.0.0",  "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",   "System.Runtime.CompilerServices.Unsafe.dll"),
         };
 
         public static bool IsInstalled()

--- a/MCPForUnity/Editor/Setup/RoslynInstaller.cs
+++ b/MCPForUnity/Editor/Setup/RoslynInstaller.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -28,8 +29,29 @@ namespace MCPForUnity.Editor.Setup
             string folder = Path.Combine(Application.dataPath, PluginsRelPath);
             foreach (var entry in NuGetEntries)
             {
-                if (!File.Exists(Path.Combine(folder, entry.dllName)))
+                string path = Path.Combine(folder, entry.dllName);
+                if (!File.Exists(path))
                     return false;
+
+                // Defense-in-depth: a stale DLL whose assembly version is older than what
+                // Roslyn references (e.g. a v4.x System.Runtime.CompilerServices.Unsafe
+                // shadowing the v6 we actually need) would still satisfy file-existence but
+                // leave Roslyn unable to load. Compare the on-disk assembly version against
+                // each entry's declared NuGet version, treating "older or unreadable" as not
+                // installed so Install() can rewrite it.
+                if (Version.TryParse(entry.version, out var requiredVersion))
+                {
+                    try
+                    {
+                        var actual = AssemblyName.GetAssemblyName(path).Version;
+                        if (actual == null || actual < requiredVersion)
+                            return false;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }
             }
             return true;
         }

--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -672,7 +672,13 @@ namespace MCPForUnity.Editor.Tools
             }
             catch (Exception e)
             {
-                errors.Add($"Roslyn compilation error: {e.Message}");
+                // Walk to the deepest cause: TargetInvocationException (and friends) wrap the real
+                // failure inside .InnerException, and reporting only e.Message hides everything
+                // useful (e.g. a missing transitive dep manifests as the generic "Exception has been
+                // thrown by the target of an invocation.").
+                Exception root = e;
+                while (root.InnerException != null) root = root.InnerException;
+                errors.Add($"Roslyn compilation error: {root.GetType().Name}: {root.Message}");
                 return null;
             }
         }


### PR DESCRIPTION
## Summary

The `RoslynInstaller` ships only 4 NuGet packages but `Microsoft.CodeAnalysis` 4.12.0 on netstandard2.0 also references `System.Runtime.CompilerServices.Unsafe` **v6.0.0.0**, which is **not** what Unity ships (Unity bundles a v4.x of that assembly). The reference is unresolved at runtime, so:

```
Roslyn.Utilities.StringTable..cctor()
  → SegmentedArray<T>..ctor()
    → FileNotFoundException: System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0
→ TypeInitializationException: 'Roslyn.Utilities.StringTable'
  → TypeInitializationException: 'Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree'
    → every parse / compile attempt throws TargetInvocationException
```

Worse, the failure is invisible: `RoslynCompiler.Compile`'s catch block logs only `e.Message`, and for `TargetInvocationException` that string is the generic _"Exception has been thrown by the target of an invocation."_ — the real cause in `InnerException` is silently dropped, so the install looks fine and `IsAvailable` returns `true`, but every actual compile fails with a useless message.

## Repro

1. Fresh project, run **Tools → MCP for Unity → Install Roslyn** (or however the install is triggered).
2. Use the MCP `execute_code` tool with `compiler="roslyn"` (or `auto`) on any C# 7+ snippet.
3. Result: `Compilation failed: Roslyn compilation error: Exception has been thrown by the target of an invocation.` — no other detail.
4. Drilling via reflection (replicating `Compile` step-by-step with proper `InnerException` walking) reveals the real chain shown above.

## Fix

* **`MCPForUnity/Editor/Setup/RoslynInstaller.cs`** — add the missing transitive dependency `system.runtime.compilerservices.unsafe` v6.0.0 to `NuGetEntries` so a fresh install drops 5 DLLs into `Assets/Plugins/Roslyn/` instead of 4. This makes `IsInstalled()` accurately reflect "Roslyn will actually load".
* **`MCPForUnity/Editor/Tools/ExecuteCode.cs`** — in `RoslynCompiler.Compile`'s outer catch, walk the `InnerException` chain to the deepest cause and report `Type.Name + Message` of that root, instead of the generic wrapper. This makes future bootstrap regressions debuggable from the tool output alone.

## Verification

Tested on Unity 2022.3 / Windows / netstandard2.0 build target:

1. Before patch: Roslyn `IsAvailable=True`, every parse fails with the generic message.
2. Removed local `Assets/Plugins/Roslyn/`, ran the patched installer → 5 DLLs present.
3. Forced a domain reload (the cached `TypeInitializationException` would otherwise persist for the AppDomain lifetime).
4. After patch: `execute_code` with `compiler="roslyn"` compiles C# 7+ snippets (`var`, `?.`, `??`, string interpolation) and runs them successfully.

## Notes

* The transitive dep is also pulled by `System.Reflection.Metadata` 8.0.0 and `System.Memory`, but the Roslyn IL references the specific `Version=6.0.0.0` ref-assembly — there is no binding redirect, and Unity's bundled `System.Runtime.CompilerServices.Unsafe` doesn't satisfy a strong-named v6 reference.
* No behavior changes for users who already have Roslyn working (e.g. via a binding redirect or a different plugins layout) — the new entry is additive.
* The `catch` change is purely diagnostic; it never alters whether compilation succeeds, only what gets surfaced when it doesn't.

## Test plan

- [ ] On a fresh project (no `Assets/Plugins/Roslyn/`), run the installer → confirm 5 DLLs are present.
- [ ] Restart the Editor (force domain reload).
- [ ] Execute a Roslyn-only snippet via `execute_code` → confirm success.
- [ ] (Negative) Manually delete `System.Runtime.CompilerServices.Unsafe.dll` and try again → confirm the error message now reports `FileNotFoundException` directly instead of the generic invocation wrapper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler error reporting to surface the root exception type and message for clearer troubleshooting.
  * Installer now verifies on-disk assembly versions and treats missing/outdated or unreadable assemblies as not installed, ensuring correct reinstalls.

* **Chores**
  * Added required runtime dependency to the installation list and adjusted related installer configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1116)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->