### PR TITLE
Fix Memory Profiler snapshot actions on Unity 6

### DIFF
--- a/MCPForUnity/Editor/Tools/Profiler/Operations/MemorySnapshotOps.cs
+++ b/MCPForUnity/Editor/Tools/Profiler/Operations/MemorySnapshotOps.cs
@@ -95,12 +95,13 @@ namespace MCPForUnity.Editor.Tools.Profiler
                     }
                 };
 
-                int paramCount = takeMethod.GetParameters().Length;
-                if (paramCount == 4 && captureFlagsType != null)
+                var takeMethodParams = takeMethod.GetParameters();
+                int paramCount = takeMethodParams.Length;
+                if (paramCount == 4 && takeMethodParams[3].ParameterType == captureFlagsType)
                     takeMethod.Invoke(null, new object[] { snapshotPath, callback, null, Enum.ToObject(captureFlagsType, 0) });
-                else if (paramCount == 3 && captureFlagsType != null)
+                else if (paramCount == 3 && takeMethodParams[2].ParameterType == captureFlagsType)
                     takeMethod.Invoke(null, new object[] { snapshotPath, callback, Enum.ToObject(captureFlagsType, 0) });
-                else if (paramCount == 4)
+                else if (paramCount == 4 && takeMethodParams[3].ParameterType == typeof(uint))
                     takeMethod.Invoke(null, new object[] { snapshotPath, callback, null, 0u });
                 else if (paramCount == 2)
                     takeMethod.Invoke(null, new object[] { snapshotPath, callback });

