### PR TITLE
Document optional Armorer Guard MCP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,32 @@ If auto-setup doesn't work, add this to your MCP client's config file:
 }
 ```
 
+**macOS/Linux with a local tool-call guard:**
+```json
+{
+  "mcpServers": {
+    "unityMCP": {
+      "command": "armorer-guard",
+      "args": [
+        "mcp-proxy",
+        "--",
+        "uvx",
+        "--from",
+        "mcpforunityserver",
+        "mcp-for-unity",
+        "--transport",
+        "stdio"
+      ]
+    }
+  }
+}
+```
+
+This optional configuration uses [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard)
+as a local MCP proxy to inspect tool-call arguments for prompt injection,
+credential leakage, exfiltration risk, and dangerous actions before forwarding
+safe calls to Unity MCP.
+
 **Windows:**
 ```json
 {


### PR DESCRIPTION
Adds an optional macOS/Linux stdio configuration showing how to wrap Unity MCP with `armorer-guard mcp-proxy -- ...`.

This gives Unity MCP users a local pre-call guardrail for prompt injection, credential leakage, exfiltration risk, and dangerous actions before requests reach the Unity MCP server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for an optional macOS/Linux configuration to route tool execution through a security-focused proxy. The proxy inspects arguments for prompt injection, credential leakage, exfiltration risks, and dangerous actions before processing requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->