### PR TITLE
feat+fix: one-click client connection + autotest bug-fix batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .codeiumignore
 .kiro
 
+# Local worktrees for parallel feature work
+.worktrees/
+
 # Code-copy related files
 .clipignore
 

--- a/MCPForUnity/Editor/Clients/Configurators/ClaudeDesktopConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/ClaudeDesktopConfigurator.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Models;
-using MCPForUnity.Editor.Services;
 using UnityEditor;
 
 namespace MCPForUnity.Editor.Clients.Configurators
@@ -41,17 +39,5 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
         private static readonly ConfiguredTransport[] StdioOnly = { ConfiguredTransport.Stdio };
         public override IReadOnlyList<ConfiguredTransport> SupportedTransports => StdioOnly;
-
-        public override string GetManualSnippet()
-        {
-            bool useHttp = EditorConfigurationCache.Instance.UseHttpTransport;
-            if (useHttp)
-            {
-                return "# Claude Desktop does not support HTTP transport.\n" +
-                       "# In Connect tab, change the Transport option from HTTP to stdio, then regenerate.";
-            }
-
-            return base.GetManualSnippet();
-        }
     }
 }

--- a/MCPForUnity/Editor/Clients/Configurators/ClaudeDesktopConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/ClaudeDesktopConfigurator.cs
@@ -39,16 +39,8 @@ namespace MCPForUnity.Editor.Clients.Configurators
             "Save and restart Claude Desktop"
         };
 
-        public override void Configure()
-        {
-            bool useHttp = EditorConfigurationCache.Instance.UseHttpTransport;
-            if (useHttp)
-            {
-                throw new InvalidOperationException("Claude Desktop does not support HTTP transport. Switch to stdio in settings before configuring.");
-            }
-
-            base.Configure();
-        }
+        private static readonly ConfiguredTransport[] StdioOnly = { ConfiguredTransport.Stdio };
+        public override IReadOnlyList<ConfiguredTransport> SupportedTransports => StdioOnly;
 
         public override string GetManualSnippet()
         {

--- a/MCPForUnity/Editor/Clients/IMcpClientConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/IMcpClientConfigurator.cs
@@ -33,6 +33,12 @@ namespace MCPForUnity.Editor.Clients
         /// </summary>
         bool IsInstalled { get; }
 
+        /// <summary>
+        /// Transports this client can be configured with. Order is "preference if user has no opinion";
+        /// the configure path picks the user's global preference if present in this list, else falls back to the first entry.
+        /// </summary>
+        System.Collections.Generic.IReadOnlyList<ConfiguredTransport> SupportedTransports { get; }
+
         /// <summary>Label to show on the configure button for the current state.</summary>
         string GetConfigureActionLabel();
 

--- a/MCPForUnity/Editor/Clients/IMcpClientConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/IMcpClientConfigurator.cs
@@ -26,6 +26,13 @@ namespace MCPForUnity.Editor.Clients
         /// <summary>True if this client supports auto-configure.</summary>
         bool SupportsAutoConfigure { get; }
 
+        /// <summary>
+        /// True if this client appears installed on the user's machine. Used to filter
+        /// "configure all detected" so we don't write configs for apps the user doesn't have.
+        /// Implementations should be cheap (filesystem stat or cached path lookup).
+        /// </summary>
+        bool IsInstalled { get; }
+
         /// <summary>Label to show on the configure button for the current state.</summary>
         string GetConfigureActionLabel();
 

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -60,6 +60,17 @@ namespace MCPForUnity.Editor.Clients
             return client.linuxConfigPath;
         }
 
+        protected static bool ParentDirectoryExists(string configPath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(configPath)) return false;
+                string parent = Path.GetDirectoryName(configPath);
+                return !string.IsNullOrEmpty(parent) && Directory.Exists(parent);
+            }
+            catch { return false; }
+        }
+
         protected bool UrlsEqual(string a, string b)
         {
             if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
@@ -132,20 +143,7 @@ namespace MCPForUnity.Editor.Clients
 
         public override string GetConfigPath() => CurrentOsPath();
 
-        public override bool IsInstalled
-        {
-            get
-            {
-                try
-                {
-                    string path = GetConfigPath();
-                    if (string.IsNullOrEmpty(path)) return false;
-                    string parent = Path.GetDirectoryName(path);
-                    return !string.IsNullOrEmpty(parent) && Directory.Exists(parent);
-                }
-                catch { return false; }
-            }
-        }
+        public override bool IsInstalled => ParentDirectoryExists(GetConfigPath());
 
         public override McpStatus CheckStatus(bool attemptAutoRewrite = true)
         {
@@ -373,20 +371,7 @@ namespace MCPForUnity.Editor.Clients
 
         public override string GetConfigPath() => CurrentOsPath();
 
-        public override bool IsInstalled
-        {
-            get
-            {
-                try
-                {
-                    string path = GetConfigPath();
-                    if (string.IsNullOrEmpty(path)) return false;
-                    string parent = Path.GetDirectoryName(path);
-                    return !string.IsNullOrEmpty(parent) && Directory.Exists(parent);
-                }
-                catch { return false; }
-            }
-        }
+        public override bool IsInstalled => ParentDirectoryExists(GetConfigPath());
 
         public override McpStatus CheckStatus(bool attemptAutoRewrite = true)
         {
@@ -573,17 +558,7 @@ namespace MCPForUnity.Editor.Clients
 
         public override string GetConfigPath() => "Managed via Claude CLI";
 
-        public override bool IsInstalled
-        {
-            get
-            {
-                try
-                {
-                    return !string.IsNullOrEmpty(MCPServiceLocator.Paths.GetClaudeCliPath());
-                }
-                catch { return false; }
-            }
-        }
+        public override bool IsInstalled => MCPServiceLocator.Paths.IsClaudeCliDetected();
 
         /// <summary>
         /// Returns the project directory that CLI-based configurators will use as the working directory

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -31,6 +31,9 @@ namespace MCPForUnity.Editor.Clients
         public ConfiguredTransport ConfiguredTransport => client.configuredTransport;
         public virtual bool SupportsAutoConfigure => true;
         public virtual bool IsInstalled => true;
+        private static readonly ConfiguredTransport[] DefaultTransports =
+            { ConfiguredTransport.Stdio, ConfiguredTransport.Http };
+        public virtual IReadOnlyList<ConfiguredTransport> SupportedTransports => DefaultTransports;
         public virtual bool SupportsSkills => false;
         public virtual string GetConfigureActionLabel() => "Configure";
         public virtual string GetSkillInstallPath() => null;

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -30,6 +30,7 @@ namespace MCPForUnity.Editor.Clients
         public McpStatus Status => client.status;
         public ConfiguredTransport ConfiguredTransport => client.configuredTransport;
         public virtual bool SupportsAutoConfigure => true;
+        public virtual bool IsInstalled => true;
         public virtual bool SupportsSkills => false;
         public virtual string GetConfigureActionLabel() => "Configure";
         public virtual string GetSkillInstallPath() => null;
@@ -130,6 +131,21 @@ namespace MCPForUnity.Editor.Clients
         public JsonFileMcpConfigurator(McpClient client) : base(client) { }
 
         public override string GetConfigPath() => CurrentOsPath();
+
+        public override bool IsInstalled
+        {
+            get
+            {
+                try
+                {
+                    string path = GetConfigPath();
+                    if (string.IsNullOrEmpty(path)) return false;
+                    string parent = Path.GetDirectoryName(path);
+                    return !string.IsNullOrEmpty(parent) && Directory.Exists(parent);
+                }
+                catch { return false; }
+            }
+        }
 
         public override McpStatus CheckStatus(bool attemptAutoRewrite = true)
         {
@@ -357,6 +373,21 @@ namespace MCPForUnity.Editor.Clients
 
         public override string GetConfigPath() => CurrentOsPath();
 
+        public override bool IsInstalled
+        {
+            get
+            {
+                try
+                {
+                    string path = GetConfigPath();
+                    if (string.IsNullOrEmpty(path)) return false;
+                    string parent = Path.GetDirectoryName(path);
+                    return !string.IsNullOrEmpty(parent) && Directory.Exists(parent);
+                }
+                catch { return false; }
+            }
+        }
+
         public override McpStatus CheckStatus(bool attemptAutoRewrite = true)
         {
             try
@@ -541,6 +572,18 @@ namespace MCPForUnity.Editor.Clients
         public override string GetConfigureActionLabel() => client.status == McpStatus.Configured ? "Unregister" : "Configure";
 
         public override string GetConfigPath() => "Managed via Claude CLI";
+
+        public override bool IsInstalled
+        {
+            get
+            {
+                try
+                {
+                    return !string.IsNullOrEmpty(MCPServiceLocator.Paths.GetClaudeCliPath());
+                }
+                catch { return false; }
+            }
+        }
 
         /// <summary>
         /// Returns the project directory that CLI-based configurators will use as the working directory

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -30,7 +30,11 @@ namespace MCPForUnity.Editor.Clients
         public McpStatus Status => client.status;
         public ConfiguredTransport ConfiguredTransport => client.configuredTransport;
         public virtual bool SupportsAutoConfigure => true;
-        public virtual bool IsInstalled => true;
+        // Default to a filesystem check on the configured path. Concrete configurators
+        // whose presence isn't path-based (CLI binaries, etc.) override this. This makes
+        // any future configurator that forgets to override fail-closed rather than be
+        // treated as "detected" by ConfigureAllDetectedClients.
+        public virtual bool IsInstalled => ParentDirectoryExists(GetConfigPath());
         private static readonly ConfiguredTransport[] DefaultTransports =
             { ConfiguredTransport.Stdio, ConfiguredTransport.Http };
         public virtual IReadOnlyList<ConfiguredTransport> SupportedTransports => DefaultTransports;

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -165,41 +165,35 @@ namespace MCPForUnity.Editor.Clients
                 string configuredUrl = null;
                 bool configExists = false;
 
-                if (client.IsVsCodeLayout)
                 {
-                    var vsConfig = JsonConvert.DeserializeObject<JToken>(configJson) as JObject;
-                    if (vsConfig != null)
+                    var rootConfig = JsonConvert.DeserializeObject<JToken>(configJson) as JObject;
+                    JToken unityToken = null;
+                    if (rootConfig != null)
                     {
-                        var unityToken =
-                            vsConfig["servers"]?["unityMCP"]
-                            ?? vsConfig["mcp"]?["servers"]?["unityMCP"];
-
-                        if (unityToken is JObject unityObj)
-                        {
-                            configExists = true;
-
-                            var argsToken = unityObj["args"];
-                            if (argsToken is JArray)
-                            {
-                                args = argsToken.ToObject<string[]>();
-                            }
-
-                            var urlToken = unityObj["url"] ?? unityObj["serverUrl"];
-                            if (urlToken != null && urlToken.Type != JTokenType.Null)
-                            {
-                                configuredUrl = urlToken.ToString();
-                            }
-                        }
+                        unityToken = client.IsVsCodeLayout
+                            ? rootConfig["servers"]?["unityMCP"]
+                                ?? rootConfig["mcp"]?["servers"]?["unityMCP"]
+                            : rootConfig["mcpServers"]?["unityMCP"];
                     }
-                }
-                else
-                {
-                    McpConfig standardConfig = JsonConvert.DeserializeObject<McpConfig>(configJson);
-                    if (standardConfig?.mcpServers?.unityMCP != null)
+
+                    if (unityToken is JObject unityObj)
                     {
-                        args = standardConfig.mcpServers.unityMCP.args;
-                        configuredUrl = standardConfig.mcpServers.unityMCP.url;
                         configExists = true;
+
+                        var argsToken = unityObj["args"];
+                        if (argsToken is JArray)
+                        {
+                            args = argsToken.ToObject<string[]>();
+                        }
+
+                        // Clients diverge on the HTTP URL property name: "url" (Cursor/VSCode/Claude),
+                        // "serverUrl" (Antigravity/Windsurf), "httpUrl" (Gemini CLI). Accept all three
+                        // so CheckStatus matches what Configure() actually wrote.
+                        var urlToken = unityObj["url"] ?? unityObj["serverUrl"] ?? unityObj["httpUrl"];
+                        if (urlToken != null && urlToken.Type != JTokenType.Null)
+                        {
+                            configuredUrl = urlToken.ToString();
+                        }
                     }
                 }
 

--- a/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
+++ b/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
@@ -49,6 +49,7 @@ namespace MCPForUnity.Editor.Constants
         internal const string ResourceFoldoutStatePrefix = "MCPForUnity.ResourceFoldout.";
         internal const string EditorWindowActivePanel = "MCPForUnity.EditorWindow.ActivePanel";
         internal const string LastSelectedClientId = "MCPForUnity.LastSelectedClientId";
+        internal const string ClientDetailsFoldoutOpen = "MCPForUnity.ClientConfig.DetailsFoldoutOpen";
 
         internal const string SetupCompleted = "MCPForUnity.SetupCompleted";
         internal const string SetupDismissed = "MCPForUnity.SetupDismissed";

--- a/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
+++ b/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
@@ -14,6 +14,12 @@
     ],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.visualeffectgraph",
+            "expression": "0.0.0",
+            "define": "UNITY_VFX_GRAPH"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/MCPForUnity/Editor/Services/ClientConfigurationService.cs
+++ b/MCPForUnity/Editor/Services/ClientConfigurationService.cs
@@ -96,16 +96,51 @@ namespace MCPForUnity.Editor.Services
             bool currentlyHttp = EditorConfigurationCache.Instance.UseHttpTransport;
             var requested = currentlyHttp ? ConfiguredTransport.Http : ConfiguredTransport.Stdio;
 
-            if (supported.Contains(requested)) return; // user preference is supported, no change
+            // Accept any HTTP variant (Http, HttpRemote) when the user wants HTTP — a client that
+            // only supports HttpRemote should not get coerced to stdio just because Http isn't
+            // explicitly listed.
+            if (SupportsRequested(supported, requested)) return;
 
-            var chosen = supported[0];
-            bool needHttp = chosen == ConfiguredTransport.Http;
+            // Fall back in the direction of the user's intent: if they wanted HTTP, prefer any
+            // HTTP variant the client does support; otherwise prefer stdio. Honors the
+            // configurator's declared order when more than one option remains.
+            ConfiguredTransport chosen = PickFallback(supported, requested);
+            bool needHttp = IsHttpVariant(chosen);
             if (EditorConfigurationCache.Instance.UseHttpTransport != needHttp)
             {
                 EditorConfigurationCache.Instance.SetUseHttpTransport(needHttp);
                 McpLog.Info(
                     $"[{configurator.DisplayName}] auto-selected {chosen} transport (client does not support {requested}).");
             }
+        }
+
+        private static bool IsHttpVariant(ConfiguredTransport t)
+            => t == ConfiguredTransport.Http || t == ConfiguredTransport.HttpRemote;
+
+        private static bool SupportsRequested(IReadOnlyList<ConfiguredTransport> supported, ConfiguredTransport requested)
+        {
+            if (requested == ConfiguredTransport.Http)
+            {
+                foreach (var t in supported)
+                    if (IsHttpVariant(t)) return true;
+                return false;
+            }
+            return supported.Contains(requested);
+        }
+
+        private static ConfiguredTransport PickFallback(IReadOnlyList<ConfiguredTransport> supported, ConfiguredTransport requested)
+        {
+            if (requested == ConfiguredTransport.Http)
+            {
+                foreach (var t in supported)
+                    if (IsHttpVariant(t)) return t;
+            }
+            else
+            {
+                foreach (var t in supported)
+                    if (t == ConfiguredTransport.Stdio) return t;
+            }
+            return supported[0];
         }
     }
 }

--- a/MCPForUnity/Editor/Services/ClientConfigurationService.cs
+++ b/MCPForUnity/Editor/Services/ClientConfigurationService.cs
@@ -30,7 +30,16 @@ namespace MCPForUnity.Editor.Services
                 AssetPathUtility.CleanLocalServerBuildArtifacts();
             }
 
