### PR TITLE
Update Antigravity mcp_config.json path for Windows

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
@@ -14,7 +14,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
             name = "Antigravity",
             windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
             macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
-            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
             HttpUrlProperty = "serverUrl",
             DefaultUnityFields = { { "disabled", false } },
             StripEnvWhenNotRequired = true

--- a/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
@@ -12,7 +12,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
         public AntigravityConfigurator() : base(new McpClient
         {
             name = "Antigravity",
-            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
             macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
             linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
             HttpUrlProperty = "serverUrl",


### PR DESCRIPTION
Updated the Windows `mcp_config.json` path to use the new `.gemini/config/mcp_config.json` location.

Please check whether the macOS and Linux paths also need to be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration location to use the shared .gemini/config/mcp_config.json on Windows and Linux for consistent configuration across components; macOS continues to use the Antigravity-specific config location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->