### PR TITLE
fix: declare required Unity module dependencies

### DIFF
--- a/MCPForUnity/package.json
+++ b/MCPForUnity/package.json
@@ -7,6 +7,9 @@
   "documentationUrl": "https://github.com/CoplayDev/unity-mcp",
   "licensesUrl": "https://github.com/CoplayDev/unity-mcp/blob/main/LICENSE",
   "dependencies": {
+    "com.unity.modules.imageconversion": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0",
+    "com.unity.modules.screencapture": "1.0.0",
     "com.unity.nuget.newtonsoft-json": "3.0.2",
     "com.unity.test-framework": "1.1.31"
   },

--- a/MCPForUnity/package.json
+++ b/MCPForUnity/package.json
@@ -7,9 +7,13 @@
   "documentationUrl": "https://github.com/CoplayDev/unity-mcp",
   "licensesUrl": "https://github.com/CoplayDev/unity-mcp/blob/main/LICENSE",
   "dependencies": {
+    "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.imageconversion": "1.0.0",
+    "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.physics2d": "1.0.0",
+    "com.unity.modules.uielements": "1.0.0",
     "com.unity.modules.screencapture": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0",
     "com.unity.nuget.newtonsoft-json": "3.0.2",
     "com.unity.test-framework": "1.1.31"
   },


### PR DESCRIPTION
## Summary

Adds missing built-in Unity module dependencies to the MCP for Unity package manifest:

- `com.unity.modules.imageconversion`
- `com.unity.modules.physics2d`
- `com.unity.modules.screencapture`

## Root Cause

`MCPForUnity.Runtime` directly uses APIs from these modules:

- `Texture2D.EncodeToPNG()` from Image Conversion
- `Physics2D` from Physics 2D
- `ScreenCapture` from Screen Capture

Projects that do not already enable these built-in modules can fail script compilation after installing the package.

## Validation

Validated in a Unity `6000.3.15f1` project that originally failed compiling `MCPForUnity.Runtime` with missing module references. After declaring the dependencies, Unity Package Manager resolved the three built-in modules and batchmode script compilation completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended project dependencies to include additional Unity modules: animation, image conversion, physics (3D), 2D physics, UI Elements, screen capture, and web request handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->