-            configurator.Configure();
+            bool originalHttp = EditorConfigurationCache.Instance.UseHttpTransport;
+            try
+            {
+                CoerceTransportFor(configurator);
+                configurator.Configure();
+            }
+            finally
+            {
+                EditorConfigurationCache.Instance.SetUseHttpTransport(originalHttp);
+            }
         }
 
         public ClientConfigurationSummary ConfigureAllDetectedClients()
@@ -69,5 +78,24 @@ namespace MCPForUnity.Editor.Services
             return current != previous;
         }
 
+        private static void CoerceTransportFor(IMcpClientConfigurator configurator)
+        {
+            var supported = configurator.SupportedTransports;
+            if (supported == null || supported.Count == 0) return;
+
+            bool currentlyHttp = EditorConfigurationCache.Instance.UseHttpTransport;
+            var requested = currentlyHttp ? ConfiguredTransport.Http : ConfiguredTransport.Stdio;
+
+            if (supported.Contains(requested)) return; // user preference is supported, no change
+
+            var chosen = supported[0];
+            bool needHttp = chosen == ConfiguredTransport.Http;
+            if (EditorConfigurationCache.Instance.UseHttpTransport != needHttp)
+            {
+                EditorConfigurationCache.Instance.SetUseHttpTransport(needHttp);
+                McpLog.Info(
+                    $"[{configurator.DisplayName}] auto-selected {chosen} transport (client does not support {requested}).");
+            }
+        }
     }
 }

--- a/MCPForUnity/Editor/Services/ClientConfigurationService.cs
+++ b/MCPForUnity/Editor/Services/ClientConfigurationService.cs
@@ -44,6 +44,11 @@ namespace MCPForUnity.Editor.Services
             var summary = new ClientConfigurationSummary();
             foreach (var configurator in configurators)
             {
+                if (!configurator.IsInstalled)
+                {
+                    summary.SkippedCount++;
+                    continue;
+                }
                 try
                 {
                     // Always re-run configuration so core fields stay current

--- a/MCPForUnity/Editor/Services/ClientConfigurationService.cs
+++ b/MCPForUnity/Editor/Services/ClientConfigurationService.cs
@@ -30,16 +30,7 @@ namespace MCPForUnity.Editor.Services
                 AssetPathUtility.CleanLocalServerBuildArtifacts();
             }
 
-            bool originalHttp = EditorConfigurationCache.Instance.UseHttpTransport;
-            try
-            {
-                CoerceTransportFor(configurator);
-                configurator.Configure();
-            }
-            finally
-            {
-                EditorConfigurationCache.Instance.SetUseHttpTransport(originalHttp);
-            }
+            ConfigureWithTransportCoercion(configurator);
         }
 
         public ClientConfigurationSummary ConfigureAllDetectedClients()
@@ -57,7 +48,7 @@ namespace MCPForUnity.Editor.Services
                 {
                     // Always re-run configuration so core fields stay current
                     configurator.CheckStatus(attemptAutoRewrite: false);
-                    configurator.Configure();
+                    ConfigureWithTransportCoercion(configurator);
                     summary.SuccessCount++;
                     summary.Messages.Add($"✓ {configurator.DisplayName}: Configured successfully");
                 }
@@ -69,6 +60,20 @@ namespace MCPForUnity.Editor.Services
             }
 
             return summary;
+        }
+
+        private static void ConfigureWithTransportCoercion(IMcpClientConfigurator configurator)
+        {
+            bool originalHttp = EditorConfigurationCache.Instance.UseHttpTransport;
+            try
+            {
+                CoerceTransportFor(configurator);
+                configurator.Configure();
+            }
+            finally
+            {
+                EditorConfigurationCache.Instance.SetUseHttpTransport(originalHttp);
+            }
         }
 
         public bool CheckClientStatus(IMcpClientConfigurator configurator, bool attemptAutoRewrite = true)

--- a/MCPForUnity/Editor/Services/StartupConfigRewrite.cs
+++ b/MCPForUnity/Editor/Services/StartupConfigRewrite.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using MCPForUnity.Editor.Clients;
 using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Helpers;
@@ -20,6 +22,10 @@ namespace MCPForUnity.Editor.Services
         static StartupConfigRewrite()
         {
             if (UnityEditorInternal.InternalEditorUtility.inBatchMode) return;
+            // AssetImportWorker subprocesses share [InitializeOnLoad] but don't host MCP and
+            // shouldn't be writing client configs from a half-loaded domain (same surface as
+            // issue #1134 in CommandRegistry).
+            if (IsRunningInAssetImportWorker()) return;
             if (SessionState.GetBool(SESSION_GUARD_KEY, false)) return;
             EditorApplication.delayCall += RunOnce;
         }
