### PR TITLE
refactor: drop defensive scaffolding made obsolete by module dep declarations

### DIFF
--- a/MCPForUnity/Editor/Resources/Project/ProjectInfo.cs
+++ b/MCPForUnity/Editor/Resources/Project/ProjectInfo.cs
@@ -38,7 +38,7 @@ namespace MCPForUnity.Editor.Resources.Project
                         textmeshpro = IsPackageInstalled("com.unity.textmeshpro"),
                         inputsystem = IsPackageInstalled("com.unity.inputsystem"),
                         uiToolkit = true,
-                        screenCapture = MCPForUnity.Runtime.Helpers.ScreenshotUtility.IsScreenCaptureModuleAvailable,
+                        screenCapture = true,
                     }
                 };
 

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -678,24 +678,9 @@ namespace MCPForUnity.Editor.Tools
                     return new SuccessResponse(message, BuildScreenshotResponseData(result, targetCamera.name, includeImage));
                 }
 
-                // Default path: use ScreenCapture API if available, camera fallback otherwise
-                bool screenCaptureAvailable = ScreenshotUtility.IsScreenCaptureModuleAvailable;
+                // Default path: ScreenCapture API for 2022.1+, camera fallback required on older versions.
+#if !UNITY_2022_1_OR_NEWER
                 bool hasCameraFallback = Camera.main != null || UnityFindObjectsCompat.FindAll<Camera>().Length > 0;
-
-#if UNITY_2022_1_OR_NEWER
-                if (!screenCaptureAvailable && !hasCameraFallback)
-                {
-                    return new ErrorResponse(
-                        "Cannot capture screenshot. The Screen Capture module is not enabled and no Camera was found in the scene. " +
-                        "Please either: (1) Enable the Screen Capture module: Window > Package Manager > Built-in > Screen Capture > Enable, " +
-                        "or (2) Add a Camera to your scene for camera-based fallback capture."
-                    );
-                }
-                if (!screenCaptureAvailable)
-                {
-                    McpLog.Warn("[ManageScene] Screen Capture module not enabled. Using camera-based fallback.");
-                }
-#else
                 if (!hasCameraFallback)
                 {
                     return new ErrorResponse(

--- a/MCPForUnity/Editor/Tools/ManageUI.cs
+++ b/MCPForUnity/Editor/Tools/ManageUI.cs
@@ -927,12 +927,6 @@ namespace MCPForUnity.Editor.Tools
                 }
 
                 // ── Case 2: start a new capture ───────────────────────────────────
-                // Verify the ScreenCapture module is enabled before attempting capture.
-                if (!ScreenshotUtility.IsScreenCaptureModuleAvailable)
-                {
-                    return new ErrorResponse(ScreenshotUtility.ScreenCaptureModuleNotAvailableError);
-                }
-
                 // Only one capture in flight at a time.  If one is already pending,
                 // reject rather than silently overwriting the state.
                 if (s_pendingCaptureStarted)

--- a/MCPForUnity/Editor/Tools/Vfx/TrailControl.cs
+++ b/MCPForUnity/Editor/Tools/Vfx/TrailControl.cs
@@ -24,13 +24,9 @@ namespace MCPForUnity.Editor.Tools.Vfx
 
             RendererHelpers.EnsureMaterial(tr);
 
-#if UNITY_2021_1_OR_NEWER
             Vector3 pos = ManageVfxCommon.ParseVector3(@params["position"]);
             tr.AddPosition(pos);
             return new { success = true, message = $"Emitted at ({pos.x}, {pos.y}, {pos.z})" };
-#else
-            return new { success = false, message = "AddPosition requires Unity 2021.1+" };
-#endif
         }
     }
 }

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -50,57 +50,6 @@ namespace MCPForUnity.Runtime.Helpers
         /// or globally via <c>ScreenshotPreferences</c> in the Editor assembly.
         /// </summary>
         public const string DefaultFolder = "Assets/Screenshots";
