### PR TITLE
ci: tier Unity test matrix + local parity check (#1107)

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -35,12 +35,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Mirror the testAllModes gate: skip matrix work on unauthorized fork PRs so we don't waste
-    # CI minutes (or check out fork code) on labels that aren't 'safe-to-test'.
+    # Gate (mirrored by testAllModes below):
+    #   - Always run for non-PR triggers (push / workflow_call / workflow_dispatch).
+    #   - Fork PRs: require 'safe-to-test' to be applied (existing secret-safety gate);
+    #     'run-wide-matrix' may be added on top to opt into the full 4-version matrix.
+    #   - In-repo PRs: only re-run via pull_request_target when 'run-wide-matrix' is the
+    #     label that just fired (the push-event run already covered the default leg).
     if: >
       github.event_name != 'pull_request_target' ||
-      (github.event.pull_request.head.repo.full_name != github.repository &&
-       github.event.label.name == 'safe-to-test')
+      (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
+        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'run-wide-matrix')
+      ) ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.label.name == 'run-wide-matrix'
+      )
     outputs:
       versions: ${{ steps.set.outputs.versions }}
     steps:
@@ -56,18 +67,21 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          WIDE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-wide-matrix') }}
         run: |
           set -euo pipefail
-          # Wide matrix on beta-push, workflow_call (release pipelines), and manual dispatch.
-          # Narrow (floor only) on PRs and feature-branch pushes to keep PR feedback fast.
+          # Wide matrix on: beta push, workflow_call (release pipelines), workflow_dispatch,
+          # or any PR labeled with 'run-wide-matrix'.
+          # Narrow (defaultVersion from tools/unity-versions.json) otherwise — fast PR feedback.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]] || \
              [[ "$EVENT_NAME" == "workflow_call" ]] || \
-             { [[ "$EVENT_NAME" == "push" ]] && [[ "$GH_REF" == "refs/heads/beta" ]]; }; then
+             { [[ "$EVENT_NAME" == "push" ]] && [[ "$GH_REF" == "refs/heads/beta" ]]; } || \
+             { [[ "$EVENT_NAME" == "pull_request_target" ]] && [[ "$WIDE_LABEL" == "true" ]]; }; then
             versions=$(jq -c '[.versions[].id]' tools/unity-versions.json)
-            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' → wide matrix: $versions"
+            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' (wide_label=$WIDE_LABEL) → wide matrix: $versions"
           else
-            versions=$(jq -c '[.versions[] | select(.role=="floor") | .id]' tools/unity-versions.json)
-            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' → floor only: $versions"
+            versions=$(jq -c '[.defaultVersion]' tools/unity-versions.json)
+            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' → default only: $versions"
           fi
           echo "versions=$versions" >> "$GITHUB_OUTPUT"
 
@@ -79,8 +93,15 @@ jobs:
       contents: read
     if: >
       github.event_name != 'pull_request_target' ||
-      (github.event.pull_request.head.repo.full_name != github.repository &&
-       github.event.label.name == 'safe-to-test')
+      (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
+        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'run-wide-matrix')
+      ) ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.label.name == 'run-wide-matrix'
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -30,8 +30,41 @@ on:
       - .github/workflows/unity-tests.yml
 
 jobs:
+  matrix:
+    name: Compute Unity version matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      versions: ${{ steps.set.outputs.versions }}
+    steps:
+      - name: Checkout version manifest
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
+          sparse-checkout: tools/unity-versions.json
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Select versions for this trigger
+        id: set
+        run: |
+          set -euo pipefail
+          # Wide matrix on beta-push, workflow_call (release pipelines), and manual dispatch.
+          # Narrow (floor only) on PRs and feature-branch pushes to keep PR feedback fast.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "${{ github.event_name }}" == "workflow_call" ]] || \
+             { [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref }}" == "refs/heads/beta" ]]; }; then
+            versions=$(jq -c '[.versions[].id]' tools/unity-versions.json)
+            echo "Trigger '${{ github.event_name }}' on ref '${{ github.ref }}' → wide matrix: $versions"
+          else
+            versions=$(jq -c '[.versions[] | select(.role=="floor") | .id]' tools/unity-versions.json)
+            echo "Trigger '${{ github.event_name }}' on ref '${{ github.ref }}' → floor only: $versions"
+          fi
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
   testAllModes:
-    name: Test in ${{ matrix.testMode }}
+    name: Test in ${{ matrix.testMode }} on Unity ${{ matrix.unityVersion }}
+    needs: matrix
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,8 +79,7 @@ jobs:
           - TestProjects/UnityMCPTests
         testMode:
           - editmode
