### PR TITLE
ci: surface failing test details + fix Unity 6.4 USS log assertion

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -183,13 +183,22 @@ jobs:
           ARTIFACTS_PATH: ${{ steps.tests.outputs.artifactsPath }}
         run: |
           set -euo pipefail
-          RESULTS_XML=$(find "$ARTIFACTS_PATH" -name '*.xml' 2>/dev/null | head -1)
+          # `|| true` so a missing $ARTIFACTS_PATH (Unity crashed before producing any) doesn't trip
+          # `pipefail` and skip the explicit empty-check diagnostic below.
+          RESULTS_XML=$(find "$ARTIFACTS_PATH" -name '*.xml' 2>/dev/null | head -1 || true)
           if [ -z "$RESULTS_XML" ]; then
             echo "::error::No test results XML found — Unity may have crashed"
             exit 1
           fi
           python3 - "$RESULTS_XML" <<'PY'
           import sys, xml.etree.ElementTree as ET
+          # Escape workflow-command payloads so test-controlled XML (under pull_request_target this
+          # is fork-supplied) can't break annotation rendering or inject extra workflow commands.
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+          def esc_data(s):
+              return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+          def esc_prop(s):
+              return esc_data(s).replace(":", "%3A").replace(",", "%2C")
           root = ET.parse(sys.argv[1]).getroot()
           totals = root.attrib
           passed = totals.get("passed", "?")
@@ -210,8 +219,8 @@ jobs:
               # First line of the message becomes the GitHub annotation title.
               first_line = msg.splitlines()[0] if msg else "(no message)"
               # GitHub annotations don't render multi-line bodies, so emit the full failure inside a collapsible group.
-              print(f"::error title=Failed: {name}::{first_line}")
-              print(f"::group::Failure details — {name}")
+              print(f"::error title=Failed: {esc_prop(name)}::{esc_data(first_line)}")
+              print(f"::group::Failure details — {esc_data(name)}")
               if msg:
                   print("Message:")
                   print(msg)

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -179,22 +179,49 @@ jobs:
 
       - name: Check test results
         if: steps.detect.outputs.unity_ok == 'true'
+        env:
+          ARTIFACTS_PATH: ${{ steps.tests.outputs.artifactsPath }}
         run: |
-          RESULTS_XML=$(find ${{ steps.tests.outputs.artifactsPath }} -name '*.xml' 2>/dev/null | head -1)
+          set -euo pipefail
+          RESULTS_XML=$(find "$ARTIFACTS_PATH" -name '*.xml' 2>/dev/null | head -1)
           if [ -z "$RESULTS_XML" ]; then
             echo "::error::No test results XML found — Unity may have crashed"
             exit 1
           fi
-          FAILED=$(grep -oP 'failed="\K[0-9]+' "$RESULTS_XML" | head -1)
-          PASSED=$(grep -oP 'passed="\K[0-9]+' "$RESULTS_XML" | head -1)
-          TOTAL=$(grep -oP 'total="\K[0-9]+' "$RESULTS_XML" | head -1)
-          INCONCLUSIVE=$(grep -oP 'inconclusive="\K[0-9]+' "$RESULTS_XML" | head -1)
-          SKIPPED=$(grep -oP 'skipped="\K[0-9]+' "$RESULTS_XML" | head -1)
-          echo "Results: $PASSED passed, $FAILED failed, $INCONCLUSIVE inconclusive, $SKIPPED skipped (total: $TOTAL)"
-          if [ "$FAILED" != "0" ]; then
-            echo "::error::$FAILED test(s) failed"
-            exit 1
-          fi
+          python3 - "$RESULTS_XML" <<'PY'
+          import sys, xml.etree.ElementTree as ET
+          root = ET.parse(sys.argv[1]).getroot()
+          totals = root.attrib
+          passed = totals.get("passed", "?")
+          failed = totals.get("failed", "?")
+          total  = totals.get("total", "?")
+          incon  = totals.get("inconclusive", "?")
+          skipped = totals.get("skipped", "?")
+          print(f"Results: {passed} passed, {failed} failed, {incon} inconclusive, {skipped} skipped (total: {total})")
+          fails = [tc for tc in root.iter("test-case") if tc.attrib.get("result") == "Failed"]
+          if not fails:
+              sys.exit(0)
+          # Surface every failure inline so a CI watcher doesn't need to download the NUnit XML artifact.
+          for tc in fails:
+              name = tc.attrib.get("fullname") or tc.attrib.get("name") or "<unknown>"
+              f = tc.find("failure")
+              msg = (f.findtext("message") or "").strip() if f is not None else ""
+              stack = (f.findtext("stack-trace") or "").strip() if f is not None else ""
+              # First line of the message becomes the GitHub annotation title.
+              first_line = msg.splitlines()[0] if msg else "(no message)"
+              # GitHub annotations don't render multi-line bodies, so emit the full failure inside a collapsible group.
+              print(f"::error title=Failed: {name}::{first_line}")
+              print(f"::group::Failure details — {name}")
+              if msg:
+                  print("Message:")
+                  print(msg)
+              if stack:
+                  print("Stack trace:")
+                  print(stack)
+              print("::endgroup::")
+          print(f"::error::{len(fails)} test(s) failed")
+          sys.exit(1)
+          PY
 
       - uses: actions/upload-artifact@v4
         if: always() && steps.detect.outputs.unity_ok == 'true' && steps.tests.outcome != 'skipped'

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageUITests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageUITests.cs
@@ -809,14 +809,25 @@ namespace MCPForUnityTests.Editor.Tools
             // USS is CSS-like, not XML — validation should be skipped
             string content = "This is not valid XML <broken>";
 