-        private static bool s_loggedLegacyScreenCaptureFallback;
-        private static bool? s_screenCaptureModuleAvailable;
-        private static System.Reflection.MethodInfo s_captureScreenshotMethod;
-        private static System.Reflection.MethodInfo s_captureScreenshotAsTextureMethod;
-
-        /// <summary>
-        /// Checks if the Screen Capture module (com.unity.modules.screencapture) is enabled.
-        /// This module can be disabled in Package Manager > Built-in, which removes the ScreenCapture class.
-        /// </summary>
-        public static bool IsScreenCaptureModuleAvailable
-        {
-            get
-            {
-                if (!s_screenCaptureModuleAvailable.HasValue)
-                {
-                    // Check if ScreenCapture type exists (module might be disabled in Package Manager > Built-in)
-                    var screenCaptureType = Type.GetType("UnityEngine.ScreenCapture, UnityEngine.ScreenCaptureModule")
-                        ?? Type.GetType("UnityEngine.ScreenCapture, UnityEngine.CoreModule");
-                    s_screenCaptureModuleAvailable = screenCaptureType != null;
-                    if (screenCaptureType != null)
-                    {
-                        s_captureScreenshotMethod = screenCaptureType.GetMethod("CaptureScreenshot",
-                            new Type[] { typeof(string), typeof(int) });
-                        s_captureScreenshotAsTextureMethod = screenCaptureType.GetMethod("CaptureScreenshotAsTexture",
-                            new Type[] { typeof(int) });
-                    }
-                }
-                return s_screenCaptureModuleAvailable.Value;
-            }
-        }
-
-        /// <summary>
-        /// Reflective invocation of ScreenCapture.CaptureScreenshotAsTexture(int). Returns
-        /// null when the Screen Capture module is disabled. Centralised so the only direct
-        /// reference to ScreenCapture lives here.
-        /// </summary>
-        internal static Texture2D InvokeCaptureScreenshotAsTexture(int superSize)
-        {
-            if (!IsScreenCaptureModuleAvailable || s_captureScreenshotAsTextureMethod == null)
-                return null;
-            return s_captureScreenshotAsTextureMethod.Invoke(null, new object[] { superSize }) as Texture2D;
-        }
-
-        /// <summary>
-        /// Error message to display when Screen Capture module is not available.
-        /// </summary>
-        public const string ScreenCaptureModuleNotAvailableError =
-            "The Screen Capture module (com.unity.modules.screencapture) is not enabled. " +
-            "To use screenshot capture with ScreenCapture API, please enable it in Unity: " +
-            "Window > Package Manager > Built-in > Screen Capture > Enable. " +
-            "Alternatively, MCP for Unity will use camera-based capture as a fallback if a Camera exists in the scene.";
 
         private static Camera FindAvailableCamera()
         {
@@ -127,44 +76,10 @@ namespace MCPForUnity.Runtime.Helpers
             bool ensureUniqueFileName = true,
             string folderOverride = null)
         {
-            // Use reflection to call ScreenCapture.CaptureScreenshot so the code compiles
-            // even when the Screen Capture module (com.unity.modules.screencapture) is disabled.
-            if (IsScreenCaptureModuleAvailable && s_captureScreenshotMethod != null)
-            {
-                ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride, isAsync: true);
-                // ScreenCapture.CaptureScreenshot accepts paths relative to the project root.
-                s_captureScreenshotMethod.Invoke(null, new object[] { result.ProjectRelativePath, result.SuperSize });
-                return result;
-            }
-            else
-            {
-                // Module disabled or unavailable - try camera fallback
-                Debug.LogWarning("[MCP for Unity] " + ScreenCaptureModuleNotAvailableError);
-                return CaptureWithCameraFallback(fileName, superSize, ensureUniqueFileName, folderOverride);
-            }
-        }
-
-        private static ScreenshotCaptureResult CaptureWithCameraFallback(string fileName, int superSize, bool ensureUniqueFileName, string folderOverride)
-        {
-            if (!s_loggedLegacyScreenCaptureFallback)
-            {
-                Debug.Log("[MCP for Unity] Using camera-based screenshot capture. " +
-                    "This requires a Camera in the scene. For best results on Unity 2022.1+, ensure the Screen Capture module is enabled: " +
-                    "Window > Package Manager > Built-in > Screen Capture > Enable.");
-                s_loggedLegacyScreenCaptureFallback = true;
-            }
-
-            var cam = FindAvailableCamera();
-            if (cam == null)
-            {
-                throw new InvalidOperationException(
-                    "No camera found to capture screenshot. Camera-based capture requires a Camera in the scene. " +
-                    "Either add a Camera to your scene, or enable the Screen Capture module: " +
-                    "Window > Package Manager > Built-in > Screen Capture > Enable."
-                );
-            }
-
-            return CaptureFromCameraToProjectFolder(cam, fileName, superSize, ensureUniqueFileName, folderOverride: folderOverride);
+            ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride, isAsync: true);
+            // ScreenCapture.CaptureScreenshot accepts paths relative to the project root.
+            ScreenCapture.CaptureScreenshot(result.ProjectRelativePath, result.SuperSize);
+            return result;
         }
 
         /// <summary>