-        unityVersion:
-          - 2021.3.45f2
+        unityVersion: ${{ fromJson(needs.matrix.outputs.versions) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -137,5 +169,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always() && steps.detect.outputs.unity_ok == 'true' && steps.tests.outcome != 'skipped'
         with:
-          name: Test results for ${{ matrix.testMode }}
+          name: Test results for ${{ matrix.testMode }} on Unity ${{ matrix.unityVersion }}
           path: ${{ steps.tests.outputs.artifactsPath }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -35,6 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Mirror the testAllModes gate: skip matrix work on unauthorized fork PRs so we don't waste
+    # CI minutes (or check out fork code) on labels that aren't 'safe-to-test'.
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (github.event.pull_request.head.repo.full_name != github.repository &&
+       github.event.label.name == 'safe-to-test')
     outputs:
       versions: ${{ steps.set.outputs.versions }}
     steps:
@@ -47,18 +53,21 @@ jobs:
           persist-credentials: false
       - name: Select versions for this trigger
         id: set
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
           # Wide matrix on beta-push, workflow_call (release pipelines), and manual dispatch.
           # Narrow (floor only) on PRs and feature-branch pushes to keep PR feedback fast.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             [[ "${{ github.event_name }}" == "workflow_call" ]] || \
-             { [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref }}" == "refs/heads/beta" ]]; }; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] || \
+             [[ "$EVENT_NAME" == "workflow_call" ]] || \
+             { [[ "$EVENT_NAME" == "push" ]] && [[ "$GH_REF" == "refs/heads/beta" ]]; }; then
             versions=$(jq -c '[.versions[].id]' tools/unity-versions.json)
-            echo "Trigger '${{ github.event_name }}' on ref '${{ github.ref }}' → wide matrix: $versions"
+            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' → wide matrix: $versions"
           else
             versions=$(jq -c '[.versions[] | select(.role=="floor") | .id]' tools/unity-versions.json)
-            echo "Trigger '${{ github.event_name }}' on ref '${{ github.ref }}' → floor only: $versions"
+            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' → floor only: $versions"
           fi
           echo "versions=$versions" >> "$GITHUB_OUTPUT"
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,8 @@ reports/
 scripts/local-test/
 .claude/settings.local.json
 
+# Per-version logs from tools/check-unity-versions.{sh,ps1}
+tools/.unity-check-logs/
+
 # Ignore the .claude directory, since it might contain local/project-level setting such as deny and allowlist.
 /.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ We support a wide Unity version range (2021+ → 6.x → CoreCLR 6.8). When an A
 
 The catalog of active shims, the policy for when to add one, what does NOT belong in a shim, and the reflection-cache pattern all live in **`MCPForUnity/Runtime/Helpers/UnityCompatShims.cs`** — the XML doc on that empty marker class is the source of truth and ships inside the UPM package, so end-users can `F12`/Go-to-definition into it. Sources for current deprecations: Unity 6.x upgrade guides and the [CoreCLR 2026 thread](https://discussions.unity.com/t/path-to-coreclr-2026-upgrade-guide/1714279).
 
+When you touch a shim or anything else gated by `#if UNITY_*_OR_NEWER`, run `tools/check-unity-versions.sh` to compile-check across the CI matrix locally before committing — the matrix lives in `tools/unity-versions.json`.
+
 ## Commands
 
 ### Running Tests
@@ -159,6 +161,10 @@ cd Server && uv run pytest tests/test_manage_material.py -v
 cd Server && uv run pytest tests/ -k "test_create_material" -v
 
 # Unity - open TestProjects/UnityMCPTests in Unity, use Test Runner window
+
+# Local multi-version compile check (parity with CI matrix, see tools/unity-versions.json)
+tools/check-unity-versions.sh           # compile-only across installed Unity Hub editors
+tools/check-unity-versions.sh --full    # full EditMode test run
 ```
 
 ### Local Development

--- a/docs/development/README-DEV.md
+++ b/docs/development/README-DEV.md
@@ -138,3 +138,91 @@ uv run pytest tests/ --cov --cov-report=html
 open htmlcov/index.html
 ```
 
+## Local Unity-version parity check
+
+CI exercises the package across multiple Unity versions to catch breaks in `#if UNITY_*_OR_NEWER` branches (see `tools/unity-versions.json` for the matrix and `.github/workflows/unity-tests.yml` for how it's consumed). The same list drives a local script so you can reproduce CI behavior before pushing.
+
+The script has two runners. Use whichever fits your setup:
+
+| Runner | When to use | Cost |
+|---|---|---|
+| **Local Unity Hub** (default) | You already have one or more matrix versions installed via Unity Hub. Fastest. | Disk: each editor is 3-6 GB. |
+| **GameCI Docker** (`--docker`) | You don't want to install every editor locally. Same containers CI uses. | One-time pull is 5-15 GB per version. On Apple Silicon, expect ~5-10× slowdown from amd64 emulation. |
+
+### Local Unity Hub mode
+
+```bash
+# Compile-only check across every locally-installed Unity in the matrix (~30-60s warm per version).
+tools/check-unity-versions.sh
+
+# Full EditMode test run — matches what CI runs end-to-end.
+tools/check-unity-versions.sh --full
+
+# Filter to one version family.
+tools/check-unity-versions.sh --only 6000.0
+```
+
+Windows uses the PowerShell companion:
+
+```powershell
+pwsh .\tools\check-unity-versions.ps1
+pwsh .\tools\check-unity-versions.ps1 -Full
+pwsh .\tools\check-unity-versions.ps1 -Only 6000.0
+```
+
+Versions not installed via Unity Hub are skipped — the script never forces you to install every editor in the matrix. Install the versions you most care about (typically the floor `2021.3.45f2` and your daily-driver Unity 6) and CI / Docker mode cover the rest.
+
+### GameCI Docker mode (no Unity Hub install required)
+
+```bash
+tools/check-unity-versions.sh --docker                # all matrix versions, compile-only
+tools/check-unity-versions.sh --docker --full         # full EditMode run
+tools/check-unity-versions.sh --docker --only 2022.3  # one version family
+```
+
+```powershell
+pwsh .\tools\check-unity-versions.ps1 -Docker
+pwsh .\tools\check-unity-versions.ps1 -Docker -Full
+```
+
+**One-time setup: get a Unity license**
+
+GameCI containers still need an activated Unity license. Free Personal activations work fine and are tied to the machine, not the editor version — so a single `.ulf` covers every version in the matrix.
+
+```bash
+# 1. Generate the request file (.alf) — outputs Unity_v<version>.alf in the current directory.
+docker run --rm -v "$PWD":/work unityci/editor:ubuntu-2021.3.45f2-base-3 \
+  /opt/unity/Editor/Unity -batchmode -nographics -quit \
+  -createManualActivationFile -logFile /dev/stdout
+
+# 2. Upload Unity_v<version>.alf at https://license.unity3d.com/manual
+#    Choose Personal license → save the resulting .ulf file.
+
+# 3. Export the .ulf contents (add to ~/.zshrc or ~/.bashrc to persist):
+export UNITY_LICENSE="$(cat /path/to/Unity_v<version>.ulf)"
+
+# 4. Run the check.
+tools/check-unity-versions.sh --docker
+```
+
+PowerShell equivalent for step 3: `$env:UNITY_LICENSE = Get-Content C:\path\to\Unity_v<version>.ulf -Raw`.
+
+The same `UNITY_LICENSE` secret is what `.github/workflows/unity-tests.yml` uses in CI — once you have it, your local Docker runs and CI behave identically.
+
+**Coverage gap on Apple Silicon Macs**: GameCI publishes only `linux/amd64` images. Docker Desktop runs them under Rosetta/QEMU at ~5-10× the native amd64 speed. A compile that takes 30s on Intel takes 3-5 min on M-series. Still faster than installing four Unity editors, but plan for it.
+
+**Opt-in pre-push hook**
+
+```bash
+tools/install-hooks.sh             # installs .git/hooks/pre-push (idempotent)
+tools/install-hooks.sh --uninstall # removes our hooks
+```
+
+Once installed, `git push` runs the compile-only check first when the push touches `MCPForUnity/Editor/**`, `MCPForUnity/Runtime/**`, `TestProjects/UnityMCPTests/**`, `tools/unity-versions.json`, or `.github/workflows/unity-tests.yml`. Pushes that touch only docs, Server/, or unrelated files skip the check.
+
+To bypass for a single push: `git push --no-verify`.
+
+**Bumping the matrix**
+
+Edit `tools/unity-versions.json` and update CI + local scripts both in one commit. The file is the single source of truth.
+

--- a/docs/development/README-DEV.md
+++ b/docs/development/README-DEV.md
@@ -138,9 +138,24 @@ uv run pytest tests/ --cov --cov-report=html
 open htmlcov/index.html
 ```
 
+## Unity-version CI matrix
+
+CI exercises the package across multiple Unity versions to catch breaks in `#if UNITY_*_OR_NEWER` branches. The matrix is configured in `tools/unity-versions.json` and consumed by `.github/workflows/unity-tests.yml`.
+
+**When the wide matrix runs (all 4 versions in parallel):**
+
+- Push to `beta` (the release gate).
+- `workflow_call` from `beta-release.yml` / `release.yml`.
+- Manual `workflow_dispatch` from the Actions tab.
+- Any PR (in-repo or fork) labeled with **`run-wide-matrix`** — apply this label when your change touches compat shims, conditional compilation, or anything else version-sensitive. The workflow re-runs with the full matrix on the next `pull_request_target` event. Cost is ~6-8 min wall clock vs ~3 min for the default leg.
+
+Fork PRs still need `safe-to-test` as the base gate (existing secret-safety pattern); `run-wide-matrix` is layered on top of that for fork-PR wide runs.
+
+**Default (single leg) runs on every other path** — feature-branch pushes and unlabeled in-repo PRs run only against `defaultVersion` from `tools/unity-versions.json` (currently Unity 6.0 LTS, `6000.0.75f1`). The `floor` role (`2021.3.45f2`) still identifies the package minimum and runs as part of the wide matrix; it's no longer the default-leg version.
+
 ## Local Unity-version parity check
 
-CI exercises the package across multiple Unity versions to catch breaks in `#if UNITY_*_OR_NEWER` branches (see `tools/unity-versions.json` for the matrix and `.github/workflows/unity-tests.yml` for how it's consumed). The same list drives a local script so you can reproduce CI behavior before pushing.
+The same `tools/unity-versions.json` drives a local script so you can reproduce CI behavior before pushing.
 
 The script has two runners. Use whichever fits your setup:
 

--- a/tools/check-unity-versions.ps1
+++ b/tools/check-unity-versions.ps1
@@ -1,0 +1,237 @@
+#requires -Version 5
+<#
+.SYNOPSIS
+  Local parity check for the CI Unity-version matrix (Windows companion to check-unity-versions.sh).
+
+.DESCRIPTION
+  Reads tools\unity-versions.json (the shared source of truth used by .github\workflows\unity-tests.yml)
+  and runs a compile-only batchmode pass on each Unity version installed via Unity Hub.
+
+  -Docker switches to running inside GameCI containers (unityci/editor:ubuntu-<id>-base-<tag>) instead
+  of looking for local Unity Hub installs. Requires Docker Desktop running and $env:UNITY_LICENSE set
+  to the contents of a Unity_lic.ulf file.
+
+  Exits non-zero if any *checked* version fails. Versions skipped (not installed locally / no image)
+  do not cause failure on their own.
+
+.PARAMETER Full
+  Run the full EditMode test suite per version instead of compile-only. Matches CI behavior; slower.
+
+.PARAMETER Only
+  Filter to versions whose id starts with this prefix (e.g. -Only 6000.0).
+
+.PARAMETER Docker
+  Run each version inside a GameCI Docker container instead of a local Unity Hub install.
+
+.PARAMETER DockerImageTag
+  Override the GameCI image tag suffix (default: 'base-3'). Pin to e.g. 'base-3.2.2' for reproducibility.
+
+.PARAMETER PrePush
+  Hint mode used by the pre-push hook; changes the failure message to mention --no-verify.
+
+.EXAMPLE
+  pwsh .\tools\check-unity-versions.ps1
+  pwsh .\tools\check-unity-versions.ps1 -Full
+  pwsh .\tools\check-unity-versions.ps1 -Only 6000.0
+  pwsh .\tools\check-unity-versions.ps1 -Docker
+#>
+
+[CmdletBinding()]
+param(
+  [switch]$Full,
+  [string]$Only = "",
+  [switch]$Docker,
+  [string]$DockerImageTag = "base-3",
+  [switch]$PrePush
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot     = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$VersionsJson = Join-Path $RepoRoot "tools\unity-versions.json"
+$ProjectPath  = Join-Path $RepoRoot "TestProjects\UnityMCPTests"
+$LogDir       = Join-Path $RepoRoot "tools\.unity-check-logs"
+
+if (-not (Test-Path $VersionsJson)) { throw "Missing: $VersionsJson" }
+if (-not (Test-Path $ProjectPath))  { throw "Missing project: $ProjectPath" }
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+# ---- mode setup --------------------------------------------------------------
+
+if ($Docker) {
+  if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error "-Docker requires Docker Desktop (https://docs.docker.com/get-docker/)"
+    exit 2
+  }
+  & docker info *> $null
+  if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker daemon not reachable. Start Docker Desktop and retry."
+    exit 2
+  }
+  if (-not $env:UNITY_LICENSE) {
+    Write-Host "error: -Docker requires a Unity license. Set `$env:UNITY_LICENSE to the contents of a Unity_lic.ulf file." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "One-time setup (free Personal license):"
+    Write-Host "  1. Generate a request file inside a GameCI container:"
+    Write-Host "       docker run --rm -v `"`${PWD}:/work`" unityci/editor:ubuntu-2021.3.45f2-base-3 ``"
+    Write-Host "         /opt/unity/Editor/Unity -batchmode -nographics -quit -createManualActivationFile ``"
+    Write-Host "         -logFile /dev/stdout"
+    Write-Host "     This writes Unity_v<version>.alf to your current directory."
+    Write-Host "  2. Upload that .alf at https://license.unity3d.com/manual -> Personal -> save the .ulf it returns."
+    Write-Host "  3. Persist the license in your PowerShell profile:"
+    Write-Host "       `$env:UNITY_LICENSE = Get-Content C:\path\to\Unity_v<version>.ulf -Raw"
+    Write-Host "  4. Re-run this script."
+    Write-Host ""
+    Write-Host "(The same UNITY_LICENSE secret is what the GitHub Actions workflow uses; one .ulf works across all"
+    Write-Host "matrix versions in practice — Unity Personal activations are tied to the machine, not the editor version.)"
+    exit 2
+  }
+} else {
+  # Unity Hub installs editors under one of these roots on Windows.
+  $HubRoots = @()
+  foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+    if ($base) {
+      $candidate = Join-Path $base "Unity\Hub\Editor"
+      if (Test-Path $candidate) { $HubRoots += $candidate }
+    }
+  }
+
+  if ($HubRoots.Count -eq 0) {
+    Write-Warning "Unity Hub editor root not found under Program Files. Install at least one editor or use -Docker."
+  }
+}
+
+function Get-UnityBin([string]$Version) {
+  foreach ($root in $HubRoots) {
+    $candidate = Join-Path $root "$Version\Editor\Unity.exe"
+    if (Test-Path $candidate) { return $candidate }
+  }
+  return $null
+}
+
+$Manifest = Get-Content $VersionsJson -Raw | ConvertFrom-Json
+$Versions = $Manifest.versions | ForEach-Object { $_.id }
+
+if ($Only) {
+  $Versions = $Versions | Where-Object { $_.StartsWith($Only) }
+  if ($Versions.Count -eq 0) {
+    Write-Error "No versions matched -Only '$Only'"
+    exit 2
+  }
+}
+
+$modeLabel = if ($Full) { "full EditMode test run" } else { "compile-only" }
+$runnerLabel = if ($Docker) { "GameCI Docker ($DockerImageTag)" } else { "local Unity Hub" }
+Write-Host "Unity-version check ($modeLabel, $runnerLabel) — $($Versions.Count) version(s) requested"
+Write-Host "  Project: $ProjectPath"
+Write-Host "  Logs:    $LogDir"
+Write-Host ""
+
+function Invoke-LocalUnity([string]$Version, [string]$LogFile) {
+  $unityBin = Get-UnityBin $Version
+  if (-not $unityBin) {
+    Write-Host "  [SKIP] $Version — not installed under any Unity Hub root" -ForegroundColor Yellow
+    return 2  # skip sentinel
+  }
+
+  Write-Host -NoNewline "  [ .. ] $Version — running...`r"
+
+  if ($Full) {
+    $unityArgs = @("-batchmode", "-nographics", "-projectPath", $ProjectPath, "-runTests", "-testPlatform", "editmode", "-logFile", $LogFile)
+  } else {
+    $unityArgs = @("-batchmode", "-quit", "-nographics", "-projectPath", $ProjectPath, "-logFile", $LogFile)
+  }
+
+  $proc = Start-Process -FilePath $unityBin -ArgumentList $unityArgs -NoNewWindow -PassThru -Wait
+  if ($proc.ExitCode -eq 0) { return 0 } else { return 1 }
+}
+
+function Invoke-DockerUnity([string]$Version, [string]$LogFile) {
+  $image = "unityci/editor:ubuntu-$Version-$DockerImageTag"
+
+  Write-Host -NoNewline "  [ .. ] $Version — pulling $image ...`r"
+  & docker pull $image *>> $LogFile
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host "  [FAIL] $Version — image pull failed ($image); see $LogFile" -ForegroundColor Red
+    Write-Host "    Pull errors:"
+    Get-Content $LogFile -Tail 5 | ForEach-Object { Write-Host "      $_" }
+    return 1
+  }
+
+  Write-Host -NoNewline "  [ .. ] $Version — running in container...`r"
+
+  $unityExtra = if ($Full) { "-runTests -testPlatform editmode" } else { "-quit" }
+
+  # Convert Windows path to Docker-friendly format for -v.
+  $projectMount = $ProjectPath.Replace('\', '/')
+
+  $script = @"
+set -e
+mkdir -p /root/.local/share/unity3d/Unity
+printf '%s' "`$UNITY_LICENSE" > /root/.local/share/unity3d/Unity/Unity_lic.ulf
+/opt/unity/Editor/Unity -batchmode -nographics -projectPath /project $unityExtra -logFile /dev/stdout
+"@
+
+  & docker run --rm `
+    --platform linux/amd64 `
+    -e UNITY_LICENSE `
+    -v "${projectMount}:/project" `
+    --entrypoint /bin/bash `
+    $image `
+    -c $script *>> $LogFile
+
+  if ($LASTEXITCODE -eq 0) { return 0 } else { return 1 }
+}
+
+$pass = 0; $fail = 0; $skip = 0
+
+foreach ($version in $Versions) {
+  $logFile = Join-Path $LogDir "$version.log"
+  "" | Set-Content -Path $logFile  # truncate stale
+
+  if ($Docker) {
+    $rc = Invoke-DockerUnity $version $logFile
+  } else {
+    $rc = Invoke-LocalUnity $version $logFile
+  }
+
+  switch ($rc) {
+    0 { Write-Host "  [PASS] $version                    " -ForegroundColor Green; $pass++ }
+    2 { $skip++ }
+    default {
+      Write-Host "  [FAIL] $version — see $logFile" -ForegroundColor Red
+      $compileErrors = Select-String -Path $logFile -Pattern "error CS\d+" -ErrorAction SilentlyContinue
+      if ($compileErrors) {
+        Write-Host "    Compile errors:"
+        $compileErrors | Select-Object -First 10 | ForEach-Object { Write-Host "      $($_.Line)" }
+      } else {
+        Write-Host "    Last 20 lines of log:"
+        Get-Content $logFile -Tail 20 | ForEach-Object { Write-Host "      $_" }
+      }
+      $fail++
+    }
+  }
+}
+
+Write-Host ""
+Write-Host "Summary: $pass passed, $fail failed, $skip skipped (of $($Versions.Count) configured)"
+
+if ($fail -gt 0) {
+  if ($PrePush) {
+    Write-Host ""
+    Write-Host "Pre-push check failed. To push anyway (skipping this hook): git push --no-verify"
+  }
+  exit 1
+}
+
+if ($pass -eq 0 -and $skip -gt 0) {
+  Write-Host ""
+  if ($Docker) {
+    Write-Host "Note: no versions ran. Check image pull errors above."
+  } else {
+    Write-Host "Note: no versions from tools/unity-versions.json are installed on this machine."
+    Write-Host "Either install via Unity Hub or use -Docker (see Get-Help for license setup)."
+  }
+}
+
+exit 0

--- a/tools/check-unity-versions.ps1
+++ b/tools/check-unity-versions.ps1
@@ -83,7 +83,7 @@ if ($Docker) {
     Write-Host "  4. Re-run this script."
     Write-Host ""
     Write-Host "(The same UNITY_LICENSE secret is what the GitHub Actions workflow uses; one .ulf works across all"
-    Write-Host "matrix versions in practice — Unity Personal activations are tied to the machine, not the editor version.)"
+    Write-Host "matrix versions in practice -- Unity Personal activations are tied to the machine, not the editor version.)"
     exit 2
   }
 } else {
@@ -122,7 +122,7 @@ if ($Only) {
 
 $modeLabel = if ($Full) { "full EditMode test run" } else { "compile-only" }
 $runnerLabel = if ($Docker) { "GameCI Docker ($DockerImageTag)" } else { "local Unity Hub" }
-Write-Host "Unity-version check ($modeLabel, $runnerLabel) — $($Versions.Count) version(s) requested"
+Write-Host "Unity-version check ($modeLabel, $runnerLabel) -- $($Versions.Count) version(s) requested"
 Write-Host "  Project: $ProjectPath"
 Write-Host "  Logs:    $LogDir"
 Write-Host ""
@@ -130,14 +130,15 @@ Write-Host ""
 function Invoke-LocalUnity([string]$Version, [string]$LogFile) {
   $unityBin = Get-UnityBin $Version
   if (-not $unityBin) {
-    Write-Host "  [SKIP] $Version — not installed under any Unity Hub root" -ForegroundColor Yellow
+    Write-Host "  [SKIP] $Version -- not installed under any Unity Hub root" -ForegroundColor Yellow
     return 2  # skip sentinel
   }
 
-  Write-Host -NoNewline "  [ .. ] $Version — running...`r"
+  Write-Host -NoNewline "  [ .. ] $Version -- running...`r"
 
+  # -quit on both paths so Unity batchmode always exits; without it -runTests can hang on test framework shutdown.
   if ($Full) {
-    $unityArgs = @("-batchmode", "-nographics", "-projectPath", $ProjectPath, "-runTests", "-testPlatform", "editmode", "-logFile", $LogFile)
+    $unityArgs = @("-batchmode", "-quit", "-nographics", "-projectPath", $ProjectPath, "-runTests", "-testPlatform", "editmode", "-logFile", $LogFile)
   } else {
     $unityArgs = @("-batchmode", "-quit", "-nographics", "-projectPath", $ProjectPath, "-logFile", $LogFile)
   }
@@ -149,18 +150,19 @@ function Invoke-LocalUnity([string]$Version, [string]$LogFile) {
 function Invoke-DockerUnity([string]$Version, [string]$LogFile) {
   $image = "unityci/editor:ubuntu-$Version-$DockerImageTag"
 
-  Write-Host -NoNewline "  [ .. ] $Version — pulling $image ...`r"
+  Write-Host -NoNewline "  [ .. ] $Version -- pulling $image ...`r"
   & docker pull $image *>> $LogFile
   if ($LASTEXITCODE -ne 0) {
-    Write-Host "  [FAIL] $Version — image pull failed ($image); see $LogFile" -ForegroundColor Red
+    Write-Host "  [FAIL] $Version -- image pull failed ($image); see $LogFile" -ForegroundColor Red
     Write-Host "    Pull errors:"
     Get-Content $LogFile -Tail 5 | ForEach-Object { Write-Host "      $_" }
     return 1
   }
 
-  Write-Host -NoNewline "  [ .. ] $Version — running in container...`r"
+  Write-Host -NoNewline "  [ .. ] $Version -- running in container...`r"
 
-  $unityExtra = if ($Full) { "-runTests -testPlatform editmode" } else { "-quit" }
+  # -quit on both paths (see Invoke-LocalUnity note).
+  $unityExtra = if ($Full) { "-quit -runTests -testPlatform editmode" } else { "-quit" }
 
   # Convert Windows path to Docker-friendly format for -v.
   $projectMount = $ProjectPath.Replace('\', '/')
@@ -199,7 +201,7 @@ foreach ($version in $Versions) {
     0 { Write-Host "  [PASS] $version                    " -ForegroundColor Green; $pass++ }
     2 { $skip++ }
     default {
-      Write-Host "  [FAIL] $version — see $logFile" -ForegroundColor Red
+      Write-Host "  [FAIL] $version -- see $logFile" -ForegroundColor Red
       $compileErrors = Select-String -Path $logFile -Pattern "error CS\d+" -ErrorAction SilentlyContinue
       if ($compileErrors) {
         Write-Host "    Compile errors:"

--- a/tools/check-unity-versions.sh
+++ b/tools/check-unity-versions.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Local parity check for the CI Unity-version matrix.
+#
+# Usage:
+#   tools/check-unity-versions.sh                 # compile-only, all installed versions from tools/unity-versions.json
+#   tools/check-unity-versions.sh --full          # full EditMode test run (matches CI behavior)
+#   tools/check-unity-versions.sh --only 6000.0   # check only versions whose id starts with the given prefix
+#   tools/check-unity-versions.sh --docker        # run inside GameCI containers (no local Unity Hub install needed)
+#   tools/check-unity-versions.sh --pre-push      # hint mode used by the pre-push hook (changes failure message)
+#
+# Modes:
+#   - Default (local): looks for Unity editors under Unity Hub. Versions not installed are skipped.
+#   - --docker: runs each version inside unityci/editor:ubuntu-<id>-base-<tag>. Requires UNITY_LICENSE env
+#     (contents of a .ulf file). On macOS arm64, expect ~5-10× slowdown from amd64 emulation.
+#
+# Exits non-zero if any *checked* version fails. Versions skipped (not installed locally / image not pulled
+# in offline mode) do not cause failure on their own.
+#
+# Linked to CI: both this script and .github/workflows/unity-tests.yml read tools/unity-versions.json.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSIONS_JSON="${REPO_ROOT}/tools/unity-versions.json"
+PROJECT_PATH="${REPO_ROOT}/TestProjects/UnityMCPTests"
+LOG_DIR="${REPO_ROOT}/tools/.unity-check-logs"
+
+# Default GameCI image tag suffix. GameCI publishes both sliding (base-3) and pinned (base-3.1.0) tags;
+# we default to the major-major (base-3) sliding tag and let users pin via --docker-image-tag.
+DOCKER_IMAGE_TAG="base-3"
+
+FULL=0
+ONLY=""
+PRE_PUSH=0
+USE_DOCKER=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --full|--with-tests) FULL=1 ;;
+    --only) ONLY="${2:-}"; shift ;;
+    --docker) USE_DOCKER=1 ;;
+    --docker-image-tag) DOCKER_IMAGE_TAG="${2:-}"; shift ;;
+    --pre-push) PRE_PUSH=1 ;;
+    -h|--help)
+      sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: 'jq' is required (brew install jq / apt-get install jq)" >&2
+  exit 2
+fi
+if [[ ! -f "$VERSIONS_JSON" ]]; then
+  echo "error: $VERSIONS_JSON missing" >&2
+  exit 2
+fi
+if [[ ! -d "$PROJECT_PATH" ]]; then
+  echo "error: project path not found: $PROJECT_PATH" >&2
+  exit 2
+fi
+
+mkdir -p "$LOG_DIR"
+
+# ---- mode setup ---------------------------------------------------------------------
+
+if [[ $USE_DOCKER -eq 1 ]]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "error: --docker requires Docker (https://docs.docker.com/get-docker/)" >&2
+    exit 2
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "error: Docker daemon not reachable. Start Docker Desktop / dockerd and retry." >&2
+    exit 2
+  fi
+  if [[ -z "${UNITY_LICENSE:-}" ]]; then
+    cat >&2 <<'EOF'
+error: --docker requires a Unity license. Set UNITY_LICENSE to the contents of a Unity_lic.ulf file.
+
+One-time setup (free Personal license):
+  1. Generate a request file inside a GameCI container:
+       docker run --rm -v "$PWD":/work unityci/editor:ubuntu-2021.3.45f2-base-3 \
+         /opt/unity/Editor/Unity -batchmode -nographics -quit -createManualActivationFile \
+         -logFile /dev/stdout
+     This writes Unity_v<version>.alf to your current directory.
+  2. Upload that .alf at https://license.unity3d.com/manual → choose Personal → save the .ulf it returns.
+  3. Export the .ulf contents in your shell (add to ~/.zshrc or similar to persist):
+       export UNITY_LICENSE="$(cat /path/to/Unity_v<version>.ulf)"
+  4. Re-run this script.
+
+(The same UNITY_LICENSE secret is what the GitHub Actions workflow uses; one .ulf works across all matrix
+versions in practice — Unity Personal activations are tied to the machine, not the editor version.)
+EOF
+    exit 2
+  fi
+
+  if [[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      echo "note: arm64 Mac — GameCI images run via amd64 emulation; expect ~5-10× slowdown."
+    fi
+  fi
+else
+  case "$(uname -s)" in
+    Darwin) HUB_ROOT="/Applications/Unity/Hub/Editor" ; UNITY_RELPATH="Unity.app/Contents/MacOS/Unity" ;;
+    Linux)  HUB_ROOT="${HOME}/Unity/Hub/Editor"       ; UNITY_RELPATH="Editor/Unity" ;;
+    *) echo "error: unsupported OS '$(uname -s)' — use check-unity-versions.ps1 on Windows, or --docker on any platform" >&2; exit 2 ;;
+  esac
+fi
+
+# Pretty output even without colors set up.
+if [[ -t 1 ]]; then
+  C_OK=$'\033[32m'; C_FAIL=$'\033[31m'; C_SKIP=$'\033[33m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+else
+  C_OK=""; C_FAIL=""; C_SKIP=""; C_DIM=""; C_RST=""
+fi
+
+VERSIONS=()
+while IFS= read -r line; do
+  VERSIONS+=("$line")
+done < <(jq -r '.versions[].id' "$VERSIONS_JSON")
+
+if [[ -n "$ONLY" ]]; then
+  filtered=()
+  for v in "${VERSIONS[@]}"; do
+    [[ "$v" == "$ONLY"* ]] && filtered+=("$v")
+  done
+  if [[ ${#filtered[@]} -eq 0 ]]; then
+    echo "No versions matched --only '$ONLY'" >&2
+    exit 2
+  fi
+  VERSIONS=("${filtered[@]}")
+fi
+
+mode_label="compile-only"
+[[ $FULL -eq 1 ]] && mode_label="full EditMode test run"
+runner_label="local Unity Hub"
+[[ $USE_DOCKER -eq 1 ]] && runner_label="GameCI Docker (${DOCKER_IMAGE_TAG})"
+echo "Unity-version check (${mode_label}, ${runner_label}) — ${#VERSIONS[@]} version(s) requested"
+echo "  Project: $PROJECT_PATH"
+echo "  Logs:    $LOG_DIR"
+echo
+
+fail_count=0
+pass_count=0
+skip_count=0
+
+# ---- per-version runners ------------------------------------------------------------
+
+run_local() {
+  local version="$1" log_file="$2"
+  local unity_bin="${HUB_ROOT}/${version}/${UNITY_RELPATH}"
+
+  if [[ ! -x "$unity_bin" ]]; then
+    echo "  ${C_SKIP}[SKIP]${C_RST} ${version} — not installed (expected at ${C_DIM}${unity_bin}${C_RST})"
+    return 2  # skip
+  fi
+
+  printf "  [ .. ] %s — running...\r" "$version"
+
+  local args
+  if [[ $FULL -eq 1 ]]; then
+    args=(-batchmode -nographics -projectPath "$PROJECT_PATH" -runTests -testPlatform editmode -logFile "$log_file")
+  else
+    args=(-batchmode -quit -nographics -projectPath "$PROJECT_PATH" -logFile "$log_file")
+  fi
+
+  if "$unity_bin" "${args[@]}" >/dev/null 2>&1; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+run_docker() {
+  local version="$1" log_file="$2"
+  local image="unityci/editor:ubuntu-${version}-${DOCKER_IMAGE_TAG}"
+
+  printf "  [ .. ] %s — pulling %s ...\r" "$version" "$image"
+  if ! docker pull "$image" >>"$log_file" 2>&1; then
+    echo "  ${C_FAIL}[FAIL]${C_RST} ${version} — image pull failed (${C_DIM}${image}${C_RST}); see ${log_file}"
+    echo "    Pull errors:"
+    tail -5 "$log_file" | sed 's/^/      /'
+    return 1
+  fi
+
+  printf "  [ .. ] %s — running in container...\r" "$version"
+
+  # GameCI images run as root and expect the .ulf at /root/.local/share/unity3d/Unity/Unity_lic.ulf.
+  # Write the license from env on container start, then run Unity with -logFile /dev/stdout so
+  # everything (mkdir output, Unity compile log, errors) streams through docker's stdout into our
+  # host log_file via a single `>> "$log_file"` redirection. No bind-mount race.
+  local unity_extra
+  if [[ $FULL -eq 1 ]]; then
+    unity_extra="-runTests -testPlatform editmode"
+  else
+    unity_extra="-quit"
+  fi
+
+  if docker run --rm \
+       --platform linux/amd64 \
+       -e UNITY_LICENSE \
+       -v "${PROJECT_PATH}:/project" \
+       --entrypoint /bin/bash \
+       "$image" \
+       -c 'set -e
+           mkdir -p /root/.local/share/unity3d/Unity
+           printf "%s" "$UNITY_LICENSE" > /root/.local/share/unity3d/Unity/Unity_lic.ulf
+           /opt/unity/Editor/Unity -batchmode -nographics -projectPath /project '"$unity_extra"' -logFile /dev/stdout' \
+       >>"$log_file" 2>&1; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# ---- main loop ----------------------------------------------------------------------
+
+for version in "${VERSIONS[@]}"; do
+  log_file="${LOG_DIR}/${version}.log"
+  : >"$log_file"  # truncate stale log
+
+  if [[ $USE_DOCKER -eq 1 ]]; then
+    run_docker "$version" "$log_file" && rc=0 || rc=$?
+  else
+    run_local "$version" "$log_file" && rc=0 || rc=$?
+  fi
+
+  case "$rc" in
+    0)
+      echo "  ${C_OK}[PASS]${C_RST} ${version}                    "
+      pass_count=$((pass_count + 1))
+      ;;
+    2)
+      skip_count=$((skip_count + 1))
+      ;;
+    *)
+      echo "  ${C_FAIL}[FAIL]${C_RST} ${version} — see ${C_DIM}${log_file}${C_RST}"
+      if grep -q "error CS" "$log_file" 2>/dev/null; then
+        echo "    Compile errors:"
+        grep -E "error CS[0-9]+" "$log_file" | head -10 | sed 's/^/      /'
+      else
+        echo "    Last 20 lines of log:"
+        tail -20 "$log_file" | sed 's/^/      /'
+      fi
+      fail_count=$((fail_count + 1))
+      ;;
+  esac
+done
+
+echo
+echo "Summary: ${pass_count} passed, ${fail_count} failed, ${skip_count} skipped (of ${#VERSIONS[@]} configured)"
+
+if [[ $fail_count -gt 0 ]]; then
+  if [[ $PRE_PUSH -eq 1 ]]; then
+    echo
+    echo "Pre-push check failed. To push anyway (skipping this hook): git push --no-verify"
+  fi
+  exit 1
+fi
+
+if [[ $pass_count -eq 0 && $skip_count -gt 0 ]]; then
+  echo
+  if [[ $USE_DOCKER -eq 1 ]]; then
+    echo "Note: no versions ran. Check image pull errors above."
+  else
+    echo "Note: no versions from tools/unity-versions.json are installed on this machine."
+    echo "Either install via Unity Hub or use --docker (see --help for license setup)."
+  fi
+fi
+
+exit 0

--- a/tools/check-unity-versions.sh
+++ b/tools/check-unity-versions.sh
@@ -34,12 +34,21 @@ ONLY=""
 PRE_PUSH=0
 USE_DOCKER=0
 
+require_value() {
+  # Validate that a flag taking a value got one (not another flag, not nothing).
+  local flag="$1" value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "error: $flag requires a value" >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --full|--with-tests) FULL=1 ;;
-    --only) ONLY="${2:-}"; shift ;;
+    --only) require_value "$1" "${2:-}"; ONLY="$2"; shift ;;
     --docker) USE_DOCKER=1 ;;
-    --docker-image-tag) DOCKER_IMAGE_TAG="${2:-}"; shift ;;
+    --docker-image-tag) require_value "$1" "${2:-}"; DOCKER_IMAGE_TAG="$2"; shift ;;
     --pre-push) PRE_PUSH=1 ;;
     -h|--help)
       sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
