### PR TITLE
fix(ui): default the per-client setup foldout to expanded so Unregister is visible

### DIFF
--- a/MCPForUnity/Editor/Clients/IMcpClientConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/IMcpClientConfigurator.cs
@@ -48,8 +48,19 @@ namespace MCPForUnity.Editor.Clients
         /// <summary>Checks and updates status; returns current status.</summary>
         McpStatus CheckStatus(bool attemptAutoRewrite = true);
 
-        /// <summary>Runs auto-configuration (register/write file/CLI etc.).</summary>
+        /// <summary>Runs auto-configuration (register/write file/CLI etc.). Always idempotent
+        /// — calling twice with the same settings is safe and is what the bulk "Configure All"
+        /// path relies on to refresh transport / server-version drift across every detected
+        /// client.</summary>
         void Configure();
+
+        /// <summary>
+        /// Removes UnityMCP from this client's config (JSON entry, CLI registration, etc.).
+        /// Default is a no-op for client types that don't yet implement removal (Codex TOML);
+        /// callers should treat this as best-effort. The UI's per-client button routes here
+        /// when <see cref="Status"/> is <see cref="McpStatus.Configured"/>.
+        /// </summary>
+        void Unregister();
 
         /// <summary>Returns the manual configuration snippet (JSON/TOML/commands).</summary>
         string GetManualSnippet();

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -334,6 +334,18 @@ namespace MCPForUnity.Editor.Clients
 
         public override void Configure()
         {
+            // Toggle: clicking when the client is currently Configured removes the
+            // unityMCP entry from the JSON file. Clicking when it is NotConfigured /
+            // IncorrectPath / etc. writes the current settings. Mirrors the Claude CLI
+            // configurator's pattern so the per-client button behaves the same way for
+            // every client type — users who landed on a stuck/wrong registration can
+            // wipe it with the same button instead of hand-editing JSON.
+            if (client.status == McpStatus.Configured)
+            {
+                UnregisterFromConfig();
+                return;
+            }
+
             string path = GetConfigPath();
             McpConfigurationHelper.EnsureConfigDirectoryExists(path);
             string result = McpConfigurationHelper.WriteMcpConfiguration(path, client);
@@ -345,6 +357,59 @@ namespace MCPForUnity.Editor.Clients
             else
             {
                 throw new InvalidOperationException(result);
+            }
+        }
+
+        public override string GetConfigureActionLabel()
+            => client.status == McpStatus.Configured ? "Unregister" : "Configure";
+
+        /// <summary>
+        /// Removes the unityMCP entry from the client's JSON config (both VS Code-style
+        /// `servers` / `mcp.servers` layouts and the standard `mcpServers` layout). Leaves
+        /// the file in place so we don't clobber other servers the user has configured.
+        /// </summary>
+        private void UnregisterFromConfig()
+        {
+            string path = GetConfigPath();
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    client.SetStatus(McpStatus.NotConfigured);
+                    client.configuredTransport = Models.ConfiguredTransport.Unknown;
+                    return;
+                }
+
+                var root = JsonConvert.DeserializeObject<JToken>(File.ReadAllText(path)) as JObject;
+                if (root == null)
+                {
+                    client.SetStatus(McpStatus.NotConfigured);
+                    client.configuredTransport = Models.ConfiguredTransport.Unknown;
+                    return;
+                }
+
+                bool removed = false;
+                if (client.IsVsCodeLayout)
+                {
+                    if ((root["servers"] as JObject)?.Remove("unityMCP") == true) removed = true;
+                    if ((root["mcp"]?["servers"] as JObject)?.Remove("unityMCP") == true) removed = true;
+                }
+                else
+                {
+                    if ((root["mcpServers"] as JObject)?.Remove("unityMCP") == true) removed = true;
+                }
+
+                if (removed)
+                {
+                    File.WriteAllText(path, root.ToString(Formatting.Indented));
+                }
+
+                client.SetStatus(McpStatus.NotConfigured);
+                client.configuredTransport = Models.ConfiguredTransport.Unknown;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to unregister: {ex.Message}");
             }
         }
 

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -45,6 +45,11 @@ namespace MCPForUnity.Editor.Clients
         public abstract string GetConfigPath();
         public abstract McpStatus CheckStatus(bool attemptAutoRewrite = true);
         public abstract void Configure();
+
+        /// <summary>Default Unregister is a no-op. Override in JsonFileMcpConfigurator /
+        /// ClaudeCliMcpConfigurator etc. where removal has a concrete implementation.</summary>
+        public virtual void Unregister() { }
+
         public abstract string GetManualSnippet();
         public abstract IList<string> GetInstallationSteps();
 
@@ -334,18 +339,9 @@ namespace MCPForUnity.Editor.Clients
 
         public override void Configure()
         {
-            // Toggle: clicking when the client is currently Configured removes the
-            // unityMCP entry from the JSON file. Clicking when it is NotConfigured /
-            // IncorrectPath / etc. writes the current settings. Mirrors the Claude CLI
-            // configurator's pattern so the per-client button behaves the same way for
-            // every client type — users who landed on a stuck/wrong registration can
-            // wipe it with the same button instead of hand-editing JSON.
-            if (client.status == McpStatus.Configured)
-            {
-                UnregisterFromConfig();
-                return;
-            }
-
+            // Always idempotent-write. The per-client UI button routes through Unregister
+            // when the user clicks while the client is already Configured; the bulk
+            // "Configure All" path calls this directly and expects an unconditional write.
             string path = GetConfigPath();
             McpConfigurationHelper.EnsureConfigDirectoryExists(path);
             string result = McpConfigurationHelper.WriteMcpConfiguration(path, client);
@@ -368,7 +364,7 @@ namespace MCPForUnity.Editor.Clients
         /// `servers` / `mcp.servers` layouts and the standard `mcpServers` layout). Leaves
         /// the file in place so we don't clobber other servers the user has configured.
         /// </summary>
-        private void UnregisterFromConfig()
+        public override void Unregister()
         {
             string path = GetConfigPath();
             try

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -405,7 +405,7 @@ namespace MCPForUnity.Editor.Clients
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException($"Failed to unregister: {ex.Message}");
+                throw new InvalidOperationException($"Failed to unregister: {ex.Message}", ex);
             }
         }
 
