### PR TITLE
ci: rename 'run-wide-matrix' label to 'full-matrix'

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -38,19 +38,19 @@ jobs:
     # Gate (mirrored by testAllModes below):
     #   - Always run for non-PR triggers (push / workflow_call / workflow_dispatch).
     #   - Fork PRs: require 'safe-to-test' to be applied (existing secret-safety gate);
-    #     'run-wide-matrix' may be added on top to opt into the full 4-version matrix.
-    #   - In-repo PRs: only re-run via pull_request_target when 'run-wide-matrix' is the
+    #     'full-matrix' may be added on top to opt into the full 4-version matrix.
+    #   - In-repo PRs: only re-run via pull_request_target when 'full-matrix' is the
     #     label that just fired (the push-event run already covered the default leg).
     if: >
       github.event_name != 'pull_request_target' ||
       (
         github.event.pull_request.head.repo.full_name != github.repository &&
         contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
-        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'run-wide-matrix')
+        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'full-matrix')
       ) ||
       (
         github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.label.name == 'run-wide-matrix'
+        github.event.label.name == 'full-matrix'
       )
     outputs:
       versions: ${{ steps.set.outputs.versions }}
@@ -67,18 +67,18 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
-          WIDE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-wide-matrix') }}
+          FULL_MATRIX_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
         run: |
           set -euo pipefail
-          # Wide matrix on: beta push, workflow_call (release pipelines), workflow_dispatch,
-          # or any PR labeled with 'run-wide-matrix'.
-          # Narrow (defaultVersion from tools/unity-versions.json) otherwise — fast PR feedback.
+          # Full matrix on: beta push, workflow_call (release pipelines), workflow_dispatch,
+          # or any PR labeled with 'full-matrix'.
+          # Default (single defaultVersion from tools/unity-versions.json) otherwise — fast PR feedback.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]] || \
              [[ "$EVENT_NAME" == "workflow_call" ]] || \
              { [[ "$EVENT_NAME" == "push" ]] && [[ "$GH_REF" == "refs/heads/beta" ]]; } || \
-             { [[ "$EVENT_NAME" == "pull_request_target" ]] && [[ "$WIDE_LABEL" == "true" ]]; }; then
+             { [[ "$EVENT_NAME" == "pull_request_target" ]] && [[ "$FULL_MATRIX_LABEL" == "true" ]]; }; then
             versions=$(jq -c '[.versions[].id]' tools/unity-versions.json)
-            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' (wide_label=$WIDE_LABEL) → wide matrix: $versions"
+            echo "Trigger '$EVENT_NAME' on ref '$GH_REF' (full_matrix_label=$FULL_MATRIX_LABEL) → full matrix: $versions"
           else
             versions=$(jq -c '[.defaultVersion]' tools/unity-versions.json)
             echo "Trigger '$EVENT_NAME' on ref '$GH_REF' → default only: $versions"
@@ -96,11 +96,11 @@ jobs:
       (
         github.event.pull_request.head.repo.full_name != github.repository &&
         contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
-        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'run-wide-matrix')
+        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'full-matrix')
       ) ||
       (
         github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.label.name == 'run-wide-matrix'
+        github.event.label.name == 'full-matrix'
       )
     strategy:
       fail-fast: false

--- a/docs/development/README-DEV.md
+++ b/docs/development/README-DEV.md
@@ -142,16 +142,16 @@ open htmlcov/index.html
 
 CI exercises the package across multiple Unity versions to catch breaks in `#if UNITY_*_OR_NEWER` branches. The matrix is configured in `tools/unity-versions.json` and consumed by `.github/workflows/unity-tests.yml`.
 
-**When the wide matrix runs (all 4 versions in parallel):**
+**When the full matrix runs (all 4 versions in parallel):**
 
 - Push to `beta` (the release gate).
 - `workflow_call` from `beta-release.yml` / `release.yml`.
 - Manual `workflow_dispatch` from the Actions tab.
-- Any PR (in-repo or fork) labeled with **`run-wide-matrix`** — apply this label when your change touches compat shims, conditional compilation, or anything else version-sensitive. The workflow re-runs with the full matrix on the next `pull_request_target` event. Cost is ~6-8 min wall clock vs ~3 min for the default leg.
+- Any PR (in-repo or fork) labeled with **`full-matrix`** — apply this label when your change touches compat shims, conditional compilation, or anything else version-sensitive. The workflow re-runs with the full matrix on the next `pull_request_target` event. Cost is ~6-8 min wall clock vs ~3 min for the default leg.
 
-Fork PRs still need `safe-to-test` as the base gate (existing secret-safety pattern); `run-wide-matrix` is layered on top of that for fork-PR wide runs.
+Fork PRs still need `safe-to-test` as the base gate (existing secret-safety pattern); `full-matrix` is layered on top of that for fork-PR full-matrix runs.
 
-**Default (single leg) runs on every other path** — feature-branch pushes and unlabeled in-repo PRs run only against `defaultVersion` from `tools/unity-versions.json` (currently Unity 6.0 LTS, `6000.0.75f1`). The `floor` role (`2021.3.45f2`) still identifies the package minimum and runs as part of the wide matrix; it's no longer the default-leg version.
+**Default (single leg) runs on every other path** — feature-branch pushes and unlabeled in-repo PRs run only against `defaultVersion` from `tools/unity-versions.json` (currently Unity 6.0 LTS, `6000.0.75f1`). The `floor` role (`2021.3.45f2`) still identifies the package minimum and runs as part of the full matrix; it's no longer the default-leg version.
 
 ## Local Unity-version parity check
 


### PR DESCRIPTION
## Summary

Shorter, less verb-y. Same semantics — applying the label opts the PR into the 4-version matrix on the next `pull_request_target` event, on top of `safe-to-test` for fork PRs and standalone for in-repo PRs.

The `run-wide-matrix` label was introduced in #1139 (merged hours ago, no PR has used it yet), so this rename is purely editorial — no migration needed.

## Renamed identifiers

| Was | Is now |
|---|---|
| `run-wide-matrix` (label name) | `full-matrix` |
| `WIDE_LABEL` (step env var) | `FULL_MATRIX_LABEL` |
| "wide matrix" (comments + echo output) | "full matrix" |
| README-DEV.md prose ("wide matrix runs") | "full matrix runs" |

## Diff scope

```
 .github/workflows/unity-tests.yml | 24 ++++++++++++------------
 docs/development/README-DEV.md    |  8 ++++----
 2 files changed, 16 insertions(+), 16 deletions(-)
```

The workflow's `Check test results` step is untouched (lives in a separate region of the file from the matrix selector and gates; doesn't conflict with #1140).

## Test plan

- [ ] YAML parses (verified locally).
- [ ] Selector dry-run shows the `full-matrix` env var still drives matrix selection correctly: `FULL_MATRIX_LABEL=true` → full matrix, `FULL_MATRIX_LABEL=false` → default only.
- [ ] After this lands on `beta`, apply the new `full-matrix` label to a test PR and confirm the workflow re-runs with all 4 versions.

## Note on related PRs

- #1139 (merged) introduced the label as `run-wide-matrix`.
- #1140 (open) is unrelated — it modifies the `Check test results` step in a different section of the same workflow file. No line-level conflict with this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated continuous integration workflow configuration and labels for test execution
  * Refined development documentation regarding CI matrix testing procedures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->