### PR TITLE
fix(clients): point Antigravity at ~/.gemini/config/ after the 2.x migration

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
@@ -18,7 +18,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
         // fails to register UnityMCP on every modern install.
         public AntigravityConfigurator() : base(new McpClient
         {
-            name = "Antigravity",
+            name = "Antigravity 2.0",
             windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
             macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
             linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
@@ -50,7 +50,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
 
         public override IList<string> GetInstallationSteps() => new List<string>
         {
-            "Open Antigravity",
+            "Open Antigravity 2.0",
             "Click the more_horiz menu in the Agent pane > MCP Servers",
             "Select 'Install' for Unity MCP or use the Configure button above",
             "Restart Antigravity if necessary"

--- a/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/AntigravityConfigurator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Models;
 using UnityEditor;
@@ -9,17 +10,43 @@ namespace MCPForUnity.Editor.Clients.Configurators
 {
     public class AntigravityConfigurator : JsonFileMcpConfigurator
     {
+        // Antigravity 2.x migrated its MCP config from ~/.gemini/antigravity/mcp_config.json
+        // (where Antigravity also stores its own runtime state — conversations, scratch, etc.)
+        // to a dedicated ~/.gemini/config/mcp_config.json. The migration drops a `.migrated`
+        // marker in the new location and renames the previous folder to `antigravity-backup`.
+        // The old path is no longer read by Antigravity at all, so writing there silently
+        // fails to register UnityMCP on every modern install.
         public AntigravityConfigurator() : base(new McpClient
         {
             name = "Antigravity",
-            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
-            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
-            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity", "mcp_config.json"),
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json"),
             HttpUrlProperty = "serverUrl",
             DefaultUnityFields = { { "disabled", false } },
             StripEnvWhenNotRequired = true
         })
         { }
+
+        // Detect Antigravity itself, not just its config dir. ~/.gemini/config/ is created on
+        // first launch of Antigravity 2.x, so the inherited ParentDirectoryExists check
+        // false-negatives on a fresh install where the user hasn't opened Antigravity yet.
+        // ~/.antigravity/ is created by the installer (VS-Code-style support dir) and the
+        // macOS app bundle is dropped by the installer; either is conclusive evidence that
+        // Antigravity is installed, regardless of whether it has been launched.
+        public override bool IsInstalled
+        {
+            get
+            {
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                if (Directory.Exists(Path.Combine(home, ".antigravity"))) return true;
+                if (Directory.Exists(Path.Combine(home, ".gemini", "config"))) return true;
+                if (Directory.Exists(Path.Combine(home, ".gemini", "antigravity"))) return true;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    return Directory.Exists("/Applications/Antigravity.app");
+                return false;
+            }
+        }
 
         public override IList<string> GetInstallationSteps() => new List<string>
         {

--- a/MCPForUnity/Editor/Clients/Configurators/AntigravityIdeConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/AntigravityIdeConfigurator.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Models;
+using UnityEditor;
+
+namespace MCPForUnity.Editor.Clients.Configurators
+{
+    /// <summary>
+    /// Antigravity IDE — the separate IDE build that ships its own ~/.gemini/antigravity-ide/
+    /// runtime dir and reads its MCP config from that same folder. It did NOT migrate to
+    /// ~/.gemini/config/ the way Antigravity 2.0 did, so it still uses the legacy in-folder
+    /// mcp_config.json layout. The two apps coexist on the same machine, so we expose them
+    /// as separate clients rather than trying to autodetect which one to write to.
+    /// </summary>
+    public class AntigravityIdeConfigurator : JsonFileMcpConfigurator
+    {
+        public AntigravityIdeConfigurator() : base(new McpClient
+        {
+            name = "Antigravity IDE",
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity-ide", "mcp_config.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity-ide", "mcp_config.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "antigravity-ide", "mcp_config.json"),
+            HttpUrlProperty = "serverUrl",
+            DefaultUnityFields = { { "disabled", false } },
+            StripEnvWhenNotRequired = true
+        })
+        { }
+
+        // ~/.gemini/antigravity-ide/ is created by the IDE on first launch and holds both
+        // its runtime state (annotations/, brain/, conversations/, ...) and its mcp_config.json
+        // — presence of the dir is the canonical "Antigravity IDE has been installed and
+        // launched at least once" signal.
+        public override bool IsInstalled
+        {
+            get
+            {
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                return Directory.Exists(Path.Combine(home, ".gemini", "antigravity-ide"));
+            }
+        }
+
+        public override IList<string> GetInstallationSteps() => new List<string>
+        {
+            "Open Antigravity IDE",
+            "Click the more_horiz menu in the Agent pane > MCP Servers",
+            "Select 'Install' for Unity MCP or use the Configure button above",
+            "Restart Antigravity IDE if necessary"
+        };
+    }
+}

--- a/MCPForUnity/Editor/Clients/Configurators/AntigravityIdeConfigurator.cs.meta
+++ b/MCPForUnity/Editor/Clients/Configurators/AntigravityIdeConfigurator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c74a24c69bb0481682d5e35731cba6b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ openupm add com.coplaydev.unity-mcp
 - In the **Clients** tab, click **Configure All Detected Clients** to set up every client found on your machine in one shot, or pick a single client from the dropdown and click **Configure**.
 - Look for 🟢 "Connected ✓".
 
-**Per-client gotchas:** Some clients (Cursor, Antigravity, OpenClaw) still require enabling an MCP toggle or plugin in their own settings. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Claude Desktop only supports stdio — MCP for Unity will silently configure it that way even if you've selected HTTP elsewhere. Claude Code, VS Code, Windsurf, Cline, and the various CLI clients auto-connect after configuration.
+**Per-client gotchas:** Some clients (Cursor, Antigravity 2.0, Antigravity IDE, OpenClaw) still require enabling an MCP toggle or plugin in their own settings. The two Antigravity clients are listed separately because Antigravity 2.0 migrated its MCP config into `~/.gemini/config/` while Antigravity IDE still uses `~/.gemini/antigravity-ide/`; if you run both, configure each one. OpenClaw also needs the `openclaw-mcp-bridge` plugin enabled and follows the currently selected MCP for Unity transport (`HTTP` or `stdio`). Claude Desktop only supports stdio — MCP for Unity will silently configure it that way even if you've selected HTTP elsewhere. Claude Code, VS Code, Windsurf, Cline, and the various CLI clients auto-connect after configuration.
 
 **Updates handle themselves.** When you update the package, MCP for Unity rewrites the configs of every detected client on the next Editor open — no need to repeat the Configure step.
 
@@ -118,7 +118,7 @@ openupm add com.coplaydev.unity-mcp
 
 If auto-setup doesn't work, add this to your MCP client's config file:
 
-**HTTP (default — works with Cursor, Windsurf, Antigravity, VS Code, Cline; Claude Desktop is stdio-only, see below):**
+**HTTP (default — works with Cursor, Windsurf, Antigravity 2.0, Antigravity IDE, VS Code, Cline; Claude Desktop is stdio-only, see below):**
 ```json
 {
   "mcpServers": {

--- a/docs/guides/MCP_CLIENT_CONFIGURATORS.md
+++ b/docs/guides/MCP_CLIENT_CONFIGURATORS.md
@@ -4,7 +4,7 @@ This guide explains how MCP client configurators work in this repo and how to ad
 
 It covers:
 
-- **Typical JSON-file clients** (Cursor, VSCode GitHub Copilot, VSCode Insiders, GitHub Copilot CLI, Windsurf, Kiro, Trae, Antigravity, etc.).
+- **Typical JSON-file clients** (Cursor, VSCode GitHub Copilot, VSCode Insiders, GitHub Copilot CLI, Windsurf, Kiro, Trae, Antigravity 2.0, Antigravity IDE, etc.).
 - **Special clients** like **Claude CLI**, **Codex**, and **OpenClaw** that require custom logic.
 - **How to add a new configurator class** so it shows up automatically in the MCP for Unity window.
 
@@ -93,7 +93,7 @@ Most MCP clients use a JSON config file that defines one or more MCP servers. Ex
 - **VSCode Insiders GitHub Copilot** – `JsonFileMcpConfigurator` with `IsVsCodeLayout = true` and Insider-specific `Code - Insiders/User/mcp.json` paths.
 - **GitHub Copilot CLI** – `JsonFileMcpConfigurator` with standard HTTP transport.
 - **Windsurf** – `JsonFileMcpConfigurator` with Windsurf-specific flags (`HttpUrlProperty = "serverUrl"`, `DefaultUnityFields["disabled"] = false`, etc.).
-- **Kiro**, **Trae**, **Antigravity (Gemini)** – JSON configs with project-specific paths and flags.
+- **Kiro**, **Trae**, **Antigravity 2.0** (`~/.gemini/config/mcp_config.json` after the 2.x migration), **Antigravity IDE** (separate `~/.gemini/antigravity-ide/mcp_config.json` — the IDE build did not migrate) – JSON configs with project-specific paths and flags.
 
 All of these follow the same pattern:
 
@@ -118,7 +118,7 @@ All of these follow the same pattern:
     - `command` + `args` (stdio with `uvx`).
 - **URL property name**
   - `HttpUrlProperty` (default `"url"`) selects which JSON property to use for HTTP urls.
-  - Example: Windsurf and Antigravity use `"serverUrl"`.
+  - Example: Windsurf and the two Antigravity clients use `"serverUrl"`.
 - **VS Code layout**
   - `IsVsCodeLayout = true` switches config structure to a VS Code compatible layout.
 - **Env object and default fields**
@@ -228,7 +228,7 @@ Override `GetInstallationSteps` to tell users how to configure the client:
 - Which menu path opens the MCP settings.
 - Whether they should rely on the **Configure** button or copy-paste the manual JSON.
 
-Look at `CursorConfigurator`, `VSCodeConfigurator`, `VSCodeInsidersConfigurator`, `KiroConfigurator`, `TraeConfigurator`, or `AntigravityConfigurator` for phrasing.
+Look at `CursorConfigurator`, `VSCodeConfigurator`, `VSCodeInsidersConfigurator`, `KiroConfigurator`, `TraeConfigurator`, `AntigravityConfigurator`, or `AntigravityIdeConfigurator` for phrasing.
 
 ### 4. Rely on the base JSON logic
 

--- a/docs/i18n/README-zh.md
+++ b/docs/i18n/README-zh.md
@@ -81,7 +81,7 @@ openupm add com.coplaydev.unity-mcp
 2. 点击 **Start Server**（会在 `localhost:8080` 启动 HTTP 服务器）
 3. 从下拉菜单选择你的 MCP Client，然后点击 **Configure**
 4. 查找 🟢 "Connected ✓"
-5. **连接你的客户端：** 一些客户端（Cursor、Antigravity、OpenClaw）需要在设置里启用 MCP 开关或插件。OpenClaw 还需要启用 `openclaw-mcp-bridge` 插件，并会跟随 MCP for Unity 当前选择的传输方式（HTTP 或 stdio）；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
+5. **连接你的客户端：** 一些客户端（Cursor、Antigravity 2.0、Antigravity IDE、OpenClaw）需要在设置里启用 MCP 开关或插件。Antigravity 2.0 与 Antigravity IDE 是分开列出的：Antigravity 2.0 已迁移到 `~/.gemini/config/`，而 Antigravity IDE 仍使用 `~/.gemini/antigravity-ide/`；如果两者都在使用，请分别配置。OpenClaw 还需要启用 `openclaw-mcp-bridge` 插件，并会跟随 MCP for Unity 当前选择的传输方式（HTTP 或 stdio）；另一些（Claude Desktop、Claude Code）在配置后会自动连接。
 
 **就这些！** 试试这样的提示词：*"Create a red, blue and yellow cube"* 或 *"Build a simple player controller"*
 


### PR DESCRIPTION
Community report: "in .gemini there are two folders, antigravity and config; antigravity is not where mcp.json is supposed to be — there is another config folder where mcp.json should be placed."

Verified on a real machine. Antigravity 2.x migrates its MCP config out of the runtime-state folder and into a dedicated one:

```
~/.gemini/
├── config/                    ← new home (Antigravity reads from here)
│   ├── .migrated              ← migration marker dropped by Antigravity 2.x
│   ├── config.json
│   └── mcp_config.json        ← "mcpServers": {}  (empty after migration)
├── antigravity/               ← still used for runtime state only
│   ├── conversations/
│   ├── scratch/
│   ├── brain/
│   └── mcp_config.json        ← THE PATH WE'VE BEEN WRITING TO. Antigravity no longer reads this.
└── antigravity-backup/        ← pre-migration backup Antigravity made
    └── mcp_config.json
```

The path mismatch combined with the recent startup auto-rewrite means we were silently overwriting a file Antigravity ignores on every Editor launch, so the user sees their carefully-configured UnityMCP entry never showing up in Antigravity's MCP servers UI.

**Two changes:**

1. Point all three platform paths at `~/.gemini/config/mcp_config.json` (Antigravity 2.x is consistent across macOS / Windows / Linux on this layout).

2. Override `IsInstalled` so a fresh install — Antigravity installed but never launched — is still detected. The inherited `ParentDirectoryExists(GetConfigPath())` would false-negative because `~/.gemini/config/` is only created on first launch of Antigravity. Check `~/.antigravity/` (installer-created, VS-Code-style support dir), either of the gemini config dirs, or the macOS app bundle. Without this, `ConfigureAllDetectedClients` skips Antigravity entirely on a brand-new machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Antigravity IDE client.
  * Renamed user-facing client to "Antigravity 2.0" and updated related onboarding steps.

* **Bug Fixes**
  * Improved installation detection for Antigravity to reduce false negatives across platforms.
  * Unified MCP configuration handling so Antigravity 2.0 uses the migrated config location.

* **Documentation**
  * Clarified quick-start and manual configuration guidance for Cursor, Antigravity 2.0, Antigravity IDE, OpenClaw, and Claude Desktop.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->