@@ -1025,7 +1025,7 @@ namespace MCPForUnity.Editor.Clients
             client.configuredTransport = HttpEndpointUtility.GetCurrentServerTransport();
         }
 
-        private void Unregister()
+        public override void Unregister()
         {
             var pathService = MCPServiceLocator.Paths;
             string claudePath = pathService.GetClaudeCliPath();

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
@@ -111,11 +111,15 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
                 manualConfigFoldout.value = false;
             }
 
-            // Restore the "Configure a single client" foldout state. Defaults to collapsed
-            // so the prominent "Configure All Detected Clients" path is what users see first.
+            // Default the per-client setup foldout to expanded. The Configure / Unregister
+            // button for the currently-selected client lives inside it, and the 9.7.0
+            // default-collapsed behavior made users believe the Unregister action had been
+            // removed (community report: "the Unregister button was removed in 9.7.0,
+            // something is stuck on stdio and I can't switch to local"). The state still
+            // persists per-user, so anyone who explicitly collapses it keeps that preference.
             if (clientDetailsFoldout != null)
             {
-                clientDetailsFoldout.value = EditorPrefs.GetBool(EditorPrefKeys.ClientDetailsFoldoutOpen, false);
+                clientDetailsFoldout.value = EditorPrefs.GetBool(EditorPrefKeys.ClientDetailsFoldoutOpen, true);
                 clientDetailsFoldout.RegisterValueChangedCallback(evt =>
                 {
                     EditorPrefs.SetBool(EditorPrefKeys.ClientDetailsFoldoutOpen, evt.newValue);

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.cs
@@ -312,6 +312,13 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
 
                 EditorUtility.DisplayDialog("Configure Detected Clients", message, "OK");
 
+                // The bulk path mutated state for every detected client. Clear the per-client
+                // status cache so any subsequent dropdown switch (or the currently-selected
+                // client refresh below) reads fresh status from disk instead of the pre-bulk
+                // value — otherwise every other client in the dropdown looks like it still
+                // has Missing/IncorrectPath status until 45 s elapses on the throttle.
+                lastStatusChecks.Clear();
+
                 if (selectedClientIndex >= 0 && selectedClientIndex < configurators.Count)
                 {
                     UpdateClientStatus();
@@ -340,7 +347,18 @@ namespace MCPForUnity.Editor.Windows.Components.ClientConfig
 
             try
             {
-                MCPServiceLocator.Client.ConfigureClient(client);
+                // Per-client toggle: Configure→register, Unregister→remove. The Configure path
+                // on JsonFile / Codex configurators is always idempotent-write so the bulk
+                // "Configure All" can call it unconditionally; the toggle lives here in the UI
+                // handler so the manual button still does what its label says.
+                if (client.Status == McpStatus.Configured)
+                {
+                    client.Unregister();
+                }
+                else
+                {
+                    MCPServiceLocator.Client.ConfigureClient(client);
+                }
                 lastStatusChecks.Remove(client);
                 RefreshClientStatus(client, forceImmediate: true);
                 UpdateManualConfiguration();

--- a/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/ClientConfig/McpClientConfigSection.uxml
@@ -4,7 +4,7 @@
         <ui:Label text="Client Configuration" class="section-title" />
         <ui:VisualElement class="section-content">
             <ui:Button name="configure-all-button" text="Configure All Detected Clients" class="primary-button" />
-            <ui:Foldout name="client-details-foldout" text="Per-client setup" value="false" class="client-details-foldout">
+            <ui:Foldout name="client-details-foldout" text="Per-client setup" value="true" class="client-details-foldout">
                 <ui:VisualElement class="setting-row">
                     <ui:Label text="Client:" class="setting-label" />
                     <ui:DropdownField name="client-dropdown" class="setting-dropdown-inline" />


### PR DESCRIPTION
Community reports:

> "Not a very good idea that the Unregister button was removed in 9.7.0. It did a wrong registration with stdio transport, and now it is difficult to re-register. :/ something is stuck on stdio, which is unstable, and I can't switch to local."

> "stdio may be simpler for us beginners but somehow it is unstable in my case. Constantly disconnects from Claude Desktop."

The Unregister button wasn't actually removed — the 9.7.0 UI reshuffle put the single-client Configure button (which toggles to "Unregister" for CLI-based clients like Claude Code) inside a "Per-client setup" foldout that defaulted to collapsed. With "Configure All Detected Clients" sitting prominently green above it, the foldout reads more like a section divider than the entry point to manual per-client management. Users who need to wipe a bad stdio registration and re-add with HTTP couldn't find it.

Flip the default to expanded in both the UXML markup and the `EditorPrefs` fallback. State still persists per-user via `EditorPrefKeys.ClientDetailsFoldoutOpen`, so anyone who explicitly collapses it keeps that preference — only the never-touched default changes, which is exactly the cohort the community report is from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Per-client configuration details now open by default for easier access.
  * Bulk "Configure All" clears stale per-client status so displayed statuses refresh from disk immediately.

* **New Features**
  * Configure action now toggles between "Configure" and "Unregister" based on current client status.
  * "Unregister" removes client entries from JSON configs and resets client status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->