### PR TITLE
ci: stop firing unity-tests/python-tests twice on beta and main pushes

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,7 +2,11 @@ name: Python Tests
 
 on:
   push:
-    branches: ["**"]
+    # Exclude beta and main: those branches re-trigger this workflow via
+    # workflow_call from beta-release.yml / release.yml. Without the exclusion,
+    # a push to beta that touches Server/** fires this workflow twice for the
+    # same SHA, and GitHub auto-cancels the duplicate.
+    branches-ignore: [beta, main]
     paths:
       - Server/**
       - .github/workflows/python-tests.yml

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -10,7 +10,13 @@ on:
         required: false
         default: ""
   push:
-    branches: ["**"]
+    # Exclude beta and main: those branches re-trigger this workflow via
+    # workflow_call from beta-release.yml / release.yml. Without the exclusion,
+    # a push to beta that touches MCPForUnity/** fires this workflow twice
+    # for the same SHA, and GitHub's auto-generated concurrency group
+    # (`unity-tests-refs/heads/beta`) cancels the older run with the noisy
+    # "higher priority waiting request" annotation.
+    branches-ignore: [beta, main]
     paths:
       - TestProjects/UnityMCPTests/**
       - MCPForUnity/Editor/**


### PR DESCRIPTION
A push to `beta` (or `main`) that touches `MCPForUnity/**` or `Server/**` fires the test workflow through two paths at once:

```
push to beta ─┬─► unity-tests.yml  (direct push trigger, branches: ["**"])
              │
              └─► beta-release.yml ──workflow_call──► unity-tests.yml
```

Both invocations end up in GitHub's auto-generated concurrency group `unity-tests-refs/heads/beta`, so the later one cancels the earlier with the "Canceling since a higher priority waiting request for unity-tests-refs/heads/beta exists" annotation. The cancelled run shows red on the Actions page even though its workflow_call sibling completed fine — pure noise.

Fix is the smallest one I could find: switch the direct push trigger on `unity-tests.yml` and `python-tests.yml` to `branches-ignore: [beta, main]`. Beta and main are already covered through `workflow_call` from `beta-release.yml` and `release.yml` respectively, so we don't lose coverage — we just stop firing the duplicate run that gets killed by concurrency.

PR checks, feature-branch pushes, and manual `workflow_dispatch` invocations are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow configurations to prevent redundant test executions on protected branches, improving build efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->