@@ -283,7 +198,7 @@ namespace MCPForUnity.Runtime.Helpers
         /// <summary>
         /// Captures a screenshot using ScreenCapture.CaptureScreenshotAsTexture, which captures the
         /// final composited frame including UI Toolkit overlays, post-processing, etc.
-        /// Falls back to camera-based capture if ScreenCapture is unavailable.
+        /// Falls back to camera-based capture if ScreenCapture returns null at runtime.
         /// </summary>
         public static ScreenshotCaptureResult CaptureComposited(
             string fileName = null,
@@ -293,16 +208,6 @@ namespace MCPForUnity.Runtime.Helpers
             int maxResolution = 0,
             string folderOverride = null)
         {
-            if (!IsScreenCaptureModuleAvailable || s_captureScreenshotAsTextureMethod == null)
-            {
-                var fallbackCamera = FindAvailableCamera();
-                if (fallbackCamera != null)
-                    return CaptureFromCameraToProjectFolder(fallbackCamera, fileName, superSize, ensureUniqueFileName,
-                        includeImage, maxResolution, folderOverride: folderOverride);
-
-                throw new InvalidOperationException("ScreenCapture module is unavailable and no fallback camera found.");
-            }
-
             ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride: folderOverride, isAsync: false);
             Texture2D tex = null;
             Texture2D downscaled = null;
@@ -315,9 +220,9 @@ namespace MCPForUnity.Runtime.Helpers
                 // composited; route through WaitForEndOfFrame instead.
                 tex = Application.isPlaying
                     ? CaptureCompositedAfterFrame(result.SuperSize)
-                    : InvokeCaptureScreenshotAsTexture(result.SuperSize);
+                    : ScreenCapture.CaptureScreenshotAsTexture(result.SuperSize);
 #else
