### PR TITLE
fix(compat): keep Runtime helpers compiling when built-in modules are disabled (#1160)

### DIFF
--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -53,6 +53,7 @@ namespace MCPForUnity.Runtime.Helpers
         private static bool s_loggedLegacyScreenCaptureFallback;
         private static bool? s_screenCaptureModuleAvailable;
         private static System.Reflection.MethodInfo s_captureScreenshotMethod;
+        private static System.Reflection.MethodInfo s_captureScreenshotAsTextureMethod;
 
         /// <summary>
         /// Checks if the Screen Capture module (com.unity.modules.screencapture) is enabled.
@@ -72,6 +73,8 @@ namespace MCPForUnity.Runtime.Helpers
                     {
                         s_captureScreenshotMethod = screenCaptureType.GetMethod("CaptureScreenshot",
                             new Type[] { typeof(string), typeof(int) });
+                        s_captureScreenshotAsTextureMethod = screenCaptureType.GetMethod("CaptureScreenshotAsTexture",
+                            new Type[] { typeof(int) });
                     }
                 }
                 return s_screenCaptureModuleAvailable.Value;
@@ -249,7 +252,7 @@ namespace MCPForUnity.Runtime.Helpers
             int maxResolution = 0,
             string folderOverride = null)
         {
-            if (!IsScreenCaptureModuleAvailable)
+            if (!IsScreenCaptureModuleAvailable || s_captureScreenshotAsTextureMethod == null)
             {
                 var fallbackCamera = FindAvailableCamera();
                 if (fallbackCamera != null)
@@ -266,7 +269,9 @@ namespace MCPForUnity.Runtime.Helpers
             int imgW = 0, imgH = 0;
             try
             {
-                tex = ScreenCapture.CaptureScreenshotAsTexture(result.SuperSize);
+                // Reflective call to ScreenCapture.CaptureScreenshotAsTexture so the file compiles
+                // even when the Screen Capture module (com.unity.modules.screencapture) is disabled.
+                tex = s_captureScreenshotAsTextureMethod.Invoke(null, new object[] { result.SuperSize }) as Texture2D;
                 if (tex == null)
                 {
                     // Fallback to camera-based if ScreenCapture fails

--- a/MCPForUnity/Runtime/Helpers/UnityPhysicsCompat.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityPhysicsCompat.cs
@@ -17,10 +17,15 @@ namespace MCPForUnity.Runtime.Helpers
     ///
     /// We use reflection rather than direct property access so calls stay clean of
     /// CS0618 warnings AND survive eventual removal of the obsolete property without
-    /// a recompile of this package.
+    /// a recompile of this package. Type lookups go through <see cref="Type.GetType(string)"/>
+    /// so this file compiles even when the Physics 2D built-in module is disabled in
+    /// the Package Manager.
     /// </summary>
     public static class UnityPhysicsCompat
     {
+        // Assembly-qualified name — resolved at runtime so the file compiles when the
+        // Physics 2D built-in module is disabled in the Package Manager.
+        private const string Physics2DTypeName = "UnityEngine.Physics2D, UnityEngine.Physics2DModule";
         /// <summary>
         /// Cross-version description of the 3D physics simulation mode.
         /// On 2022.2+ this maps onto <c>UnityEngine.SimulationMode</c>; on older
@@ -46,9 +51,13 @@ namespace MCPForUnity.Runtime.Helpers
                 if (!_physics2DProbed)
                 {
                     _physics2DProbed = true;
-                    _physics2DAutoSync = typeof(Physics2D).GetProperty(
-                        "autoSyncTransforms",
-                        BindingFlags.Public | BindingFlags.Static);
+                    var physics2DType = Type.GetType(Physics2DTypeName);
+                    if (physics2DType != null)
+                    {
+                        _physics2DAutoSync = physics2DType.GetProperty(
+                            "autoSyncTransforms",
+                            BindingFlags.Public | BindingFlags.Static);
+                    }
                 }
                 return _physics2DAutoSync;
             }


### PR DESCRIPTION
## Summary

Fixes #1160 — v9.7.0 introduced two Runtime compile failures for users who disable the **Physics 2D** or **Screen Capture** built-in modules in *Package Manager → Built-in*.

- **`UnityPhysicsCompat.cs:49`** — the shim file used `typeof(Physics2D)` directly, contradicting its own XML doc (*"reflection rather than direct property access … survive eventual removal without a recompile"*). Switched to `Type.GetType("UnityEngine.Physics2D, UnityEngine.Physics2DModule")`.
- **`ScreenshotUtility.cs:269`** — the file already invests in a reflective `ScreenCapture.CaptureScreenshot` path (`s_captureScreenshotMethod`) so it compiles without the module. The newer `CaptureComposited` method bypassed that pattern with a direct `ScreenCapture.CaptureScreenshotAsTexture` call. Added a sibling cached `MethodInfo` and routed the call through it.

Editor-side direct usages (`PhysicsQueryOps.cs`, `ManageUI.cs`) are pre-existing in v9.6.8 and represent intentional feature requirements — out of scope here.

## Why this fix vs. "module is required"

The package already advertises graceful degradation: `ScreenshotUtility` ships `IsScreenCaptureModuleAvailable` + `ScreenCaptureModuleNotAvailableError` + a camera-based fallback, and `UnityPhysicsCompat`'s XML doc explicitly promises reflective access. v9.7.0 silently broke both promises in Runtime files — restoring them is the minimal, contract-aligned change.

## Test plan

- [ ] In a project with **Physics 2D** disabled in *Package Manager → Built-in*, install this branch and confirm Runtime compiles (pre-fix: `CS1069` on `UnityPhysicsCompat.cs:49`).
- [ ] In a project with **Screen Capture** disabled, confirm Runtime compiles (pre-fix: `CS0103` on `ScreenshotUtility.cs:269`) and `CaptureComposited` falls back to camera capture when called.
- [ ] CI matrix (`tools/check-unity-versions.sh`) — these are reflection-only changes with no new `#if UNITY_*` gating, so no version-specific risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced screenshot capture with improved fallback mechanisms when modules are unavailable.
  * Improved Physics2D compatibility resolution for better resilience across varying module configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->