### PR TITLE
fix: correct scene_view positioned capture instructions

### DIFF
--- a/unity-mcp-skill/SKILL.md
+++ b/unity-mcp-skill/SKILL.md
@@ -98,10 +98,31 @@ manage_camera(action="screenshot", capture_source="scene_view", include_image=Tr
 manage_camera(action="screenshot", capture_source="scene_view", view_target="Canvas", include_image=True)
 ```
 
+> **Warning — `scene_view` + `view_position` unsupported:** Passing `view_position` or `view_rotation` with `capture_source="scene_view"` returns an error — these parameters are not valid for scene view capture. To take a positioned Scene View screenshot, first use `execute_code` with `SceneView.LookAt()` to move the Scene View, then capture the Scene View as-is with no framing or position parameters:
+>
+> ```csharp
+> // Run via execute_code to reposition the scene view
+> var sv = UnityEditor.SceneView.lastActiveSceneView
+>     ?? UnityEditor.EditorWindow.GetWindow<UnityEditor.SceneView>();
+> sv.Focus();
+> sv.LookAt(new Vector3(0, 0, 0), Quaternion.Euler(60, 30, 0), 400f);
+> sv.orthographic = false;
+> UnityEditor.SceneView.RepaintAll();
+> return "positioned";
+> ```
+>
+> ```python
+> # Capture the Scene View as-is — do not pass view_target, view_position, or view_rotation,
+> # as view_target would re-frame the viewport and override the LookAt() setup above.
+> manage_camera(action="screenshot", capture_source="scene_view", include_image=True)
+> ```
+>
+> `LookAt(pivot, rotation, size)`: pivot = world-space orbit point; rotation = Euler angles (x=pitch, y=yaw; 90° pitch = top-down); size = zoom/distance.
+
 **Best practices for AI scene understanding:**
 - Use `include_image=True` when you need to *see* the scene, not just save a file.
 - Use `batch="surround"` for a comprehensive overview (6 angles, one command).
-- Use `view_target`/`view_position` to capture from a specific viewpoint without needing a scene camera.
+- Use `view_target`/`view_position` to capture from a specific viewpoint without needing a scene camera. Note: `view_position` and `view_rotation` are **incompatible with `capture_source="scene_view"`** and return an error — use `SceneView.LookAt()` via `execute_code` instead (see warning above). `view_target` is supported with `scene_view`.
 - Use `capture_source="scene_view"` to see the editor viewport (gizmos, wireframes, grid).
 - Keep `max_resolution` at 256–512 to balance quality vs. token cost.
 

--- a/unity-mcp-skill/SKILL.md
+++ b/unity-mcp-skill/SKILL.md
@@ -105,8 +105,7 @@ manage_camera(action="screenshot", capture_source="scene_view", view_target="Can
 > var sv = UnityEditor.SceneView.lastActiveSceneView
 >     ?? UnityEditor.EditorWindow.GetWindow<UnityEditor.SceneView>();
 > sv.Focus();
-> sv.LookAt(new Vector3(0, 0, 0), Quaternion.Euler(60, 30, 0), 400f);
-> sv.orthographic = false;
+> sv.LookAt(new Vector3(0, 0, 0), Quaternion.Euler(60, 30, 0), 400f, false, true);
 > UnityEditor.SceneView.RepaintAll();
 > return "positioned";
 > ```
@@ -117,7 +116,7 @@ manage_camera(action="screenshot", capture_source="scene_view", view_target="Can
 > manage_camera(action="screenshot", capture_source="scene_view", include_image=True)
 > ```
 >
-> `LookAt(pivot, rotation, size)`: pivot = world-space orbit point; rotation = Euler angles (x=pitch, y=yaw; 90° pitch = top-down); size = zoom/distance.
+> `LookAt(pivot, rotation, size, ortho, instant)`: pivot = world-space orbit point; rotation = Euler angles (x=pitch, y=yaw; 90° pitch = top-down); size = zoom/distance; ortho = orthographic mode; instant = apply immediately for deterministic screenshots.
 
 **Best practices for AI scene understanding:**
 - Use `include_image=True` when you need to *see* the scene, not just save a file.


### PR DESCRIPTION
Document that `view_position` and `view_rotation` are invalid with `capture_source="scene_view"`, and show the `SceneView.LookAt()` workflow for taking positioned Scene View screenshots.

## Description
Clarifies the Unity MCP skill guidance for taking positioned Scene View screenshots. `view_position` and `view_rotation` are not valid with `capture_source="scene_view"`, so the docs now show the correct workflow: move the Scene View with `UnityEditor.SceneView.LookAt()` first, then capture the Scene View as-is.

## Type of Change
- Bug fix (non-breaking change that fixes an issue)
- Documentation update

## Changes Made
- Added a warning that `view_position` and `view_rotation` return an error when used with `capture_source="scene_view"`.
- Added a `SceneView.LookAt()` example using `execute_code` to position the Scene View before capture.
- Clarified that the follow-up `manage_camera` call should not pass `view_target`, `view_position`, or `view_rotation` when capturing the positioned Scene View as-is.
- Updated the best-practices note to distinguish unsupported `view_position`/`view_rotation` from supported `view_target` framing.

## Testing/Screenshots/Recordings
Not run. Documentation-only change.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`

## Related Issues
None.

## Additional Notes
This change does not modify tool behavior. It corrects agent-facing instructions so positioned Scene View screenshots use the supported `SceneView.LookAt()` workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Scene View camera positioning via standard capture operations does not accept framing/positioning parameters; attempting to use them will fail.
  * Added an alternative workflow showing how to reposition the Scene View first (via an execution step) and then capture without framing parameters.
  * Updated best-practices to reflect Scene View compatibility nuances and supported targeting options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1126)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->