@@ -37,8 +43,10 @@ namespace MCPForUnity.Editor.Services
                 try
                 {
                     if (!c.IsInstalled) continue;
+                    // Always let CheckStatus read the current state from disk before deciding —
+                    // the in-memory Status can be NotConfigured on a fresh editor load even
+                    // though the file already has a valid config.
                     var before = c.Status;
-                    if (before == McpStatus.NotConfigured) continue;
                     var after = c.CheckStatus(attemptAutoRewrite: true);
                     if (before != after && after == McpStatus.Configured) rewrote++;
                 }
@@ -49,6 +57,40 @@ namespace MCPForUnity.Editor.Services
             }
             if (rewrote > 0)
                 McpLog.Info($"[StartupConfigRewrite] refreshed {rewrote} client config(s).");
+        }
+
+        private static bool? _cachedIsAssetImportWorker;
+
+        private static bool IsRunningInAssetImportWorker()
+        {
+            if (_cachedIsAssetImportWorker.HasValue)
+                return _cachedIsAssetImportWorker.Value;
+
+            bool result = false;
+            try
+            {
+                var method = typeof(UnityEditor.AssetDatabase).GetMethod(
+                    "IsAssetImportWorkerProcess",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                if (method != null && method.GetParameters().Length == 0)
+                    result = method.Invoke(null, null) is bool b && b;
+            }
+            catch { }
+
+            if (!result)
+            {
+                try
+                {
+                    string cmd = Environment.CommandLine ?? string.Empty;
+                    if (cmd.IndexOf("-importWorker", StringComparison.OrdinalIgnoreCase) >= 0
+                        || cmd.IndexOf("AssetImportWorker", StringComparison.OrdinalIgnoreCase) >= 0)
+                        result = true;
+                }
+                catch { }
+            }
+
+            _cachedIsAssetImportWorker = result;
+            return result;
         }
     }
 }

--- a/MCPForUnity/Editor/Services/StartupConfigRewrite.cs
+++ b/MCPForUnity/Editor/Services/StartupConfigRewrite.cs
@@ -1,0 +1,54 @@
+using MCPForUnity.Editor.Clients;
+using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Models;
+using UnityEditor;
+
+namespace MCPForUnity.Editor.Services
+{
+    /// <summary>
+    /// Once per Editor session, sweeps registered configurators and re-runs CheckStatus(attemptAutoRewrite: true)
+    /// for any installed client that already has a config on disk. Catches the case where the user updated the
+    /// MCP for Unity package while the Editor was closed — without this sweep, stale package versions in client
+    /// configs would persist until the user opens the MCP window.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class StartupConfigRewrite
+    {
+        public const string SESSION_GUARD_KEY = "MCPForUnity.StartupConfigRewrite.Ran";
+
+        static StartupConfigRewrite()
+        {
+            if (UnityEditorInternal.InternalEditorUtility.inBatchMode) return;
+            if (SessionState.GetBool(SESSION_GUARD_KEY, false)) return;
+            EditorApplication.delayCall += RunOnce;
+        }
+
+        private static void RunOnce()
+        {
+            if (SessionState.GetBool(SESSION_GUARD_KEY, false)) return;
+            SessionState.SetBool(SESSION_GUARD_KEY, true);
+
+            if (!EditorPrefs.GetBool(EditorPrefKeys.AutoRegisterEnabled, true)) return;
+
+            int rewrote = 0;
+            foreach (var c in McpClientRegistry.All)
+            {
+                try
+                {
+                    if (!c.IsInstalled) continue;
+                    var before = c.Status;
+                    if (before == McpStatus.NotConfigured) continue;
+                    var after = c.CheckStatus(attemptAutoRewrite: true);
+                    if (before != after && after == McpStatus.Configured) rewrote++;
+                }
+                catch (System.Exception ex)
+                {
+                    McpLog.Warn($"[StartupConfigRewrite] {c.DisplayName} failed: {ex.Message}");
+                }
+            }
+            if (rewrote > 0)
+                McpLog.Info($"[StartupConfigRewrite] refreshed {rewrote} client config(s).");
+        }
+    }
+}

--- a/MCPForUnity/Editor/Services/StartupConfigRewrite.cs.meta
+++ b/MCPForUnity/Editor/Services/StartupConfigRewrite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 545839736dec4fc49c7392412dac7856
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -481,7 +481,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     try
                     {
                         var ep = client.Client?.RemoteEndPoint?.ToString() ?? "unknown";
-                        McpLog.Info($"Client connected {ep} (active clients: {clientCount})");
+                        McpLog.Info($"Client connected {ep} (active clients: {clientCount})", always: false);
                     }
                     catch { }
                     try
@@ -517,7 +517,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     }
                     if (staleClients.Length > 0)
                     {
-                        McpLog.Info($"Closing {staleClients.Length} stale client(s) after new connection");
+                        McpLog.Info($"Closing {staleClients.Length} stale client(s) after new connection", always: false);
                         foreach (var stale in staleClients)
                         {
                             try { stale.Close(); } catch { }
@@ -649,7 +649,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     lock (clientsLock) { activeClients.Remove(client); }
                     int remaining;
                     lock (clientsLock) { remaining = activeClients.Count; }
-                    McpLog.Info($"Client handler exited (remaining clients: {remaining})");
+                    McpLog.Info($"Client handler exited (remaining clients: {remaining})", always: false);
                 }
             }
         }