-                tex = InvokeCaptureScreenshotAsTexture(result.SuperSize);
+                tex = ScreenCapture.CaptureScreenshotAsTexture(result.SuperSize);
 #endif
                 if (tex == null)
                 {
@@ -857,7 +762,7 @@ namespace MCPForUnity.Runtime.Helpers
         {
             yield return new WaitForEndOfFrame();
             Texture2D tex = null;
-            try { tex = ScreenshotUtility.InvokeCaptureScreenshotAsTexture(_superSize); }
+            try { tex = ScreenCapture.CaptureScreenshotAsTexture(_superSize); }
             catch (Exception ex) { Debug.LogError($"[MCP for Unity] CaptureScreenshotAsTexture failed: {ex.Message}"); }
             _onComplete?.Invoke(tex);
             Destroy(gameObject);

--- a/MCPForUnity/Runtime/Helpers/UnityPhysicsCompat.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityPhysicsCompat.cs
@@ -17,15 +17,10 @@ namespace MCPForUnity.Runtime.Helpers
     ///
     /// We use reflection rather than direct property access so calls stay clean of
     /// CS0618 warnings AND survive eventual removal of the obsolete property without
-    /// a recompile of this package. Type lookups go through <see cref="Type.GetType(string)"/>
-    /// so this file compiles even when the Physics 2D built-in module is disabled in
-    /// the Package Manager.
+    /// a recompile of this package.
     /// </summary>
     public static class UnityPhysicsCompat
     {
-        // Assembly-qualified name — resolved at runtime so the file compiles when the
-        // Physics 2D built-in module is disabled in the Package Manager.
-        private const string Physics2DTypeName = "UnityEngine.Physics2D, UnityEngine.Physics2DModule";
         /// <summary>
         /// Cross-version description of the 3D physics simulation mode.
         /// On 2022.2+ this maps onto <c>UnityEngine.SimulationMode</c>; on older
@@ -51,13 +46,9 @@ namespace MCPForUnity.Runtime.Helpers
                 if (!_physics2DProbed)
                 {
                     _physics2DProbed = true;
-                    var physics2DType = Type.GetType(Physics2DTypeName);
-                    if (physics2DType != null)
-                    {
-                        _physics2DAutoSync = physics2DType.GetProperty(
-                            "autoSyncTransforms",
-                            BindingFlags.Public | BindingFlags.Static);
-                    }
+                    _physics2DAutoSync = typeof(Physics2D).GetProperty(
+                        "autoSyncTransforms",
+                        BindingFlags.Public | BindingFlags.Static);
                 }
                 return _physics2DAutoSync;
             }


### PR DESCRIPTION
## Summary

Follow-up to #1122 (declared the Physics 2D / Screen Capture / Image Conversion / etc. modules as required deps in `package.json`). Now that Unity Package Manager keeps those modules enabled while MCP for Unity is installed, two defensive layers that protected against the now-impossible \"module disabled\" case are dead code. Plus one sub-floor `#if` gate that was always-true on our `unity: 2021.3` floor.

Net: **+15 / -144** across 6 files.

## Premise check

What needs to stay constant for the cleanup to be safe (validated against the CI matrix in `tools/unity-versions.json`: 2021.3.45f2 → 2022.3.62f1 → 6000.0.75f1 → 6000.4.8f1):

| Symbol | Stable since |
|---|---|
| `typeof(Physics2D)` | Always — in `UnityEngine` for ~15 years |
| `ScreenCapture.CaptureScreenshot(string, int)` | Unity 2017 |
| `ScreenCapture.CaptureScreenshotAsTexture(int)` | Unity 2017 |
| `com.unity.modules.physics2d` built-in | Unity 2019.3 |
| `com.unity.modules.screencapture` built-in | Unity 2019.3 |

All five span the entire supported matrix. The dep declarations from #1122 force the modules to be present, which makes `typeof(...)` and direct `ScreenCapture.X` calls safe.

What stays reflective (and should): the **property lookups** inside `UnityPhysicsCompat.cs` (`autoSyncTransforms`, `simulationMode`) — those are for *property-level* deprecations in Unity 6.x, a different concern from module presence.

## Changes

### Tier 1A — `UnityPhysicsCompat.cs`
Revert `Type.GetType(\"UnityEngine.Physics2D, UnityEngine.Physics2DModule\")` to `typeof(Physics2D)`. Drop the `Physics2DTypeName` const and the file-level doc paragraph claiming the file compiles when the module is disabled.

### Tier 1B — `TrailControl.cs`
Strip the `#if UNITY_2021_1_OR_NEWER` / `#else` gate around `tr.AddPosition(pos)`. Package floor is `2021.3`, so the `#else` branch (\"AddPosition requires Unity 2021.1+\") was unreachable.

### Tier 2 — `ScreenshotUtility.cs` + callers
- Remove `IsScreenCaptureModuleAvailable` public property, `ScreenCaptureModuleNotAvailableError` constant, `InvokeCaptureScreenshotAsTexture` helper, and the three reflection caches (`s_screenCaptureModuleAvailable`, `s_captureScreenshotMethod`, `s_captureScreenshotAsTextureMethod`).
- Replace `MethodInfo.Invoke` calls with direct `ScreenCapture.CaptureScreenshot(...)` / `ScreenCapture.CaptureScreenshotAsTexture(...)` in `CaptureToProjectFolder`, `CaptureComposited`, and the `ScreenshotCapturer` MonoBehaviour.
- **Camera-based fallback path is preserved** (`FindAvailableCamera` + `CaptureFromCameraToProjectFolder`) — it still handles transient `null` returns from `ScreenCapture` inside `CaptureComposited`.
- Drop the pre-flight `if (!IsScreenCaptureModuleAvailable)` gates in `ManageUI.cs` (UI render flow) and `ManageScene.cs` (screenshot flow). The 2022.1+/2021.3 split in `ManageScene.cs` is preserved — that's about `ScreenCapture` not behaving identically on the floor version, separate concern.
- `ProjectInfo.cs` (`mcpforunity://project/info` resource): `screenCapture` field is now hardcoded `true`. Preserves the resource shape for any consumer that reads it.

### Explicitly out of scope
- The reflective `CompilationPipeline.isCompiling` lookups in 4 bridge/service files (originally my proposed \"Tier 1C\") are **not** touched here — there are open PRs in that area, so leaving for a separate cleanup pass.

## Test plan

- [ ] Recommend labelling `full-matrix` so the cleanup runs against 2021.3.45f2 + 2022.3.62f1 + 6000.0.75f1 + 6000.4.8f1.
- [ ] Smoke-test in a real Unity project that **`manage_camera action=screenshot`** still produces a valid PNG (camera-based path + `ScreenCapture` path).
- [ ] Smoke-test that **`manage_ui action=render_ui`** still queues + returns the play-mode capture.
- [ ] No new tests added — this is pure removal of code paths that cannot fire with the current declared deps.

## Related
- Follows #1122 (declare module deps)
- Reverts the runtime-reflection half of #1162 (the property-level reflection in `UnityPhysicsCompat.cs` is kept; only the module-detect reflection is reverted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen capture reliability by streamlining capture logic and removing conditions that could prevent screenshots in certain scenarios.
  * Enhanced trail renderer consistency by ensuring position tracking works uniformly across all supported Unity versions.
  * Refined Physics 2D compatibility handling for more robust runtime property resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->