### PR TITLE
fix(prefabs): wire missing C# handler for editor/prefab-stage resource

### DIFF
--- a/MCPForUnity/Editor/Resources/Editor/GetPrefabStage.cs
+++ b/MCPForUnity/Editor/Resources/Editor/GetPrefabStage.cs
@@ -1,0 +1,43 @@
+using System;
+using MCPForUnity.Editor.Helpers;
+using Newtonsoft.Json.Linq;
+using UnityEditor.SceneManagement;
+
+namespace MCPForUnity.Editor.Resources.Editor
+{
+    /// <summary>
+    /// Returns information about the currently open Prefab Stage (Isolation or
+    /// In-Context mode), or { isOpen = false } when no prefab is being edited.
+    ///
+    /// Wires up the existing <c>mcpforunity://editor/prefab-stage</c> resource
+    /// (Server/src/services/resources/prefab_stage.py) which dispatches the
+    /// <c>get_prefab_stage</c> command name expected by this handler.
+    /// </summary>
+    [McpForUnityResource("get_prefab_stage")]
+    public static class GetPrefabStage
+    {
+        public static object HandleCommand(JObject @params)
+        {
+            try
+            {
+                var stage = PrefabStageUtility.GetCurrentPrefabStage();
+                if (stage == null)
+                    return new SuccessResponse("No prefab stage open.", new { isOpen = false });
+
+                var root = stage.prefabContentsRoot;
+                return new SuccessResponse("Retrieved prefab stage info.", new
+                {
+                    isOpen = true,
+                    assetPath = stage.assetPath,
+                    prefabRootName = root != null ? root.name : null,
+                    mode = stage.mode.ToString(),
+                    isDirty = stage.scene.isDirty,
+                });
+            }
+            catch (Exception e)
+            {
+                return new ErrorResponse($"Error getting prefab stage: {e.Message}");
+            }
+        }
+    }
+}

--- a/MCPForUnity/Editor/Resources/Editor/GetPrefabStage.cs.meta
+++ b/MCPForUnity/Editor/Resources/Editor/GetPrefabStage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bbcba512cf6473184c038e6e3926136
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Description

The `mcpforunity://editor/prefab-stage` resource was wired Python-side in PR #1013 ("Prefab stages integration") via `Server/src/services/resources/prefab_stage.py`, but its dispatched `get_prefab_stage` command name was never given a C# handler. Reading the resource hits `CommandRegistry`'s not-found throw with:

```
Unknown or unsupported command type: get_prefab_stage
```

This change adds the missing handler at `MCPForUnity/Editor/Resources/Editor/GetPrefabStage.cs`, returning the 5 fields the Python `PrefabStageResponse` pydantic model expects (`isOpen`, `assetPath`, `prefabRootName`, `mode`, `isDirty`) via `PrefabStageUtility.GetCurrentPrefabStage()`. Mirrors the `EditorState.cs` sibling resource's shape exactly.

No Python-side or schema changes required — the existing Python resource already dispatches the correct command name.

## Type of Change

- [x] **Bug fix** (non-breaking change that fixes an issue)

## Changes Made

- **Added** `MCPForUnity/Editor/Resources/Editor/GetPrefabStage.cs` — new `[McpForUnityResource("get_prefab_stage")]` static class with `HandleCommand(JObject @params)` method
  - Calls `PrefabStageUtility.GetCurrentPrefabStage()`
  - Returns `{ isOpen = false }` when no stage open
  - Returns the 5 documented fields when a stage IS open (`mode.ToString()` produces `"InIsolation"` or `"InContext"`)
  - Null-guards `prefabContentsRoot` for the (rare) domain-reload edge case
- **Added** `MCPForUnity/Editor/Resources/Editor/GetPrefabStage.cs.meta` — Unity asset meta with fresh GUID

## Testing/Screenshots/Recordings