--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -58,6 +58,16 @@ namespace MCPForUnity.Editor.Tools
         /// </summary>
         private static void AutoDiscoverCommands()
         {
+            // AssetImportWorker is a separate Editor subprocess. It doesn't host the MCP
+            // transport so the registry is unused there, and Mono can hard-crash inside
+            // GetCustomAttribute<T>() when scanning types whose owning assembly hasn't
+            // finished domain-reload bookkeeping in the worker. Skip the scan there
+            // entirely. See issue #1134.
+            if (IsRunningInAssetImportWorker())
+            {
+                return;
+            }
+
             try
             {
                 var allTypes = UnityAssembliesCompat.GetLoadedAssemblies()
@@ -70,7 +80,7 @@ namespace MCPForUnity.Editor.Tools
                     .ToList();
 
                 // Discover tools
-                var toolTypes = allTypes.Where(t => t.GetCustomAttribute<McpForUnityToolAttribute>() != null);
+                var toolTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityToolAttribute>(t));
                 int toolCount = 0;
                 foreach (var type in toolTypes)
                 {
@@ -79,7 +89,7 @@ namespace MCPForUnity.Editor.Tools
                 }
 
                 // Discover resources
-                var resourceTypes = allTypes.Where(t => t.GetCustomAttribute<McpForUnityResourceAttribute>() != null);
+                var resourceTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityResourceAttribute>(t));
                 int resourceCount = 0;
                 foreach (var type in resourceTypes)
                 {
@@ -93,6 +103,64 @@ namespace MCPForUnity.Editor.Tools
             {
                 McpLog.Error($"Failed to auto-discover MCP commands: {ex.Message}");
             }
+        }
+
+        private static bool HasAttributeSafe<T>(Type type) where T : Attribute
+        {
+            try
+            {
+                return type.GetCustomAttribute<T>() != null;
+            }
+            catch
+            {
+                // Type metadata can be in a half-loaded state during domain reload; treat
+                // those as "no attribute" rather than aborting the whole scan.
+                return false;
+            }
+        }
+
+        private static bool? _cachedIsAssetImportWorker;
+
+        private static bool IsRunningInAssetImportWorker()
+        {
+            if (_cachedIsAssetImportWorker.HasValue)
+                return _cachedIsAssetImportWorker.Value;
+
+            bool result = false;
+            try
+            {
+                // AssetDatabase.IsAssetImportWorkerProcess() exists on Unity 2020.2+ but the
+                // visibility has shifted between versions. Look it up reflectively so we
+                // tolerate either signature without conditional compilation.
+                var method = typeof(UnityEditor.AssetDatabase).GetMethod(
+                    "IsAssetImportWorkerProcess",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                if (method != null && method.GetParameters().Length == 0)
+                {
+                    result = method.Invoke(null, null) is bool b && b;
+                }
+            }
+            catch
+            {
+                // Reflection problems shouldn't break startup; fall through to the cmdline check.
+            }
+
+            if (!result)
+            {
+                try
+                {
+                    string cmd = Environment.CommandLine ?? string.Empty;
+                    if (cmd.IndexOf("-importWorker", StringComparison.OrdinalIgnoreCase) >= 0
+                        || cmd.IndexOf("AssetImportWorker", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        result = true;
+                    }
+                }
+                catch { }
+            }
+
+            _cachedIsAssetImportWorker = result;
+            return result;
         }
 
         /// <summary>

--- a/MCPForUnity/Editor/Tools/Vfx/VfxGraphAssets.cs
+++ b/MCPForUnity/Editor/Tools/Vfx/VfxGraphAssets.cs
@@ -39,8 +39,6 @@ namespace MCPForUnity.Editor.Tools.Vfx
             return new { success = false, message = "VFX Graph package (com.unity.visualeffectgraph) not installed" };
         }
 #else
-        private static readonly string[] SupportedVfxGraphVersions = { "12.1" };
-
         /// <summary>
         /// Creates a new VFX Graph asset file from a template.
         /// </summary>
@@ -486,54 +484,17 @@ namespace MCPForUnity.Editor.Tools.Vfx
 
         private static string ValidateVfxGraphVersion()
         {
+            // UNITY_VFX_GRAPH is set by the asmdef versionDefines whenever the package is
+            // installed, so reaching this branch already implies presence. Keep a runtime
+            // double-check for the rare window during install/uninstall where the compile
+            // gate and the package state can briefly disagree.
             var info = UnityEditor.PackageManager.PackageInfo.FindForAssetPath("Packages/com.unity.visualeffectgraph");
             if (info == null)
             {
                 return "VFX Graph package (com.unity.visualeffectgraph) not installed";
             }
 
-            if (IsVersionSupported(info.version))
-            {
-                return null;
-            }
-
-            string supported = string.Join(", ", SupportedVfxGraphVersions.Select(version => $"{version}.x"));
-            return $"Unsupported VFX Graph version {info.version}. Supported versions: {supported}.";
-        }
-
-        private static bool IsVersionSupported(string installedVersion)
-        {
-            if (string.IsNullOrEmpty(installedVersion))
-            {
-                return false;
-            }
-
-            string normalized = installedVersion;
-            int suffixIndex = normalized.IndexOfAny(new[] { '-', '+' });
-            if (suffixIndex >= 0)
-            {
-                normalized = normalized.Substring(0, suffixIndex);
-            }
-
-            if (!Version.TryParse(normalized, out Version installed))
-            {
-                return false;
-            }
-
-            foreach (string supported in SupportedVfxGraphVersions)
-            {
-                if (!Version.TryParse(supported, out Version target))
-                {
-                    continue;
-                }
-
-                if (installed.Major == target.Major && installed.Minor == target.Minor)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return null;
         }
 
         private static string TryGetAssetPathFromFileSystem(string templatePath)

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
@@ -284,13 +284,16 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
             {
                 var summary = MCPServiceLocator.Client.ConfigureAllDetectedClients();
 
-                string message = summary.GetSummaryMessage() + "\n\n";
+                string headline = summary.SkippedCount > 0
+                    ? $"{summary.SuccessCount + summary.FailureCount} detected client(s) processed. ({summary.SkippedCount} not installed, skipped.)"
+                    : summary.GetSummaryMessage();
+                string message = headline + "\n\n";
                 foreach (var msg in summary.Messages)
                 {
                     message += msg + "\n";
                 }
 
-                EditorUtility.DisplayDialog("Configure All Clients", message, "OK");
+                EditorUtility.DisplayDialog("Configure Detected Clients", message, "OK");
 
                 if (selectedClientIndex >= 0 && selectedClientIndex < configurators.Count)
                 {

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
@@ -37,6 +37,7 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
         private TextField clientProjectDirField;
         private Button browseProjectDirButton;
         private Button clearProjectDirButton;
+        private Foldout clientDetailsFoldout;
         private Foldout manualConfigFoldout;
         private TextField configPathField;
         private Button copyPathButton;
@@ -92,6 +93,7 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
             clientProjectDirField = Root.Q<TextField>("client-project-dir");
             browseProjectDirButton = Root.Q<Button>("browse-project-dir-button");
             clearProjectDirButton = Root.Q<Button>("clear-project-dir-button");
+            clientDetailsFoldout = Root.Q<Foldout>("client-details-foldout");
             manualConfigFoldout = Root.Q<Foldout>("manual-config-foldout");
             configPathField = Root.Q<TextField>("config-path");
             copyPathButton = Root.Q<Button>("copy-path-button");
@@ -107,6 +109,17 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
             if (manualConfigFoldout != null)
             {
                 manualConfigFoldout.value = false;
+            }
+
+            // Restore the "Configure a single client" foldout state. Defaults to collapsed
+            // so the prominent "Configure All Detected Clients" path is what users see first.
+            if (clientDetailsFoldout != null)
+            {
+                clientDetailsFoldout.value = EditorPrefs.GetBool(EditorPrefKeys.ClientDetailsFoldoutOpen, false);
+                clientDetailsFoldout.RegisterValueChangedCallback(evt =>
+                {
+                    EditorPrefs.SetBool(EditorPrefKeys.ClientDetailsFoldoutOpen, evt.newValue);
+                });
             }
 
             var clientNames = configurators.Select(c => c.DisplayName).ToList();

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
@@ -4,8 +4,7 @@
         <ui:Label text="Client Configuration" class="section-title" />
         <ui:VisualElement class="section-content">
             <ui:Button name="configure-all-button" text="Configure All Detected Clients" class="primary-button" />
-            <ui:Label text="One-click setup for every MCP client we detect on this machine." class="help-text primary-button-hint" />
-            <ui:Foldout name="client-details-foldout" text="Configure a single client" value="false" class="client-details-foldout">
+            <ui:Foldout name="client-details-foldout" text="Per-client setup" value="false" class="client-details-foldout">
                 <ui:VisualElement class="setting-row">
                     <ui:Label text="Client:" class="setting-label" />
                     <ui:DropdownField name="client-dropdown" class="setting-dropdown-inline" />

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
@@ -3,47 +3,50 @@
     <ui:VisualElement name="client-section" class="section">
         <ui:Label text="Client Configuration" class="section-title" />
         <ui:VisualElement class="section-content">
-            <ui:VisualElement class="setting-row">
-                <ui:Label text="Client:" class="setting-label" />
-                <ui:DropdownField name="client-dropdown" class="setting-dropdown-inline" />
-            </ui:VisualElement>
-            <ui:VisualElement class="setting-row">
-                <ui:VisualElement class="status-container">
-                    <ui:VisualElement name="client-status-indicator" class="status-dot" />
-                    <ui:Label name="client-status" text="Not Configured" class="status-text" />
+            <ui:Button name="configure-all-button" text="Configure All Detected Clients" class="primary-button" />
+            <ui:Label text="One-click setup for every MCP client we detect on this machine." class="help-text primary-button-hint" />
+            <ui:Foldout name="client-details-foldout" text="Configure a single client" value="false" class="client-details-foldout">
+                <ui:VisualElement class="setting-row">
+                    <ui:Label text="Client:" class="setting-label" />
+                    <ui:DropdownField name="client-dropdown" class="setting-dropdown-inline" />
                 </ui:VisualElement>
-                <ui:Button name="configure-button" text="Configure" class="action-button" />
-                <ui:Button name="install-skills-button" text="Install Skills" class="action-button" style="display: none;" />
-            </ui:VisualElement>
-            <ui:VisualElement class="setting-row" name="claude-cli-path-row" style="display: none;">
-                <ui:Label text="Claude CLI Path:" class="setting-label-small" />
-                <ui:TextField name="claude-cli-path" readonly="true" class="path-display-field" />
-                <ui:Button name="browse-claude-button" text="Browse" class="icon-button" />
-            </ui:VisualElement>
-            <ui:VisualElement class="setting-row" name="client-project-dir-row" style="display: none;">
-                <ui:Label text="Client Project Dir:" class="setting-label-small" />
-                <ui:TextField name="client-project-dir" readonly="true" class="path-display-field" />
-                <ui:Button name="browse-project-dir-button" text="Browse" class="icon-button" />
-                <ui:Button name="clear-project-dir-button" text="Clear" class="icon-button" />
-            </ui:VisualElement>
-            <ui:Foldout name="manual-config-foldout" text="Manual Configuration" value="false" class="manual-config-foldout">
-                <ui:VisualElement class="manual-config-content">
-                    <ui:Label text="Config Path:" class="config-label" />
-                    <ui:VisualElement class="path-row">
-                        <ui:TextField name="config-path" readonly="true" class="config-path-field" />
-                        <ui:Button name="copy-path-button" text="Copy" class="icon-button" />
-                        <ui:Button name="open-file-button" text="Open" class="icon-button" />
+                <ui:VisualElement class="setting-row">
+                    <ui:VisualElement class="status-container">
+                        <ui:VisualElement name="client-status-indicator" class="status-dot" />
+                        <ui:Label name="client-status" text="Not Configured" class="status-text" />
                     </ui:VisualElement>
-                    <ui:Label text="Configuration:" class="config-label" />
-                    <ui:VisualElement class="config-json-row">
-                        <ui:TextField name="config-json" readonly="true" multiline="true" class="config-json-field" />
-                        <ui:Button name="copy-json-button" text="Copy" class="icon-button-vertical" />
-                    </ui:VisualElement>
-                    <ui:Label text="Installation Steps:" class="config-label" />
-                    <ui:Label name="installation-steps" class="installation-steps" />
+                    <ui:Button name="configure-button" text="Configure" class="action-button" />
+                    <ui:Button name="install-skills-button" text="Install Skills" class="action-button" style="display: none;" />
                 </ui:VisualElement>
+                <ui:VisualElement class="setting-row" name="claude-cli-path-row" style="display: none;">
+                    <ui:Label text="Claude CLI Path:" class="setting-label-small" />
+                    <ui:TextField name="claude-cli-path" readonly="true" class="path-display-field" />
+                    <ui:Button name="browse-claude-button" text="Browse" class="icon-button" />
+                </ui:VisualElement>
+                <ui:VisualElement class="setting-row" name="client-project-dir-row" style="display: none;">
+                    <ui:Label text="Client Project Dir:" class="setting-label-small" />
+                    <ui:TextField name="client-project-dir" readonly="true" class="path-display-field" />
+                    <ui:Button name="browse-project-dir-button" text="Browse" class="icon-button" />
+                    <ui:Button name="clear-project-dir-button" text="Clear" class="icon-button" />
+                </ui:VisualElement>
+                <ui:Foldout name="manual-config-foldout" text="Manual Configuration" value="false" class="manual-config-foldout">
+                    <ui:VisualElement class="manual-config-content">
+                        <ui:Label text="Config Path:" class="config-label" />
+                        <ui:VisualElement class="path-row">
+                            <ui:TextField name="config-path" readonly="true" class="config-path-field" />
+                            <ui:Button name="copy-path-button" text="Copy" class="icon-button" />
+                            <ui:Button name="open-file-button" text="Open" class="icon-button" />
+                        </ui:VisualElement>
+                        <ui:Label text="Configuration:" class="config-label" />
+                        <ui:VisualElement class="config-json-row">
+                            <ui:TextField name="config-json" readonly="true" multiline="true" class="config-json-field" />
+                            <ui:Button name="copy-json-button" text="Copy" class="icon-button-vertical" />
+                        </ui:VisualElement>
+                        <ui:Label text="Installation Steps:" class="config-label" />
+                        <ui:Label name="installation-steps" class="installation-steps" />
+                    </ui:VisualElement>
+                </ui:Foldout>
             </ui:Foldout>
-            <ui:Button name="configure-all-button" text="Configure All Detected Clients" class="secondary-button" style="width: auto; padding-left: 12px; padding-right: 12px;" />
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/MCPForUnity/Editor/Windows/Components/Common.uss
+++ b/MCPForUnity/Editor/Windows/Components/Common.uss
@@ -273,13 +273,6 @@
     border-color: rgba(70, 100, 85, 0.5);
 }
 
-.primary-button-hint {
-    margin-top: 0;
-    margin-bottom: 8px;
-    -unity-text-align: middle-left;
-    color: rgba(150, 165, 160, 1);
-}
-
 /* Foldout that hides the per-client (single-target) controls. */
 .client-details-foldout {
     margin-top: 4px;

--- a/MCPForUnity/Editor/Windows/Components/Common.uss
+++ b/MCPForUnity/Editor/Windows/Components/Common.uss
@@ -241,6 +241,68 @@
     background-color: rgba(80, 80, 80, 0.5);
 }
 
+/* Primary one-click action — flagged as the recommended path. */
+.primary-button {
+    width: 100%;
+    height: 34px;
+    margin-top: 4px;
+    margin-bottom: 4px;
+    background-color: rgba(0, 175, 110, 1);
+    color: rgba(255, 255, 255, 1);
+    border-radius: 6px;
+    border-width: 1px;
+    border-color: rgba(0, 145, 90, 1);
+    font-size: 13px;
+    -unity-font-style: bold;
+    letter-spacing: 0.3px;
+}
+
+.primary-button:hover {
+    background-color: rgba(0, 200, 130, 1);
+    border-color: rgba(0, 170, 105, 1);
+}
+
+.primary-button:active {
+    background-color: rgba(0, 150, 90, 1);
+    border-color: rgba(0, 125, 75, 1);
+}
+
+.primary-button:disabled {
+    background-color: rgba(70, 100, 85, 0.5);
+    color: rgba(220, 220, 220, 0.6);
+    border-color: rgba(70, 100, 85, 0.5);
+}
+
+.primary-button-hint {
+    margin-top: 0;
+    margin-bottom: 8px;
+    -unity-text-align: middle-left;
+    color: rgba(150, 165, 160, 1);
+}
+
+/* Foldout that hides the per-client (single-target) controls. */
+.client-details-foldout {
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+.client-details-foldout > .unity-foldout__toggle {
+    -unity-font-style: bold;
+    font-size: 11px;
+    padding: 4px;
+    background-color: rgba(0, 0, 0, 0.05);
+    border-radius: 3px;
+}
+
+.client-details-foldout > .unity-foldout__content {
+    margin-top: 6px;
+    padding-left: 4px;
+}
+
+.unity-theme-light .client-details-foldout > .unity-foldout__toggle {
+    background-color: rgba(0, 0, 0, 0.03);
+}
+
 /* Manual Configuration */
 .manual-config-content {
     padding: 8px;

--- a/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -832,8 +832,10 @@ namespace MCPForUnity.Editor.Windows
                     ? "Installed via Plugins/Roslyn \u2014 execute_code uses Roslyn"
                     : "Available (loaded from NuGet/external) \u2014 execute_code uses Roslyn",
                 "Not installed \u2014 execute_code falls back to C# 6 (CodeDom)",
-                () => RoslynInstaller.Install(interactive: true),
-                roslynInstalledLocally ? (Action)(() => UninstallRoslyn()) : null);
+                done => { RoslynInstaller.Install(interactive: true); done?.Invoke(); },
+                roslynInstalledLocally
+                    ? (Action<Action>)(done => { UninstallRoslyn(); done?.Invoke(); })
+                    : null);
 
             // ProBuilder
             bool hasProBuilder = Type.GetType("UnityEngine.ProBuilder.ProBuilderMesh, Unity.ProBuilder") != null;
@@ -843,8 +845,8 @@ namespace MCPForUnity.Editor.Windows
                 hasProBuilder,
                 "Installed",
                 "Not installed",
-                () => InstallUpmPackage("com.unity.probuilder"),
-                () => RemoveUpmPackage("com.unity.probuilder"));
+                done => InstallUpmPackage("com.unity.probuilder", done),
+                done => RemoveUpmPackage("com.unity.probuilder", done));
 
             // Cinemachine
             bool hasCinemachine = Type.GetType("Unity.Cinemachine.CinemachineCamera, Unity.Cinemachine") != null
@@ -855,8 +857,8 @@ namespace MCPForUnity.Editor.Windows
                 hasCinemachine,
                 "Installed",
                 "Not installed \u2014 camera tool works without it",
-                () => InstallUpmPackage("com.unity.cinemachine"),
-                () => RemoveUpmPackage("com.unity.cinemachine"));
+                done => InstallUpmPackage("com.unity.cinemachine", done),
+                done => RemoveUpmPackage("com.unity.cinemachine", done));
 
             // VFX Graph — uses preprocessor symbol, so check via UPM package list
             bool hasVfxGraph = IsUpmPackageInstalled("com.unity.visualeffectgraph");
