### PR TITLE
ci: fire unity-tests on every PR (mirrors python-tests pattern)

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -16,6 +16,19 @@ on:
       - MCPForUnity/Editor/**
       - MCPForUnity/Runtime/**
       - .github/workflows/unity-tests.yml
+  # Same-repo PRs get a unity-tests status check on every open / push via this trigger
+  # (mirrors python-tests.yml). Fork PRs ALSO fire this trigger but run in the fork's
+  # context without secrets — the detect step downstream writes unity_ok=false and the
+  # job exits clean with a "missing license secrets" notice so the status check still
+  # appears. Maintainers apply 'safe-to-test' to invoke pull_request_target below for
+  # a real fork-PR test run.
+  pull_request:
+    branches: [main, beta]
+    paths:
+      - TestProjects/UnityMCPTests/**
+      - MCPForUnity/Editor/**
+      - MCPForUnity/Runtime/**
+      - .github/workflows/unity-tests.yml
   # Fork PRs: maintainer applies the 'safe-to-test' label after reviewing
   # the diff. The workflow runs with UNITY_LICENSE in scope against the
   # PR's head SHA. Re-pushed commits do NOT auto-trigger — maintainer must
@@ -28,6 +41,13 @@ on:
       - MCPForUnity/Editor/**
       - MCPForUnity/Runtime/**
       - .github/workflows/unity-tests.yml
+
+# Dedup runs for the same branch across push / pull_request / pull_request_target / workflow_call.
+# Same-repo PRs would otherwise fire both push (on the branch SHA) AND pull_request (on the PR);
+# concurrency keeps only the newer in-flight run per branch.
+concurrency:
+  group: unity-tests-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   matrix:
@@ -71,12 +91,12 @@ jobs:
         run: |
           set -euo pipefail
           # Full matrix on: beta push, workflow_call (release pipelines), workflow_dispatch,
-          # or any PR labeled with 'full-matrix'.
+          # or any PR (pull_request OR pull_request_target) labeled with 'full-matrix'.
           # Default (single defaultVersion from tools/unity-versions.json) otherwise — fast PR feedback.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]] || \
              [[ "$EVENT_NAME" == "workflow_call" ]] || \
              { [[ "$EVENT_NAME" == "push" ]] && [[ "$GH_REF" == "refs/heads/beta" ]]; } || \
-             { [[ "$EVENT_NAME" == "pull_request_target" ]] && [[ "$FULL_MATRIX_LABEL" == "true" ]]; }; then
+             { { [[ "$EVENT_NAME" == "pull_request" ]] || [[ "$EVENT_NAME" == "pull_request_target" ]]; } && [[ "$FULL_MATRIX_LABEL" == "true" ]]; }; then
             versions=$(jq -c '[.versions[].id]' tools/unity-versions.json)
             echo "Trigger '$EVENT_NAME' on ref '$GH_REF' (full_matrix_label=$FULL_MATRIX_LABEL) → full matrix: $versions"
           else

--- a/docs/development/README-DEV.md
+++ b/docs/development/README-DEV.md
@@ -142,16 +142,18 @@ open htmlcov/index.html
 
 CI exercises the package across multiple Unity versions to catch breaks in `#if UNITY_*_OR_NEWER` branches. The matrix is configured in `tools/unity-versions.json` and consumed by `.github/workflows/unity-tests.yml`.
 
+**Every PR gets a unity-tests status check on open** (mirrors `python-tests.yml`). For same-repo PRs the default Unity 6 leg actually runs; for fork PRs the workflow appears but skips with a "missing license secrets" notice until a maintainer applies `safe-to-test` (existing secret-safety gate). The full 4-version matrix is opt-in via the `full-matrix` label.
+
 **When the full matrix runs (all 4 versions in parallel):**
 
 - Push to `beta` (the release gate).
 - `workflow_call` from `beta-release.yml` / `release.yml`.
 - Manual `workflow_dispatch` from the Actions tab.
-- Any PR (in-repo or fork) labeled with **`full-matrix`** — apply this label when your change touches compat shims, conditional compilation, or anything else version-sensitive. The workflow re-runs with the full matrix on the next `pull_request_target` event. Cost is ~6-8 min wall clock vs ~3 min for the default leg.
+- Any PR (in-repo or fork) labeled with **`full-matrix`** — apply when your change touches compat shims, conditional compilation, or anything else version-sensitive. Triggers a full-matrix run on the next `pull_request` or `pull_request_target` event. Cost is ~6-8 min wall clock vs ~3 min for the default leg.
 
-Fork PRs still need `safe-to-test` as the base gate (existing secret-safety pattern); `full-matrix` is layered on top of that for fork-PR full-matrix runs.
+Fork PRs still need `safe-to-test` as the base gate (so secrets are exposed against reviewed-only fork code); `full-matrix` is layered on top for fork-PR full-matrix runs.
 
-**Default (single leg) runs on every other path** — feature-branch pushes and unlabeled in-repo PRs run only against `defaultVersion` from `tools/unity-versions.json` (currently Unity 6.0 LTS, `6000.0.75f1`). The `floor` role (`2021.3.45f2`) still identifies the package minimum and runs as part of the full matrix; it's no longer the default-leg version.
+**Default (single leg)** — every other path runs only against `defaultVersion` from `tools/unity-versions.json` (currently Unity 6.0 LTS, `6000.0.75f1`). The `floor` role (`2021.3.45f2`) still identifies the package minimum and runs as part of the full matrix; it's no longer the default-leg version.
 
 ## Local Unity-version parity check
 


### PR DESCRIPTION
## Summary

Closes the asymmetry between `python-tests.yml` (auto-fires on every PR via `pull_request`) and `unity-tests.yml` (only fires on labeled `pull_request_target`, or on `push` events).

Today on a fresh PR you see:

- `Python Tests / ...` → ran, status check appears
- `Unity Tests` → **no status check at all** until a maintainer labels (fork PR) or the branch is pushed to upstream

After this PR:

- Every PR (in-repo or fork) gets a `Unity Tests / Test in editmode on Unity 6000.0.75f1` status check on open. Default leg only (~3 min) by default.
- Same-repo PRs run for real (`pull_request` has access to secrets when source = base repo).
- Fork PRs fire the workflow in fork context (no secrets) — existing `detect` step writes `unity_ok=false` and the existing "Skip Unity tests (missing license secrets)" step prints the notice, job exits clean. The check appears but signals to the maintainer that `safe-to-test` is needed for a real run (existing pattern preserved).
- Apply `full-matrix` label on either event type to opt into the wide 4-version matrix.

## Changes

```
 .github/workflows/unity-tests.yml | 24 ++++++++++++++++++++++--
 docs/development/README-DEV.md    |  8 +++++---
 2 files changed, 27 insertions(+), 5 deletions(-)
```

Three workflow changes:

1. **Add `pull_request: branches: [main, beta]` trigger** with the same path filter as `pull_request_target`. The job-level `if:` gates already pass through non-`pull_request_target` events, so no gate edits needed.

2. **Extend the matrix selector to honor `full-matrix` label on `pull_request` events** (not just `pull_request_target`). Lets in-repo PR contributors opt into the wide matrix at PR-open time without waiting for `pull_request_target: types: [labeled]`.

3. **Workflow-level `concurrency` group** keyed on `github.head_ref || github.ref`. Same-repo PRs would otherwise fire both `push` (on the branch SHA) and `pull_request` (on the PR SHA) and double-run the matrix; concurrency dedupes (newer cancels older).

## Selector dry-run

Verified across the seven trigger cases:

```
PR open, no label                                       -> default
PR open WITH full-matrix label                          -> FULL
pull_request_target + full-matrix label                 -> FULL
push to feature branch (no PR)                          -> default
push to beta                                            -> FULL
workflow_call (from beta-release.yml / release.yml)     -> FULL
workflow_dispatch (manual from Actions tab)             -> FULL
```

## Fork-PR cosmetic note

On a fork PR with no labels:

- Status check title: `Unity Tests / Test in editmode on Unity 6000.0.75f1`
- Job result: **success** (because `detect` writes `unity_ok=false`, the explicit skip step runs and exits 0)
- Log clearly says: `Unity license secrets missing; skipping Unity tests.`

The "success" status is slightly misleading at a glance, but the same pattern is already established (the workflow was using this on the push trigger for the same reason). The clear log message is the source of truth; the status check just signals "the workflow saw your PR". If the project decides this is too noisy, the skip step could be switched to `exit 78` (was once "neutral" but GH removed neutral statuses in 2020 — would now show as failure). Pragmatic call to keep as-is.

## Test plan

- [ ] Open this PR — confirm a `Unity Tests` status check appears (because this PR's diff touches `.github/workflows/unity-tests.yml` which is on the path filter).
- [ ] On the first in-repo PR after this lands, confirm the unity-tests job actually runs the default Unity 6 leg (~3 min).
- [ ] On a fork PR after this lands, confirm the unity-tests check appears with success status and the log says "Skipping Unity tests..." — then the maintainer applies `safe-to-test` and the `pull_request_target` path runs for real.
- [ ] Push two commits rapidly to a feature branch with an open PR — confirm the older run is cancelled and only the newest leg completes (concurrency group working).
- [ ] Apply `full-matrix` label to an in-repo PR — confirm the next push runs all 4 legs.

## Stacking with other open PRs

This change is **independent** of any open PRs touching unity-tests.yml — it edits only the trigger surface and matrix selector while leaving the existing job bodies, gates, and check-results step unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/test workflow with improved run deduplication and branch-specific build configurations to streamline testing processes.

* **Documentation**
  * Updated development guidelines to clarify Unity version testing matrix behavior, trigger conditions, and expected test execution timelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->