Tested end-to-end against a local Unity 6 (Unity 6000.4.0f1) project running the patched package via UPM git URL pointing at this branch.

**Test 1 — prefab open in isolation mode** (`Assets/UI/Prefabs/Buttons/SmallCardFrame.prefab` double-clicked):

```
ReadMcpResourceTool(server="UnityMCP", uri="mcpforunity://editor/prefab-stage")
→ {
    "success": true,
    "message": "Retrieved prefab stage info.",
    "error": null,
    "data": {
      "isOpen": true,
      "assetPath": "Assets/UI/Prefabs/Buttons/SmallCardFrame.prefab",
      "prefabRootName": "SmallCardFrame",
      "mode": "InIsolation",
      "isDirty": false
    },
    "hint": null
  }
```

All 5 fields populate correctly. `mode="InIsolation"` confirms `stage.mode.ToString()` produces the string form the pydantic model expects. Python `PrefabStageResponse.data` validates cleanly through `parse_resource_response`.

**Test 2 — no prefab open**: trivially covered by the single null-check branch (`if (stage == null) return new SuccessResponse(..., new { isOpen = false })`); not exercised live in testing since no logic could differ from the inspection-evident path.

## Documentation Updates

- [x] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual updates following the guide at `tools/UPDATE_DOCS.md`

**Rationale for unchecked docs sub-boxes**: This is a bug-fix wiring a previously-shipped resource (`editor_prefab_stage` is already listed in `README.md` line 103's Available Resources, added by PR #1013). No new resource is introduced. Verified that recent bug-fix PRs (#1106, #1103) do not touch `README.md` or `manifest.json` — those documents are reserved for feature releases per repo convention. `manifest.json` `tools` array doesn't list resources, so no entry to add. `docs/i18n/README-zh.md` mirrors README and needs no change either. Happy to add a "Recent Updates" entry if reviewer prefers — current convention seems to reserve those for new tools/resources.

## Related Issues

No existing GitHub issue references this bug (searched via `gh search prs --repo CoplayDev/unity-mcp 'prefab stage'`). Considered filing one but decided a direct PR with the fix is lower-friction since the root cause and remedy are both trivial to verify from the source.

## Additional Notes

**Root cause analysis** (in case it helps future maintainers): the orphan came from PR #1013. That PR introduced the prefab-stages feature, adding the Python resource (`Server/src/services/resources/prefab_stage.py`) and three Unity-side action handlers in `ManagePrefabs.cs` (`open_prefab_stage`, `save_prefab_stage`, `close_prefab_stage`). The fourth action — `get_prefab_stage` — was scoped as a read-state RESOURCE (not a tool action), so it sits in `MCPForUnity/Editor/Resources/Editor/` alongside `EditorState.cs` rather than as an action under `ManagePrefabs.HandleCommand`. The resource description in `mcpforunity://prefab-api` describes the expected 5-field return shape, which this PR delivers.

**Tests**: No test files added. Verified that none of the 19 sibling `[McpForUnityResource]` handlers across the codebase have associated C# unit tests (`MCPForUnity/Editor/Resources/**` has no `*Tests.cs` files for any handler; `TestProjects/UnityMCPTests/Assets/Tests/EditMode/` covers `Tools/` only). No Python test exists for `prefab_stage.py` either. Following established precedent of no per-handler tests for resources.

**Compatibility**: `PrefabStageUtility.GetCurrentPrefabStage()` and the `PrefabStage.assetPath` / `prefabContentsRoot` / `mode` / `scene.isDirty` API surface have all been stable since Unity 2018.3 and exist on the documented minimum supported version (Unity 2021.3 LTS+ per `README.md`). No backwards-compatibility shim needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to query the current prefab stage state in the Unity Editor: reports whether a prefab stage is open, the prefab asset path, the prefab root name (if any), the editor edit mode, and whether there are unsaved changes.
  * Queries now provide clear success/failure responses for robust handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->