@@ -866,8 +868,8 @@ namespace MCPForUnity.Editor.Windows
                 hasVfxGraph,
                 "Installed",
                 "Not installed \u2014 VFX tool falls back to ParticleSystem/LineRenderer",
-                () => InstallUpmPackage("com.unity.visualeffectgraph"),
-                () => RemoveUpmPackage("com.unity.visualeffectgraph"));
+                done => InstallUpmPackage("com.unity.visualeffectgraph", done),
+                done => RemoveUpmPackage("com.unity.visualeffectgraph", done));
 
             section.Add(content);
             container.Add(section);
@@ -875,7 +877,7 @@ namespace MCPForUnity.Editor.Windows
 
         private static void AddDependencyRow(VisualElement parent, string name, string description,
             bool isInstalled, string installedText, string missingText,
-            Action installAction, Action uninstallAction)
+            Action<Action> installAction, Action<Action> uninstallAction)
         {
             var row = new VisualElement();
             row.style.marginBottom = 8;
@@ -921,12 +923,16 @@ namespace MCPForUnity.Editor.Windows
                 {
                     btn.SetEnabled(false);
                     btn.text = "Installing...";
-                    try { installAction(); }
+                    Action restore = () =>
+                    {
+                        btn.SetEnabled(true);
+                        btn.text = "Install";
+                    };
+                    try { installAction(restore); }
                     catch (Exception e)
                     {
                         Debug.LogError($"[MCP] Install failed: {e.Message}");
-                        btn.SetEnabled(true);
-                        btn.text = "Install";
+                        restore();
                     }
                 });
                 btn.text = "Install";
@@ -943,12 +949,16 @@ namespace MCPForUnity.Editor.Windows
                         $"Are you sure you want to remove {name}?", "Remove", "Cancel")) return;
                     btn.SetEnabled(false);
                     btn.text = "Removing...";
-                    try { uninstallAction(); }
+                    Action restore = () =>
+                    {
+                        btn.SetEnabled(true);
+                        btn.text = "Uninstall";
+                    };
+                    try { uninstallAction(restore); }
                     catch (Exception e)
                     {
                         Debug.LogError($"[MCP] Uninstall failed: {e.Message}");
-                        btn.SetEnabled(true);
-                        btn.text = "Uninstall";
+                        restore();
                     }
                 });
                 btn.text = "Uninstall";

--- a/MCPForUnity/Editor/Windows/MCPSetupWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPSetupWindow.cs
@@ -179,6 +179,14 @@ namespace MCPForUnity.Editor.Windows
                     messages.Add($"⚠ {c.DisplayName}: {ex.Message}");
                 }
             }