-            var result = ToJObject(ManageUI.HandleCommand(new JObject
+            // Unity 6000.4+'s USS importer logs an error on this content; the test only
+            // verifies that ManageUI itself doesn't pre-validate .uss as UXML, not the
+            // downstream importer's behavior.
+            LogAssert.ignoreFailingMessages = true;
+            try
             {
-                ["action"] = "create",
-                ["path"] = path,
-                ["contents"] = content,
-            }));
+                var result = ToJObject(ManageUI.HandleCommand(new JObject
+                {
+                    ["action"] = "create",
+                    ["path"] = path,
+                    ["contents"] = content,
+                }));
 
-            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            }
+            finally
+            {
+                LogAssert.ignoreFailingMessages = false;
+            }
         }
 
         // ---- Path traversal validation ----


### PR DESCRIPTION
## Summary

Two related changes bundled — the workflow improvement made the test failure on Unity 6000.4 easy to diagnose, and the test fix addresses the failure that motivated it.

### 1. Workflow: surface failing-test details inline

Follow-up to #1139. Previously the **Check test results** step only echoed NUnit summary counts and exited non-zero — to find out *which* test failed you had to download the `editmode-results.xml` artifact and parse it.

See the post-merge run on #1139 for the concrete pain point: the only signal in the job log was

```
Results: 844 passed, 1 failed, 18 inconclusive, 46 skipped (total: 909)
Error: 1 test(s) failed
Error: Process completed with exit code 1.
```

…with no test name. Tracing it down meant `gh api …/artifacts/<id>/zip` → unzip → XML parse.

This change rewrites the step to use Python (preinstalled on `ubuntu-latest`) to parse the NUnit XML and, for each `<test-case result="Failed">`, emit:

- A workflow annotation (`::error title=Failed: <fullname>::<first line>`) that renders as a clickable annotation on the run page.
- A `::group::` collapsed block with the full failure message + stack trace, so the next reader sees everything in the log without leaving the run.

Behavior on green runs is unchanged: summary line, exit 0. Artifact upload is still performed for deep diagnostics (`editmode.log` etc).

Dry-run against the actual `editmode-results.xml` from the run that motivated this:

```
::error title=Failed: MCPForUnityTests.Editor.Tools.ManageUITests.Create_Uss_SkipsUxmlValidation::Unhandled log message: '[Error] Assets/Temp/ManageUITests/NoValidation_*.uss (line 1): error: Unsupported selector format...'
::group::Failure details — MCPForUnityTests.Editor.Tools.ManageUITests.Create_Uss_SkipsUxmlValidation
Message:
Unhandled log message: '[Error] ...Unsupported selector format: 'This is not valid XML <broken>''. Use UnityEngine.TestTools.LogAssert.Expect
Stack trace:
UnityEditor.AssetDatabase:ImportAsset (string,UnityEditor.ImportAssetOptions)
MCPForUnity.Editor.Tools.ManageUI:CreateFile ... (at /github/workspace/MCPForUnity/Editor/Tools/ManageUI.cs:188)
MCPForUnityTests.Editor.Tools.ManageUITests:Create_Uss_SkipsUxmlValidation () (at Assets/Tests/EditMode/Tools/ManageUITests.cs:812)
...
::endgroup::
::error::1 test(s) failed
```

Why Python (and not more `grep -oP`): NUnit XML is nested, has CDATA sections, and the failure body has embedded newlines + special chars. `xml.etree.ElementTree` is preinstalled on `ubuntu-latest` and handles all of that cleanly. Also lets us pull `passed`/`failed`/`total`/etc. straight from the root `<test-run>` attributes instead of regex on each one.

### 2. Test fix: ManageUITests.Create_Uss_SkipsUxmlValidation on Unity 6.4

The actual failure surfaced by #1139's new matrix. Unity 6000.4's USS importer became stricter and logs an `[Error]` when imported content isn't valid USS — the test deliberately passes invalid-as-XML content (`"This is not valid XML <broken>"`) to verify ManageUI skips UXML validation on `.uss` files, and the resulting importer log is caught by NUnit's `LogAssert` as an unhandled message.

The test's contract — "ManageUI's create-USS path doesn't pre-validate content as UXML" — is independent of what the asset importer does after the file lands on disk. Wrapping the call with `LogAssert.ignoreFailingMessages = true / false` matches the existing pattern used by `Create_MissingNamespace_WritesWithWarning` and `Create_WrongRootElement_WritesWithWarning` in the same file (both already use this exact suppression for the same downstream-importer-log reason).

Older Unity versions (2021.3 / 2022.3 / 6000.0) don't surface that log; the test passes there. This regression was structurally invisible to the pre-#1139 single-version CI.

## Test plan

- [ ] On the first wide-matrix run after this lands, the previously-failing 6000.4.8f1 leg should pass.
- [ ] On any subsequent failure (e.g. an intentional regression test), confirm the annotations panel shows the failed test name + the collapsible group contains full message + stack — no artifact download required.
- [ ] Confirm green-run behavior is unchanged: single summary line, no extra annotations.
- [ ] Confirm the artifact upload still works (unchanged step).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI test-result reporting: per-test error annotations, grouped/collapsible failure details (including stack traces), aggregated totals, and stricter fail detection.

* **Tests**
  * Updated a unit test to suppress downstream importer noise during a UI creation scenario, preventing spurious failures while preserving test intent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->