@@ -159,9 +168,11 @@ run_local() {
 
   printf "  [ .. ] %s — running...\r" "$version"
 
+  # -quit on both paths so Unity batchmode always exits — without it -runTests can hang waiting
+  # on test framework shutdown on some Unity versions.
   local args
   if [[ $FULL -eq 1 ]]; then
-    args=(-batchmode -nographics -projectPath "$PROJECT_PATH" -runTests -testPlatform editmode -logFile "$log_file")
+    args=(-batchmode -quit -nographics -projectPath "$PROJECT_PATH" -runTests -testPlatform editmode -logFile "$log_file")
   else
     args=(-batchmode -quit -nographics -projectPath "$PROJECT_PATH" -logFile "$log_file")
   fi
@@ -191,9 +202,10 @@ run_docker() {
   # Write the license from env on container start, then run Unity with -logFile /dev/stdout so
   # everything (mkdir output, Unity compile log, errors) streams through docker's stdout into our
   # host log_file via a single `>> "$log_file"` redirection. No bind-mount race.
+  # -quit on both paths (see run_local note).
   local unity_extra
   if [[ $FULL -eq 1 ]]; then
-    unity_extra="-runTests -testPlatform editmode"
+    unity_extra="-quit -runTests -testPlatform editmode"
   else
     unity_extra="-quit"
   fi

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -17,14 +17,21 @@ fi
 # the CI workflow uses, so the hook fires for the same scope of changes.
 relevant_paths='^(MCPForUnity/(Editor|Runtime)/|TestProjects/UnityMCPTests/|tools/unity-versions\.json$|\.github/workflows/unity-tests\.yml$)'
 
+# Git's empty-tree SHA — fallback that always exists. Used when we can't find a sensible merge
+# base (shallow clone, fresh fork with no origin/beta or origin/main, etc.) so the hook still
+# runs the check instead of silently skipping it.
+EMPTY_TREE=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+
 # stdin format from git: <local-ref> <local-sha> <remote-ref> <remote-sha> (one line per ref being pushed)
 relevant=0
 while read -r local_ref local_sha remote_ref remote_sha; do
   [[ -z "$local_sha" || "$local_sha" == "0000000000000000000000000000000000000000" ]] && continue
 
   if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
-    # New branch on remote — diff against the default branch (or HEAD~ as fallback)
-    base=$(git merge-base "$local_sha" origin/beta 2>/dev/null || git merge-base "$local_sha" origin/main 2>/dev/null || echo "$local_sha~1")
+    # New branch on remote — diff against the default branch, or the empty tree as a guaranteed-valid fallback.
+    base=$(git merge-base "$local_sha" origin/beta 2>/dev/null \
+        || git merge-base "$local_sha" origin/main 2>/dev/null \
+        || echo "$EMPTY_TREE")
   else
     base="$remote_sha"
   fi

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Pre-push hook: runs the local Unity-version parity check in compile-only mode.
+# Installed by tools/install-hooks.sh; opt-in (devs without the hook see no behavior change).
+# To bypass for a single push: git push --no-verify
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="${REPO_ROOT}/tools/check-unity-versions.sh"
+
+if [[ ! -x "$SCRIPT" ]]; then
+  echo "pre-push: $SCRIPT missing or not executable; skipping Unity-version check." >&2
+  exit 0
+fi
+
+# Skip if the push touches nothing relevant. We approximate "relevant" with the same path filters
+# the CI workflow uses, so the hook fires for the same scope of changes.
+relevant_paths='^(MCPForUnity/(Editor|Runtime)/|TestProjects/UnityMCPTests/|tools/unity-versions\.json$|\.github/workflows/unity-tests\.yml$)'
+
+# stdin format from git: <local-ref> <local-sha> <remote-ref> <remote-sha> (one line per ref being pushed)
+relevant=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [[ -z "$local_sha" || "$local_sha" == "0000000000000000000000000000000000000000" ]] && continue
+
+  if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
+    # New branch on remote — diff against the default branch (or HEAD~ as fallback)
+    base=$(git merge-base "$local_sha" origin/beta 2>/dev/null || git merge-base "$local_sha" origin/main 2>/dev/null || echo "$local_sha~1")
+  else
+    base="$remote_sha"
+  fi
+
+  if git diff --name-only "$base..$local_sha" 2>/dev/null | grep -qE "$relevant_paths"; then
+    relevant=1
+    break
+  fi
+done
+
+if [[ $relevant -eq 0 ]]; then
+  echo "pre-push: no Unity-relevant changes detected; skipping check."
+  exit 0
+fi
+
+exec "$SCRIPT" --pre-push

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Installs the repo's git hooks into .git/hooks/.
+#
+# Usage:
+#   tools/install-hooks.sh           # install missing hooks (preserves existing ones)
+#   tools/install-hooks.sh --force   # overwrite any existing hooks
+#   tools/install-hooks.sh --uninstall  # remove hooks that match the ones we installed
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="${REPO_ROOT}/tools/hooks"
+DST_DIR="${REPO_ROOT}/.git/hooks"
+
+if [[ ! -d "$DST_DIR" ]]; then
+  echo "error: $DST_DIR not found — is this a git checkout?" >&2
+  exit 2
+fi
+if [[ ! -d "$SRC_DIR" ]]; then
+  echo "error: $SRC_DIR missing" >&2
+  exit 2
+fi
+
+FORCE=0
+UNINSTALL=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    --uninstall) UNINSTALL=1 ;;
+    -h|--help)
+      sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+installed=0
+skipped=0
+removed=0
+
+for src in "$SRC_DIR"/*; do
+  [[ -e "$src" ]] || continue
+  name="$(basename "$src")"
+  dst="$DST_DIR/$name"
+
+  if [[ $UNINSTALL -eq 1 ]]; then
+    if [[ -e "$dst" ]] && cmp -s "$src" "$dst"; then
+      rm -f "$dst"
+      echo "  removed $dst"
+      removed=$((removed + 1))
+    else
+      echo "  skipped $dst (not our hook, or absent)"
+    fi
+    continue
+  fi
+
+  if [[ -e "$dst" && $FORCE -ne 1 ]]; then
+    if cmp -s "$src" "$dst"; then
+      echo "  ok       $dst (already up to date)"
+      skipped=$((skipped + 1))
+    else
+      echo "  skipped  $dst (exists and differs — use --force to overwrite)"
+      skipped=$((skipped + 1))
+    fi
+    continue
+  fi
+
+  cp "$src" "$dst"
+  chmod +x "$dst"
+  echo "  installed $dst"
+  installed=$((installed + 1))
+done
+
+if [[ $UNINSTALL -eq 1 ]]; then
+  echo
+  echo "Summary: $removed hook(s) removed"
+else
+  echo
+  echo "Summary: $installed installed, $skipped skipped"
+  if [[ $installed -gt 0 ]]; then
+    echo
+    echo "Hooks are active. To bypass for a single push: git push --no-verify"
+  fi
+fi

--- a/tools/unity-versions.json
+++ b/tools/unity-versions.json
@@ -1,6 +1,8 @@
 {
   "$comment": "Single source of truth for Unity versions exercised by CI and tools/check-unity-versions.* local script. Versions are pinned to specific patch releases (no floating tags) per acceptance criteria in CoplayDev/unity-mcp#1107. Every id MUST have a corresponding GameCI Docker image at unityci/editor:ubuntu-<id>-base-3 since both CI (game-ci/unity-test-runner@v4) and local --docker mode pull from there. Verify availability before bumping: https://hub.docker.com/v2/repositories/unityci/editor/tags/?name=<id>",
   "$coverageGap": "UNITY_6000_5_OR_NEWER and UNITY_6000_6_OR_NEWER branches are NOT exercised by this matrix because GameCI has not yet published Docker images for Unity 6000.5+/6000.6+. Bump the 'rolling' row to a 6000.5+/6000.6+ patch once https://hub.docker.com/r/unityci/editor publishes one. Tracked branches in code: UnityObjectIdCompat.cs (EntityId path).",
+  "defaultVersion": "6000.0.75f1",
+  "$defaultVersionComment": "Unity version used when CI runs the narrow matrix (default PR feedback path). Must be one of the ids in 'versions' below. Today's pick is 6.0 LTS — the version most users target. The 'floor' role still identifies the package's minimum supported version separately.",
   "versions": [
     {
       "id": "2021.3.45f2",

--- a/tools/unity-versions.json
+++ b/tools/unity-versions.json
@@ -1,0 +1,26 @@
+{
+  "$comment": "Single source of truth for Unity versions exercised by CI and tools/check-unity-versions.* local script. Versions are pinned to specific patch releases (no floating tags) per acceptance criteria in CoplayDev/unity-mcp#1107. Every id MUST have a corresponding GameCI Docker image at unityci/editor:ubuntu-<id>-base-3 since both CI (game-ci/unity-test-runner@v4) and local --docker mode pull from there. Verify availability before bumping: https://hub.docker.com/v2/repositories/unityci/editor/tags/?name=<id>",
+  "$coverageGap": "UNITY_6000_5_OR_NEWER and UNITY_6000_6_OR_NEWER branches are NOT exercised by this matrix because GameCI has not yet published Docker images for Unity 6000.5+/6000.6+. Bump the 'rolling' row to a 6000.5+/6000.6+ patch once https://hub.docker.com/r/unityci/editor publishes one. Tracked branches in code: UnityObjectIdCompat.cs (EntityId path).",
+  "versions": [
+    {
+      "id": "2021.3.45f2",
+      "role": "floor",
+      "notes": "Package minimum (matches MCPForUnity/package.json 'unity' field and TestProjects/UnityMCPTests/ProjectSettings/ProjectVersion.txt). Legacy branch: all UNITY_2022_*/UNITY_6000_* flags OFF."
+    },
+    {
+      "id": "2022.3.62f1",
+      "role": "lts",
+      "notes": "Last 2022 LTS. Exercises UNITY_2022_1/2/3_OR_NEWER branches; UNITY_2023_*/UNITY_6000_* OFF. Catches FindObjectsByType-style regressions (the #1105 path)."
+    },
+    {
+      "id": "6000.0.75f1",
+      "role": "lts",
+      "notes": "Unity 6.0 LTS (latest patch on GameCI). UNITY_6000_0_OR_NEWER ON (27 files), UNITY_2023_*_OR_NEWER ON, UNITY_6000_3/4/5/6 OFF."
+    },
+    {
+      "id": "6000.4.8f1",
+      "role": "rolling",
+      "notes": "Latest 6.x available on GameCI. UNITY_6000_0/1/2/3/4_OR_NEWER ON; UNITY_6000_5/6 OFF (no GameCI image yet — see $coverageGap)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #1107.

- CI's `unity-tests.yml` runs the wide matrix (2021.3.45f2, 2022.3.62f1, 6000.0.75f1, 6000.4.8f1) only on push-to-beta / workflow_call (from `beta-release.yml` and `release.yml`) / `workflow_dispatch`. PRs and feature-branch pushes still run only the floor 2021.3.45f2 leg, so PR feedback time is unchanged.
- The existing publish gate (`update_unity_beta_version`, `publish_pypi_prerelease`) already `needs: [unity_tests]`, so widening the matrix automatically widens the gate. No changes to `beta-release.yml` or `release.yml`.
- `tools/check-unity-versions.{sh,ps1}` lets developers reproduce CI locally — either against editors installed via Unity Hub, or via `--docker` against the same GameCI containers CI uses (no editor install required, just Docker + a free Unity Personal `.ulf`).
- Opt-in `pre-push` hook (`tools/install-hooks.sh`) runs the compile-only check when a push touches Unity-relevant paths.
- Single source of truth: `tools/unity-versions.json` — consumed by both the CI matrix preamble job and the local scripts. One file to bump when adding/removing versions.

## Why these four versions

Each version was chosen to exercise a distinct slice of the `#if UNITY_*_OR_NEWER` conditionals in `MCPForUnity/`:

| Version | Branches exercised |
|---|---|
| **2021.3.45f2** | Legacy — all `UNITY_2022_*` / `UNITY_6000_*` flags OFF; matches `package.json` `"unity": "2021.3"` |
| **2022.3.62f1** | `UNITY_2022_1/2/3_OR_NEWER` ON; catches `FindObjectsByType(sortMode)` regressions like #1105 |
| **6000.0.75f1** | Unity 6.0 LTS — `UNITY_6000_0_OR_NEWER` ON (27 files), `UNITY_2023_*` ON |
| **6000.4.8f1** | Latest 6.x on GameCI — `UNITY_6000_0/1/2/3/4_OR_NEWER` ON |

All four are pinned to specific patch releases per #1107's acceptance criteria (no floating tags), and each was verified present on `unityci/editor` Docker Hub before committing.

## Known coverage gap (documented in JSON `$coverageGap`)

`UNITY_6000_5_OR_NEWER` and `UNITY_6000_6_OR_NEWER` branches in `UnityObjectIdCompat.cs` are **not** exercised by this matrix because GameCI has not yet published images for Unity 6000.5+/6000.6+ (their latest 6.x is 6000.4.8f1 as of this PR). Bump the `rolling` row in `tools/unity-versions.json` when a 6000.5+/6000.6+ image lands.

## Test plan

- [ ] Open this PR — confirm the new **Compute Unity version matrix** job emits `["2021.3.45f2"]` and only the floor leg runs (PR feedback unchanged).
- [ ] After merging to `beta`, confirm the matrix job emits all 4 versions and four parallel test legs run.
- [ ] Confirm `beta-release.yml`'s `update_unity_beta_version` job waits for all 4 legs (no change to gating chain).
- [ ] Negative test (#1107 acceptance criterion): on a throwaway branch, introduce a 2022.3-only compile break and confirm the 2022.3.62f1 leg fails while the 2021.3.45f2 leg passes.
- [ ] Local check: install one matrix version via Unity Hub, run `tools/check-unity-versions.sh --only <prefix>`, confirm PASS.
- [ ] Local Docker check: with `UNITY_LICENSE` set, run `tools/check-unity-versions.sh --docker --only 2021.3`, confirm pull + run succeed.

## What I couldn't verify in CI before this PR

End-to-end Docker pull and Unity container run weren't smoke-tested locally — my dev machine's Docker daemon hit a persistent `EOF` from `registry-1.docker.io` during testing (network/IPv6 issue, not a script bug). All image tags were API-verified against Docker Hub; the script logic is structurally sound, but actual `docker pull` + Unity-in-container behavior needs verification by anyone with a working Docker Hub connection. The CI workflow itself will exercise the same GameCI images via `game-ci/unity-test-runner@v4` on first merge to beta, which validates the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now derives a Unity version matrix at runtime, runs tests across selected Unity versions, and uploads per-version artifacts with mode+version labels.

* **Documentation**
  * Added developer guidance for local multi-version parity checks, reproduce instructions (local/Docker), license notes, and pre-push validation docs.

* **Chores**
  * Added local parity check utilities (CLI + PowerShell), a pre-push hook and installer, a single source-of-truth Unity version manifest, and ignore rules for per-version logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->