--- a/MCPForUnity/Editor/Tools/Profiler/Operations/MemorySnapshotOps.cs
+++ b/MCPForUnity/Editor/Tools/Profiler/Operations/MemorySnapshotOps.cs
@@ -11,7 +11,9 @@ namespace MCPForUnity.Editor.Tools.Profiler
     internal static class MemorySnapshotOps
     {
         private static readonly Type MemoryProfilerType =
-            Type.GetType("Unity.MemoryProfiler.MemoryProfiler, Unity.MemoryProfiler.Editor");
+            Type.GetType("Unity.Profiling.Memory.MemoryProfiler, UnityEngine.CoreModule")
+            ?? Type.GetType("UnityEngine.Profiling.Memory.Experimental.MemoryProfiler, UnityEngine.CoreModule")
+            ?? Type.GetType("Unity.MemoryProfiler.MemoryProfiler, Unity.MemoryProfiler.Editor");
 
         private static bool HasPackage => MemoryProfilerType != null;
 
@@ -35,11 +37,30 @@ namespace MCPForUnity.Editor.Tools.Profiler
             try
             {
                 var debugScreenCaptureType = Type.GetType(
-                    "Unity.Profiling.Memory.Experimental.DebugScreenCapture, Unity.MemoryProfiler.Editor");
+                    "Unity.Profiling.DebugScreenCapture, UnityEngine.CoreModule")
+                    ?? Type.GetType("UnityEngine.Profiling.Experimental.DebugScreenCapture, UnityEngine.CoreModule")
+                    ?? Type.GetType("Unity.Profiling.Memory.Experimental.DebugScreenCapture, Unity.MemoryProfiler.Editor");
+                var captureFlagsType = Type.GetType(
+                    "Unity.Profiling.Memory.CaptureFlags, UnityEngine.CoreModule")
+                    ?? Type.GetType("UnityEngine.Profiling.Memory.Experimental.CaptureFlags, UnityEngine.CoreModule");
 
                 System.Reflection.MethodInfo takeMethod = null;
 
-                if (debugScreenCaptureType != null)
+                if (debugScreenCaptureType != null && captureFlagsType != null)
+                {
+                    var screenshotCallbackType = typeof(Action<,,>).MakeGenericType(
+                        typeof(string), typeof(bool), debugScreenCaptureType);
+                    takeMethod = MemoryProfilerType.GetMethod("TakeSnapshot",
+                        new[] { typeof(string), typeof(Action<string, bool>), screenshotCallbackType, captureFlagsType });
+                }
+
+                if (takeMethod == null && captureFlagsType != null)
+                {
+                    takeMethod = MemoryProfilerType.GetMethod("TakeSnapshot",
+                        new[] { typeof(string), typeof(Action<string, bool>), captureFlagsType });
+                }
+
+                if (takeMethod == null && debugScreenCaptureType != null)
                 {
                     var screenshotCallbackType = typeof(Action<,,>).MakeGenericType(
                         typeof(string), typeof(bool), debugScreenCaptureType);
@@ -49,7 +70,6 @@ namespace MCPForUnity.Editor.Tools.Profiler
 
                 if (takeMethod == null)
                 {
-                    // Try 2-param overload: TakeSnapshot(string, Action<string, bool>)
                     takeMethod = MemoryProfilerType.GetMethod("TakeSnapshot",
                         new[] { typeof(string), typeof(Action<string, bool>) });
                 }
@@ -76,7 +96,11 @@ namespace MCPForUnity.Editor.Tools.Profiler
                 };
 
                 int paramCount = takeMethod.GetParameters().Length;
-                if (paramCount == 4)
+                if (paramCount == 4 && captureFlagsType != null)
+                    takeMethod.Invoke(null, new object[] { snapshotPath, callback, null, Enum.ToObject(captureFlagsType, 0) });
+                else if (paramCount == 3 && captureFlagsType != null)
+                    takeMethod.Invoke(null, new object[] { snapshotPath, callback, Enum.ToObject(captureFlagsType, 0) });
+                else if (paramCount == 4)
                     takeMethod.Invoke(null, new object[] { snapshotPath, callback, null, 0u });
                 else if (paramCount == 2)
                     takeMethod.Invoke(null, new object[] { snapshotPath, callback });
@@ -98,9 +122,6 @@ namespace MCPForUnity.Editor.Tools.Profiler
 
         internal static object ListSnapshots(JObject @params)
         {
-            if (!HasPackage)
-                return PackageMissingError();
-
             var p = new ToolParams(@params);
             string searchPath = p.Get("search_path");
 
@@ -141,9 +162,6 @@ namespace MCPForUnity.Editor.Tools.Profiler
 
         internal static object CompareSnapshots(JObject @params)
         {
-            if (!HasPackage)
-                return PackageMissingError();
-
             var p = new ToolParams(@params);
             var pathAResult = p.GetRequired("snapshot_a");
             if (!pathAResult.IsSuccess)


### PR DESCRIPTION
## Description
Fixes Memory Profiler MCP snapshot actions on Unity 6, where `MemoryProfiler.TakeSnapshot` is exposed from `UnityEngine.CoreModule` with `CaptureFlags` overloads instead of the older `Unity.MemoryProfiler.Editor` reflection path.

This resolves cases where `com.unity.memoryprofiler` is installed, but MCP still returns “Package com.unity.memoryprofiler is required.”

## Type of Change
Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Resolve `MemoryProfiler` from Unity 6/CoreModule API paths before falling back to the legacy editor assembly path.
- Support `TakeSnapshot` overloads that use `CaptureFlags`.
- Keep legacy overload fallbacks for older Unity versions.
- Verify the selected overload parameter type before invoking it, so Unity 6 `CaptureFlags` overloads and legacy `uint` overloads cannot be mixed.
- Allow `memory_list_snapshots` and `memory_compare_snapshots` to run without MemoryProfiler type discovery, since they only read `.snap` file metadata.

## Testing/Screenshots/Recordings
- Ran `uv run --extra dev pytest tests/test_manage_profiler.py -v`
  - Result: 40 passed
- Verified in a Unity 6 project with `com.unity.memoryprofiler` installed:
  - `memory_take_snapshot`
  - `memory_list_snapshots`
  - `memory_compare_snapshots`
  - `profiler_status`
  - `get_frame_timing`
  - `get_counters`
  - `frame_debugger_get_events`
- Verified error paths for missing snapshot files and missing compare parameters.
- Verified Unity 6 reflection exposes:
  - `Unity.Profiling.Memory.MemoryProfiler`
  - `TakeSnapshot(string, Action<string, bool>, CaptureFlags)`
  - `TakeSnapshot(string, Action<string, bool>, Action<string, bool, DebugScreenCapture>, CaptureFlags)`

## Documentation Updates
- [ ] I have added/removed/modified tools or resources

## Related Issues

## Additional Notes
The Memory Profiler list and compare actions only operate on snapshot file metadata, so they should not fail just because runtime MemoryProfiler type discovery fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory profiler detection to support additional Unity versions and configuration variants
  * Improved memory snapshot capture to work seamlessly with various Unity API implementations
  * Refined snapshot operations to handle edge cases more reliably across different system configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1125)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->