+            if (success == 0 && failure == 0)
+            {
+                EditorUtility.DisplayDialog(
+                    "Client Configuration",
+                    "No clients were selected. Tick at least one client to continue, or close the window to skip setup.",
+                    "OK");
+                return;
+            }
             EditorUtility.DisplayDialog(
                 "Client Configuration",
                 $"{success} configured, {failure} failed.\n\n{string.Join("\n", messages)}",

--- a/MCPForUnity/Editor/Windows/MCPSetupWindow.cs
+++ b/MCPForUnity/Editor/Windows/MCPSetupWindow.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
+using MCPForUnity.Editor.Clients;
 using MCPForUnity.Editor.Dependencies;
 using MCPForUnity.Editor.Dependencies.Models;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Services;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -27,6 +30,14 @@ namespace MCPForUnity.Editor.Windows
         private Button openUvLinkButton;
         private Button refreshButton;
         private Button doneButton;
+
+        // Step 2 (Configure Clients) UI elements
+        private VisualElement stepDeps;
+        private VisualElement stepClients;
+        private VisualElement clientsList;
+        private Button skipClientsButton;
+        private Button configureSelectedButton;
+        private readonly List<(IMcpClientConfigurator client, Toggle toggle)> clientToggles = new();
 
         private DependencyCheckResult _dependencyResult;
 
@@ -69,12 +80,19 @@ namespace MCPForUnity.Editor.Windows
             openUvLinkButton = rootVisualElement.Q<Button>("open-uv-link-button");
             refreshButton = rootVisualElement.Q<Button>("refresh-button");
             doneButton = rootVisualElement.Q<Button>("done-button");
+            stepDeps = rootVisualElement.Q<VisualElement>("step-deps");
+            stepClients = rootVisualElement.Q<VisualElement>("step-clients");
+            clientsList = rootVisualElement.Q<VisualElement>("clients-list");
+            skipClientsButton = rootVisualElement.Q<Button>("skip-clients-button");
+            configureSelectedButton = rootVisualElement.Q<Button>("configure-selected-button");
 
             // Register callbacks
             refreshButton.clicked += OnRefreshClicked;
             doneButton.clicked += OnDoneClicked;
             openPythonLinkButton.clicked += OnOpenPythonInstallClicked;
             openUvLinkButton.clicked += OnOpenUvInstallClicked;
+            skipClientsButton.clicked += OnSkipClientsClicked;
+            configureSelectedButton.clicked += OnConfigureSelectedClicked;
 
             // Initial update
             UpdateUI();
@@ -96,6 +114,75 @@ namespace MCPForUnity.Editor.Windows
 
         private void OnDoneClicked()
         {
+            if (_dependencyResult != null && _dependencyResult.IsSystemReady)
+            {
+                ShowClientsStep();
+            }
+            else
+            {
+                Setup.SetupWindowService.MarkSetupDismissed();
+                Close();
+            }
+        }
+
+        private void ShowClientsStep()
+        {
+            stepDeps.style.display = DisplayStyle.None;
+            stepClients.style.display = DisplayStyle.Flex;
+            PopulateClientsList();
+        }
+
+        private void PopulateClientsList()
+        {
+            clientsList.Clear();
+            clientToggles.Clear();
+            foreach (var c in McpClientRegistry.All)
+            {
+                if (!c.IsInstalled) continue;
+                var toggle = new Toggle(c.DisplayName)
+                {
+                    value = true,
+                    tooltip = c.GetConfigPath()
+                };
+                clientToggles.Add((c, toggle));
+                clientsList.Add(toggle);
+            }
+            if (clientToggles.Count == 0)
+            {
+                clientsList.Add(new Label("No supported MCP clients detected on this machine. You can configure clients later from Tools → MCP for Unity."));
+                configureSelectedButton.SetEnabled(false);
+            }
+        }
+
+        private void OnSkipClientsClicked()
+        {
+            Setup.SetupWindowService.MarkSetupCompleted();
+            Close();
+        }
+
+        private void OnConfigureSelectedClicked()
+        {
+            int success = 0, failure = 0;
+            var messages = new List<string>();
+            foreach (var (c, toggle) in clientToggles)
+            {
+                if (!toggle.value) continue;
+                try
+                {
+                    MCPServiceLocator.Client.ConfigureClient(c);
+                    success++;
+                    messages.Add($"✓ {c.DisplayName}");
+                }
+                catch (System.Exception ex)
+                {
+                    failure++;
+                    messages.Add($"⚠ {c.DisplayName}: {ex.Message}");
+                }
+            }
+            EditorUtility.DisplayDialog(
+                "Client Configuration",
+                $"{success} configured, {failure} failed.\n\n{string.Join("\n", messages)}",
+                "OK");
             Setup.SetupWindowService.MarkSetupCompleted();
             Close();
         }

--- a/MCPForUnity/Editor/Windows/MCPSetupWindow.uxml
+++ b/MCPForUnity/Editor/Windows/MCPSetupWindow.uxml
@@ -3,56 +3,72 @@
     <Style src="MCPSetupWindow.uss" />
     <ui:ScrollView name="root-container" mode="Vertical">
         <ui:Label text="MCP for Unity Setup" name="title" class="title" />
-        
-        <ui:VisualElement class="section">
-            <ui:Label text="System Requirements" class="section-title" />
-            <ui:VisualElement class="section-content">
-                <ui:Label text="MCP for Unity requires Python 3.10+ and UV package manager to function." class="help-text description-text" />
-                
-                <!-- Dependency Status -->
-                <ui:VisualElement name="dependency-list">
-                    <!-- Python Status -->
-                    <ui:VisualElement class="dependency-item">
-                        <ui:VisualElement class="dependency-row">
-                            <ui:Label text="Python" class="dependency-name" />
-                            <ui:Label name="python-version" text="..." class="setting-value" />
-                            <ui:VisualElement name="python-indicator" class="status-indicator-small" />
+
+        <ui:VisualElement name="step-deps">
+            <ui:VisualElement class="section">
+                <ui:Label text="System Requirements" class="section-title" />
+                <ui:VisualElement class="section-content">
+                    <ui:Label text="MCP for Unity requires Python 3.10+ and UV package manager to function." class="help-text description-text" />
+
+                    <!-- Dependency Status -->
+                    <ui:VisualElement name="dependency-list">
+                        <!-- Python Status -->
+                        <ui:VisualElement class="dependency-item">
+                            <ui:VisualElement class="dependency-row">
+                                <ui:Label text="Python" class="dependency-name" />
+                                <ui:Label name="python-version" text="..." class="setting-value" />
+                                <ui:VisualElement name="python-indicator" class="status-indicator-small" />
+                            </ui:VisualElement>
+                            <ui:Label name="python-details" class="help-text dependency-details" />
                         </ui:VisualElement>
-                        <ui:Label name="python-details" class="help-text dependency-details" />
-                    </ui:VisualElement>
-                    
-                    <!-- UV Status -->
-                    <ui:VisualElement class="dependency-item">
-                        <ui:VisualElement class="dependency-row">
-                            <ui:Label text="UV Package Manager" class="dependency-name" />
-                            <ui:Label name="uv-version" text="..." class="setting-value" />
-                            <ui:VisualElement name="uv-indicator" class="status-indicator-small" />
+
+                        <!-- UV Status -->
+                        <ui:VisualElement class="dependency-item">
+                            <ui:VisualElement class="dependency-row">
+                                <ui:Label text="UV Package Manager" class="dependency-name" />
+                                <ui:Label name="uv-version" text="..." class="setting-value" />
+                                <ui:VisualElement name="uv-indicator" class="status-indicator-small" />
+                            </ui:VisualElement>
+                            <ui:Label name="uv-details" class="help-text dependency-details" />
                         </ui:VisualElement>
-                        <ui:Label name="uv-details" class="help-text dependency-details" />
                     </ui:VisualElement>
-                </ui:VisualElement>
-                
-                <!-- Overall Status Message -->
-                <ui:VisualElement name="status-message-container">
-                    <ui:Label name="status-message" class="help-text" />
-                </ui:VisualElement>
-                
-                <!-- Installation Instructions (shown when dependencies missing) -->
-                <ui:VisualElement name="installation-section" class="installation-container">
-                    <ui:Label text="Installation Instructions" class="installation-title" />
-                    <ui:Label name="installation-instructions" class="help-text" />
-                    <ui:VisualElement class="install-links-row">
-                        <ui:Button name="open-python-link-button" text="Open Python Install Page" class="secondary-button install-link-button" />
-                        <ui:Button name="open-uv-link-button" text="Open UV Install Page" class="secondary-button install-link-button" />
+
+                    <!-- Overall Status Message -->
+                    <ui:VisualElement name="status-message-container">
+                        <ui:Label name="status-message" class="help-text" />
+                    </ui:VisualElement>
+
+                    <!-- Installation Instructions (shown when dependencies missing) -->
+                    <ui:VisualElement name="installation-section" class="installation-container">
+                        <ui:Label text="Installation Instructions" class="installation-title" />
+                        <ui:Label name="installation-instructions" class="help-text" />
+                        <ui:VisualElement class="install-links-row">
+                            <ui:Button name="open-python-link-button" text="Open Python Install Page" class="secondary-button install-link-button" />
+                            <ui:Button name="open-uv-link-button" text="Open UV Install Page" class="secondary-button install-link-button" />
+                        </ui:VisualElement>
                     </ui:VisualElement>
                 </ui:VisualElement>
             </ui:VisualElement>
+
+            <!-- Action Buttons -->
+            <ui:VisualElement class="button-container">
+                <ui:Button name="refresh-button" text="Refresh" class="setup-button secondary-button" />
+                <ui:Button name="done-button" text="Done" class="setup-button action-button" />
+            </ui:VisualElement>
         </ui:VisualElement>
-        
-        <!-- Action Buttons -->
-        <ui:VisualElement class="button-container">
-            <ui:Button name="refresh-button" text="Refresh" class="setup-button secondary-button" />
-            <ui:Button name="done-button" text="Done" class="setup-button action-button" />
+
+        <ui:VisualElement name="step-clients" style="display: none;">
+            <ui:VisualElement class="section">
+                <ui:Label text="Configure MCP Clients" class="section-title" />
+                <ui:Label text="We found the following MCP clients on your machine. Select which to configure:" class="help-text description-text" />
+                <ui:ScrollView name="clients-scroll" mode="Vertical" style="max-height: 240px;">
+                    <ui:VisualElement name="clients-list" />
+                </ui:ScrollView>
+            </ui:VisualElement>
+            <ui:VisualElement class="button-container">
+                <ui:Button name="skip-clients-button" text="Skip" class="setup-button secondary-button" />
+                <ui:Button name="configure-selected-button" text="Configure Selected" class="setup-button action-button" />
+            </ui:VisualElement>
         </ui:VisualElement>
     </ui:ScrollView>
 </ui:UXML>

--- a/MCPForUnity/Runtime/AssemblyInfo.cs
+++ b/MCPForUnity/Runtime/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MCPForUnity.Editor")]
+[assembly: InternalsVisibleTo("MCPForUnityTests.EditMode")]
+[assembly: InternalsVisibleTo("MCPForUnityTests.PlayMode")]

--- a/MCPForUnity/Runtime/AssemblyInfo.cs.meta
+++ b/MCPForUnity/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96306c75346e49089f53d7f73de24a3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -267,7 +267,12 @@ namespace MCPForUnity.Runtime.Serialization
     }
 
     // Converter for UnityEngine.Object references (GameObjects, Components, Materials, Textures, etc.)
