### PR TITLE
fix: register undo when deleting GameObjects via manage_gameobject

### DIFF
--- a/MCPForUnity/Editor/Tools/GameObjects/GameObjectDelete.cs
+++ b/MCPForUnity/Editor/Tools/GameObjects/GameObjectDelete.cs
@@ -26,10 +26,7 @@ namespace MCPForUnity.Editor.Tools.GameObjects
                 {
                     string goName = targetGo.name;
                     int goId = targetGo.GetInstanceIDCompat();
-                    // Note: Undo.DestroyObjectImmediate doesn't work reliably in test context,
-                    // so we use Object.DestroyImmediate. This means delete isn't undoable.
-                    // TODO: Investigate Undo.DestroyObjectImmediate behavior in Unity 2022+
-                    Object.DestroyImmediate(targetGo);
+                    Undo.DestroyObjectImmediate(targetGo);
                     deletedObjects.Add(new { name = goName, instanceID = goId });
                 }
             }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageGameObjectDeleteTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageGameObjectDeleteTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using Newtonsoft.Json.Linq;
 using MCPForUnity.Editor.Tools.GameObjects;
@@ -372,6 +373,35 @@ namespace MCPForUnityTests.Editor.Tools
             // Clean up only survivors from tracking
             if (!target1Deleted) testObjects.Remove(target1);
             if (!target2Deleted) testObjects.Remove(target2);
+        }
+
+        #endregion
+
+        #region Undo Tests
+
+        [Test]
+        public void Delete_RegistersUndo_RestoresOnUndo()
+        {
+            var target = CreateTestObject("UndoRoundtrip");
+
+            var p = new JObject
+            {
+                ["action"] = "delete",
+                ["target"] = "UndoRoundtrip",
+                ["searchMethod"] = "by_name"
+            };
+
+            var result = ManageGameObject.HandleCommand(p);
+            var resultObj = result as JObject ?? JObject.FromObject(result);
+            Assert.IsTrue(resultObj.Value<bool>("success"), resultObj.ToString());
+            Assert.IsNull(GameObject.Find("UndoRoundtrip"), "Object should be deleted before undo");
+            testObjects.Remove(target);
+
+            Undo.PerformUndo();
+
+            var restored = GameObject.Find("UndoRoundtrip");
+            Assert.IsNotNull(restored, "Undo should restore deleted GameObject");
+            testObjects.Add(restored);
         }
 
         #endregion


### PR DESCRIPTION
## Summary

`manage_gameobject(action="delete")` calls `Object.DestroyImmediate` directly, bypassing Unity's undo stack — so `manage_editor(action="undo")` cannot recover GameObjects deleted via MCP. This one-line fix switches to `Undo.DestroyObjectImmediate`, restoring expected editor-undo behavior with full reference-graph restoration.

The package already uses `Undo.DestroyObjectImmediate` correctly elsewhere — `ComponentOps.cs:130`, `GameObjectComponentHelpers.cs:88,137`. `GameObjectDelete.cs` was the outlier.

## Why the existing comment was stale

```csharp
// Note: Undo.DestroyObjectImmediate doesn't work reliably in test context,
// so we use Object.DestroyImmediate. This means delete isn't undoable.
// TODO: Investigate Undo.DestroyObjectImmediate behavior in Unity 2022+
```

`package.json` targets `unity: "2021.3"`. The TODO is from that era — `Undo.DestroyObjectImmediate` has been stable across all currently-supported Unity versions. The new undo test plus the existing 11-test baseline pass without regression on Unity 6000.3.10f1.

## Tests

Added `Delete_RegistersUndo_RestoresOnUndo` to the existing `ManageGameObjectDeleteTests` class — creates a GameObject via `new GameObject(name)` (no prior undo registration), invokes the delete handler, asserts the object is gone, calls `Undo.PerformUndo()`, asserts restoration.

## Verified

- [x] Existing 11 `ManageGameObjectDeleteTests` still pass
- [x] New undo test passes
- [x] Live MCP roundtrip on Unity 6000.3.10f1: `manage_gameobject(action="delete")` → `manage_editor(action="undo")` restores the object with the same `instanceID`

## Related, not included

`ManagePrefabs.cs` has several other raw `Object.DestroyImmediate` call sites (lines ~881, ~1112, ~1119, ~1136, ~1148, ~1198) with the same bug shape — they deserve a separate audit/PR. Kept out of this change to keep scope tight to the `manage_gameobject` delete path.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GameObject deletion operations now properly integrate with Unity's Undo/Redo system, allowing users to undo delete actions.

* **Tests**
  * Added test coverage verifying GameObject deletion operations register correctly with the Undo system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->