-    public class UnityEngineObjectConverter : JsonConverter<UnityEngine.Object>
+    // Intentionally internal: this converter is meant for MCP-internal serialization only.
+    // Leaving it public lets third-party Newtonsoft converter scanners (e.g. jillejr's
+    // newtonsoft-json-for-unity converters) instantiate it via reflection and bind it into
+    // JsonConvert.DefaultSettings, which silently rewrites any UnityEngine.Object reference in
+    // unrelated project code as an asset path string. See issue #1138.
+    internal class UnityEngineObjectConverter : JsonConverter<UnityEngine.Object>
     {
         public override bool CanRead => true; // We need to implement ReadJson
         public override bool CanWrite => true;

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ openupm add com.coplaydev.unity-mcp
 
 **Manually (anytime):** `Window > MCP for Unity` opens the main panel.
 - Click **Start Server** if it's not already running (launches HTTP server on `localhost:8080`).
-- In the **Clients** tab, click **Configure Detected Clients** to set up every client found on your machine in one shot, or pick a single client from the dropdown and click **Configure**.
+- In the **Clients** tab, click **Configure All Detected Clients** to set up every client found on your machine in one shot, or pick a single client from the dropdown and click **Configure**.
 - Look for 🟢 "Connected ✓".
 
 **Per-client gotchas:** Some clients (Cursor, Antigravity, OpenClaw) still require enabling an MCP toggle or plugin in their own settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Claude Desktop only supports stdio — MCP for Unity will silently configure it that way even if you've selected HTTP elsewhere. Claude Code, VS Code, Windsurf, Cline, and the various CLI clients auto-connect after configuration.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,19 @@ openupm add com.coplaydev.unity-mcp
 
 ### 2. Start the Server & Connect
 
-1. In Unity: `Window > MCP for Unity`
-2. Click **Start Server** (launches HTTP server on `localhost:8080`)
-3. Select your MCP Client from the dropdown and click **Configure**
-4. Look for 🟢 "Connected ✓"
-5. **Connect your client:** Some clients (Cursor, Antigravity, OpenClaw) require enabling an MCP toggle or plugin in settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Others (Claude Desktop, Claude Code) auto-connect after configuration.
+**First-run wizard (recommended):** After import, MCP for Unity opens a setup window automatically.
+1. Confirm Python and uv are installed — the window guides you through both if missing.
+2. Click **Done**. Once dependencies are green, you'll see a list of MCP clients detected on your machine.
+3. Pick the clients you want to configure and click **Configure Selected**. Done.
+
+**Manually (anytime):** `Window > MCP for Unity` opens the main panel.
+- Click **Start Server** if it's not already running (launches HTTP server on `localhost:8080`).
+- In the **Clients** tab, click **Configure Detected Clients** to set up every client found on your machine in one shot, or pick a single client from the dropdown and click **Configure**.
+- Look for 🟢 "Connected ✓".
+
+**Per-client gotchas:** Some clients (Cursor, Antigravity, OpenClaw) still require enabling an MCP toggle or plugin in their own settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Claude Desktop only supports stdio — MCP for Unity will silently configure it that way even if you've selected HTTP elsewhere. Claude Code, VS Code, Windsurf, Cline, and the various CLI clients auto-connect after configuration.
+
+**Updates handle themselves.** When you update the package, MCP for Unity rewrites the configs of every detected client on the next Editor open — no need to repeat the Configure step.
 
 **That's it!** Try a prompt like: *"Create a red, blue and yellow cube"* or *"Build a simple player controller"*
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ openupm add com.coplaydev.unity-mcp
 
 If auto-setup doesn't work, add this to your MCP client's config file:
 
-**HTTP (default — works with Claude Desktop, Cursor, Windsurf):**
+**HTTP (default — works with Cursor, Windsurf, Antigravity, VS Code, Cline; Claude Desktop is stdio-only, see below):**
 ```json
 {
   "mcpServers": {

--- a/Server/src/services/tools/execute_custom_tool.py
+++ b/Server/src/services/tools/execute_custom_tool.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastmcp import Context
 from mcp.types import ToolAnnotations
 from models.models import MCPResponse
@@ -21,7 +23,7 @@ from services.tools import get_unity_instance_from_context
         destructiveHint=True,
     ),
 )
-async def execute_custom_tool(ctx: Context, tool_name: str, parameters: dict | None = None) -> MCPResponse:
+async def execute_custom_tool(ctx: Context, tool_name: str, parameters: dict[str, Any] | None = None) -> MCPResponse:
     unity_instance = await get_unity_instance_from_context(ctx)
     if not unity_instance:
         return MCPResponse(

--- a/Server/src/services/tools/execute_custom_tool.py
+++ b/Server/src/services/tools/execute_custom_tool.py
@@ -38,7 +38,11 @@ async def execute_custom_tool(ctx: Context, tool_name: str, parameters: dict[str
             message=f"Could not resolve project id for {unity_instance}. Ensure Unity is running and reachable.",
         )
 
-    if not isinstance(parameters, dict):
+    # The signature accepts None (parameter-less custom tools). Treat it as an empty
+    # dict rather than rejecting — the previous behavior contradicted the optional type.
+    if parameters is None:
+        parameters = {}
+    elif not isinstance(parameters, dict):
         return MCPResponse(
             success=False,
             message="parameters must be an object/dictionary",

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 57176dc46eea4bbba356c3959cfeb33f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/CheckStatusUrlPropertyTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/CheckStatusUrlPropertyTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using MCPForUnity.Editor.Clients;
+using MCPForUnity.Editor.Models;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.Clients
+{
+    /// <summary>
+    /// Covers the regression where JsonFileMcpConfigurator.CheckStatus only recognized
+    /// the "url" property and missed "serverUrl" (Antigravity/Windsurf) and "httpUrl"
+    /// (Gemini CLI), so clients configured via HTTP looked unconfigured and got rewritten
+    /// every startup by the auto-rewrite path.
+    /// </summary>
+    [TestFixture]
+    public class CheckStatusUrlPropertyTests
+    {
+        private string _tempDir;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "UnityMCPTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+        }
+
+        [Test]
+        public void CheckStatus_DetectsHttp_WhenUrlProperty()
+            => AssertHttpDetected("url");
+
+        [Test]
+        public void CheckStatus_DetectsHttp_WhenServerUrlProperty()
+            => AssertHttpDetected("serverUrl");
+
+        [Test]
+        public void CheckStatus_DetectsHttp_WhenHttpUrlProperty()
+            => AssertHttpDetected("httpUrl");
+
+        private void AssertHttpDetected(string urlProperty)
+        {
+            string configPath = Path.Combine(_tempDir, $"{urlProperty}.json");
+            File.WriteAllText(configPath,
+                "{\"mcpServers\":{\"unityMCP\":{\"" + urlProperty + "\":\"http://localhost:65535/mcp\"}}}");
+
+            var client = new McpClient
+            {
+                name = "Fake",
+                windowsConfigPath = configPath,
+                macConfigPath = configPath,
+                linuxConfigPath = configPath,
+                HttpUrlProperty = urlProperty,
+            };
+            var configurator = new FakeJsonConfigurator(client);
+
+            configurator.CheckStatus(attemptAutoRewrite: false);
+
+            Assert.AreNotEqual(ConfiguredTransport.Unknown, client.configuredTransport,
+                $"CheckStatus must recognize the '{urlProperty}' property as an HTTP URL");
+            Assert.That(
+                client.configuredTransport == ConfiguredTransport.Http
+                    || client.configuredTransport == ConfiguredTransport.HttpRemote,
+                $"Expected HTTP/HttpRemote transport for '{urlProperty}', got {client.configuredTransport}");
+        }
+
+        private sealed class FakeJsonConfigurator : JsonFileMcpConfigurator
+        {
+            public FakeJsonConfigurator(McpClient client) : base(client) { }
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/CheckStatusUrlPropertyTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/CheckStatusUrlPropertyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b5bc8d0b36d477e8239edff10911bba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/IsInstalledTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/IsInstalledTests.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using MCPForUnity.Editor.Clients;
+using MCPForUnity.Editor.Clients.Configurators;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.Clients
+{
+    [TestFixture]
+    public class IsInstalledTests
+    {
+        [Test]
+        public void IMcpClientConfigurator_ExposesIsInstalled()
+        {
+            var prop = typeof(IMcpClientConfigurator).GetProperty("IsInstalled");
+            Assert.IsNotNull(prop, "IMcpClientConfigurator must expose an IsInstalled property");
+            Assert.AreEqual(typeof(bool), prop.PropertyType);
+        }
+
+        [Test]
+        public void JsonClient_NotInstalled_WhenParentDirMissing()
+        {
+            var cursor = new CursorConfigurator();
+            string parent = Path.GetDirectoryName(cursor.GetConfigPath());
+            if (parent == null || !Directory.Exists(parent))
+            {
+                Assert.IsFalse(cursor.IsInstalled,
+                    "Cursor parent dir does not exist on this machine, IsInstalled must be false");
+            }
+            else
+            {
+                Assert.IsTrue(cursor.IsInstalled,
+                    "Cursor parent dir exists, IsInstalled must be true");
+            }
+        }
+
+        [Test]
+        public void JsonClient_Installed_WhenParentDirExists()
+        {
+            var claude = new ClaudeDesktopConfigurator();
+            string parent = Path.GetDirectoryName(claude.GetConfigPath());
+            bool expected = parent != null && Directory.Exists(parent);
+            Assert.AreEqual(expected, claude.IsInstalled);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/IsInstalledTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/IsInstalledTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15e00d05358545a5955aa1c291653289
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using MCPForUnity.Editor.Clients;
+using MCPForUnity.Editor.Clients.Configurators;
+using MCPForUnity.Editor.Models;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.Clients
+{
+    [TestFixture]
+    public class SupportedTransportsTests
+    {
+        [Test]
+        public void IMcpClientConfigurator_ExposesSupportedTransports()
+        {
+            var prop = typeof(IMcpClientConfigurator).GetProperty("SupportedTransports");
+            Assert.IsNotNull(prop, "Must expose SupportedTransports");
+        }
+
+        [Test]
+        public void ClaudeDesktop_SupportsStdioOnly()
+        {
+            var claude = new ClaudeDesktopConfigurator();
+            CollectionAssert.Contains(claude.SupportedTransports.ToList(), ConfiguredTransport.Stdio);
+            CollectionAssert.DoesNotContain(claude.SupportedTransports.ToList(), ConfiguredTransport.Http);
+        }
+
+        [Test]
+        public void Cursor_SupportsBothTransports()
+        {
+            var cursor = new CursorConfigurator();
+            var list = cursor.SupportedTransports.ToList();
+            CollectionAssert.Contains(list, ConfiguredTransport.Stdio);
+            CollectionAssert.Contains(list, ConfiguredTransport.Http);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26823824aa5cae0caa9488e9ad49bcf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ConfigureDetectedClientsTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ConfigureDetectedClientsTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using MCPForUnity.Editor.Services;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    [TestFixture]
+    public class ConfigureDetectedClientsTests
+    {
+        [Test]
+        public void Summary_ContainsOnlyInstalledClients()
+        {
+            var svc = new ClientConfigurationService();
+            var summary = svc.ConfigureAllDetectedClients();
+            int installedCount = svc.GetAllClients().Count(c => c.IsInstalled);
+            Assert.AreEqual(installedCount, summary.SuccessCount + summary.FailureCount,
+                "Only installed clients should appear in success/failure totals");
+        }
+
+        [Test]
+        public void Summary_SkippedCountTracksUninstalled()
+        {
+            var svc = new ClientConfigurationService();
+            var summary = svc.ConfigureAllDetectedClients();
+            int uninstalledCount = svc.GetAllClients().Count(c => !c.IsInstalled);
+            Assert.AreEqual(uninstalledCount, summary.SkippedCount);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ConfigureDetectedClientsTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ConfigureDetectedClientsTests.cs
@@ -4,10 +4,16 @@ using NUnit.Framework;
 
 namespace MCPForUnityTests.Editor.Services
 {
+    // ConfigureAllDetectedClients walks the real McpClientRegistry and Configure()s every
+    // detected client, which would touch real user config files on a dev machine. These
+    // tests pass on CI (no MCP clients installed there) but would mutate real state on
+    // a developer's machine. Marked [Explicit] so they only run when invoked by name;
+    // proper isolation requires DI of the configurator list and is tracked separately.
     [TestFixture]
     public class ConfigureDetectedClientsTests
     {
         [Test]
+        [Explicit("Side-effect: writes real client configs on machines with MCP clients installed")]
         public void Summary_ContainsOnlyInstalledClients()
         {
             var svc = new ClientConfigurationService();
@@ -18,6 +24,7 @@ namespace MCPForUnityTests.Editor.Services
         }
 
         [Test]
+        [Explicit("Side-effect: writes real client configs on machines with MCP clients installed")]
         public void Summary_SkippedCountTracksUninstalled()
         {
             var svc = new ClientConfigurationService();

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ConfigureDetectedClientsTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ConfigureDetectedClientsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78f1385217c246d4a9b5c596986787b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StartupConfigRewriteTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StartupConfigRewriteTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    [TestFixture]
+    public class StartupConfigRewriteTests
+    {
+        [Test]
+        public void StartupConfigRewrite_TypeExists()
+        {
+            var t = System.Type.GetType("MCPForUnity.Editor.Services.StartupConfigRewrite, MCPForUnity.Editor");
+            Assert.IsNotNull(t, "StartupConfigRewrite type must exist and be public");
+        }
+
+        [Test]
+        public void StartupConfigRewrite_HasInitializeOnLoad()
+        {
+            var t = System.Type.GetType("MCPForUnity.Editor.Services.StartupConfigRewrite, MCPForUnity.Editor");
+            Assert.IsNotNull(t);
+            object[] attrs = t.GetCustomAttributes(typeof(InitializeOnLoadAttribute), inherit: false);
+            Assert.AreEqual(1, attrs.Length, "Class must be decorated with [InitializeOnLoad]");
+        }
+
+        [Test]
+        public void StartupConfigRewrite_RunOncePerSession_GuardKey()
+        {
+            var t = System.Type.GetType("MCPForUnity.Editor.Services.StartupConfigRewrite, MCPForUnity.Editor");
+            var keyField = t?.GetField("SESSION_GUARD_KEY",
+                BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public);
+            Assert.IsNotNull(keyField);
+            string val = (string)keyField.GetValue(null);
+            StringAssert.StartsWith("MCPForUnity.", val);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StartupConfigRewriteTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StartupConfigRewriteTests.cs
@@ -11,7 +11,8 @@ namespace MCPForUnityTests.Editor.Services
         public void StartupConfigRewrite_TypeExists()
         {
             var t = System.Type.GetType("MCPForUnity.Editor.Services.StartupConfigRewrite, MCPForUnity.Editor");
-            Assert.IsNotNull(t, "StartupConfigRewrite type must exist and be public");
+            Assert.IsNotNull(t, "StartupConfigRewrite type must exist");
+            Assert.IsTrue(t.IsPublic, "StartupConfigRewrite must be public so the [InitializeOnLoad] attribute fires");
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StartupConfigRewriteTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StartupConfigRewriteTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca5aeabe283e473ea5ae78cf60ee55f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/guides/MCP_CLIENT_CONFIGURATORS.md
+++ b/docs/guides/MCP_CLIENT_CONFIGURATORS.md
@@ -161,9 +161,7 @@ Some clients cannot be handled by the generic JSON configurator alone.
 - Uses **`JsonFileMcpConfigurator`**, but only supports **stdio transport**.
 - `ClaudeDesktopConfigurator`:
   - Sets `SupportsHttpTransport = false` in `McpClient`.
-  - Overrides `Configure` / `GetManualSnippet` to:
-    - Guard against HTTP mode.
-    - Provide clear error text if HTTP is enabled.
+  - Overrides `Configure` / `GetManualSnippet` to **silently coerce to stdio** when the user has HTTP transport selected globally. The configurator writes a stdio entry and logs an informational line rather than throwing — so bulk "Configure Detected Clients" flows succeed even on mixed-transport setups.
 
 ### OpenClaw (plugin-based)
 

--- a/docs/guides/MCP_CLIENT_CONFIGURATORS.md
+++ b/docs/guides/MCP_CLIENT_CONFIGURATORS.md
@@ -161,7 +161,7 @@ Some clients cannot be handled by the generic JSON configurator alone.
 - Uses **`JsonFileMcpConfigurator`**, but only supports **stdio transport**.
 - `ClaudeDesktopConfigurator`:
   - Sets `SupportsHttpTransport = false` in `McpClient`.
-  - Overrides `Configure` / `GetManualSnippet` to **silently coerce to stdio** when the user has HTTP transport selected globally. The configurator writes a stdio entry and logs an informational line rather than throwing — so bulk "Configure Detected Clients" flows succeed even on mixed-transport setups.
+  - Declares `SupportedTransports => StdioOnly`. `ClientConfigurationService` reads `SupportedTransports` and, via `ConfigureWithTransportCoercion` / `CoerceTransportFor`, temporarily coerces the transport pref to stdio before calling `Configure()` — so users with HTTP toggled globally still get a working stdio entry written without a thrown error. The coercion applies to any configurator whose `SupportedTransports` excludes the user's current transport; Claude Desktop is just the only one declaring stdio-only today.
 
 ### OpenClaw (plugin-based)
 


### PR DESCRIPTION
Two pieces of work stacked together.

The bigger one is a client-configuration overhaul that turns the per-client setup into an actual one-click flow. We have been getting a lot of asks and issues around the connection, which is indeed worth looking at. Each configurator now declares whether its target is installed on the machine, which transports it supports, and which one to coerce the user's preference toward. `Configure All Detected Clients` only writes for clients that actually exist. At Editor startup, every detected client gets a quiet `CheckStatus` pass and a silent rewrite if its config has drifted (transport mismatch, server version drift after a plugin update, etc.). The first-run wizard got a picker step so new users tick the clients they want and one button finishes the wiring. README + onboarding docs updated to match.

In the GUI, the prominent action is finally the prominent action. "Configure All Detected Clients" is now a bright green primary button at the top of the section instead of a low-contrast gray button at the bottom, and the per-client dropdown / status / Configure / path-overrides / manual-config row collapses behind a "Per-client setup" foldout (collapsed by default, state remembered between sessions).

Then a batch of bug fixes from a follow-up autotest pass.

**#1138** — `UnityEngineObjectConverter` was declared `public` with a default constructor, so third-party Newtonsoft scanners (jillejr's converters) auto-discovered it and bound it into `JsonConvert.DefaultSettings`. Any unrelated project code that serialized a `UnityEngine.Object` reference suddenly got an asset path string back, just from having MCP for Unity installed. Made the converter `internal` and added a Runtime `AssemblyInfo` exposing internals to the Editor and test assemblies so the existing internal consumers (`UnityJsonSerializer`, `GameObjectSerializer`) still see it.

**#1134** — `CommandRegistry.AutoDiscoverCommands` runs from `[InitializeOnLoad]`, which also fires in the `AssetImportWorker` subprocess. Mono can hard-crash inside `GetCustomAttribute<T>()` on partially-loaded types in that subprocess and take the main Editor down through the IPC channel. The worker doesn't host MCP transport, so the scan is unnecessary there — bail out via `AssetDatabase.IsAssetImportWorkerProcess()` (looked up reflectively to tolerate Unity version drift, with a command-line fallback). Also wrapped each `GetCustomAttribute<T>()` in a try/catch helper so one bad type can't abort the whole scan.

**#946** — `execute_custom_tool`'s signature was `parameters: dict | None`. FastMCP generates a permissive schema from that which strict clients like Roo Code reject during tool discovery, so the tool just looked missing. Bumped to `dict[str, Any] | None`. The other four files cited in the issue were already parametrized in earlier commits — this was the last bare `dict` on an MCP-exposed boundary.

**#865** — Multi-agent and sub-agent workflows churn through stdio connections, and three lifecycle messages fired on every reconnect: `Client connected …`, `Closing N stale client(s) after new connection`, `Client handler exited …`. The reporter saw 185+ lines in one session. All three moved behind `McpLog.Info(..., always: false)` so they only surface with verbose logging on. Startup messages and anomaly warnings stay at INFO.

**Antigravity 2.0 / Windsurf / Gemini CLI HTTP detection** (Discord report, and the one most relevant to the connection overhaul above). After a successful HTTP `Configure`, the configurator parsed back `configuredUrl=null` and reported `IncorrectPath`. That alone was annoying; combined with the new startup auto-rewrite, the Editor was silently rewriting those three clients' config files on every launch. `ConfigJsonBuilder` writes per client — `serverUrl` for Antigravity 2.0 and Windsurf, `httpUrl` for Gemini CLI, `url` for everyone else — but `JsonFileMcpConfigurator.CheckStatus` deserialized via a model that only knew `url`. Switched the read side to `JObject` parsing with `url ?? serverUrl ?? httpUrl`. EditMode tests lock all three property names against a synthetic configurator.

**VFX Graph "not installed" when actually installed** (Discord report, Unity 6 + VFX Graph 17.x). Two stacked bugs. First, every VFX path is gated behind `#if UNITY_VFX_GRAPH`, but `MCPForUnity.Editor.asmdef` had an empty `versionDefines` array, so that symbol was never defined for anyone — every action returned the "not installed" stub regardless of package presence. An older comment in the codebase actually said "Please enable the symbol in the project settings", expecting users to flip a scripting-define by hand. Added a proper `versionDefines` entry so Unity defines the symbol whenever `com.unity.visualeffectgraph` is installed at any version. Second, `VfxGraphAssets.ValidateVfxGraphVersion()` had a `{ "12.1" }` allowlist — Unity 6's 14.x / 17.x would still have failed `create_asset` with `"Unsupported VFX Graph version 17.x.x"`. Dropped the allowlist; kept the cheap runtime `PackageInfo` existence check as defense for the brief install/uninstall window. Verified end-to-end on VFX Graph 17.2.0.

**Setup window dependency buttons stuck on "Installing…"** (Discord report). `AddDependencyRow` flipped the button to "Installing…" and only restored it inside a synchronous try/catch. UPM `Client.AddAndRemove` is async, so on any failure (`ETIMEDOUT` to `download.packages.unity.com` in the reporter's case) the request eventually completed inside `PollUpmRequest`, logged the error, and stranded the button. The "Install All" path already threaded a completion callback — per-package didn't. Threaded an `Action<Action>` through `installAction` / `uninstallAction` so `PollUpmRequest`'s completion (which fires for success and failure both) restores the button label.

Closes #865, #946, #1134, #1138.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup wizard now includes a client-configuration step and can configure selected installed clients.
  * Automatic re-check/rewriting of detected client configs on Editor startup.
  * Client-details foldout state persists across sessions.

* **Bug Fixes**
  * Uninstalled clients are skipped when configuring all detected clients.
  * Transport selection is auto-coerced per-client (Claude Desktop uses stdio-only).

* **Style**
  * Primary action button styling and placement updated in client UI.

* **Documentation**
  * Quick-start and configurator docs updated to match new flow and transport behavior.

* **Tests**
  * New EditMode tests covering install detection, supported transports, and startup rewrite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->