### PR TITLE
fix(execute_code): route CodeDom references through a response file (#1144)

### DIFF
--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -275,34 +275,57 @@ namespace MCPForUnity.Editor.Tools
             // CodeDom needs the netstandard-aware filtered paths
             var filtered = FilterAssemblyPathsForCodeDom(assemblyPaths);
 
-            using (var provider = new CSharpCodeProvider())
+            // CSharpCodeProvider turns every ReferencedAssemblies entry into a literal /r:"..." flag
+            // on the csc command line. Projects with ~100+ asmdefs blow past Windows' 32 KB
+            // CreateProcess argument limit and fail with "The filename or extension is too long."
+            // Route references through a response file (@responsefile is supported by both mcs and
+            // Roslyn csc) so we pass exactly one short argument regardless of reference count.
+            string responseFilePath = Path.Combine(Path.GetTempPath(), $"mcp-codedom-{Guid.NewGuid():N}.rsp");
+
+            try
             {
-                var parameters = new CompilerParameters
+                using (var writer = new StreamWriter(responseFilePath, append: false, Encoding.UTF8))
                 {
-                    GenerateInMemory = true,
-                    GenerateExecutable = false,
-                    TreatWarningsAsErrors = false,
-                };
-
-                foreach (var path in filtered)
-                    parameters.ReferencedAssemblies.Add(path);
-
-                var results = provider.CompileAssemblyFromSource(parameters, source);
-
-                if (results.Errors.HasErrors)
-                {
-                    foreach (CompilerError error in results.Errors)
+                    foreach (var path in filtered)
                     {
-                        if (!error.IsWarning)
-                        {
-                            int userLine = Math.Max(1, error.Line - WrapperLineOffset);
-                            errors.Add($"Line {userLine}: {error.ErrorText}");
-                        }
+                        writer.Write("/r:\"");
+                        writer.Write(path);
+                        writer.WriteLine("\"");
                     }
-                    return null;
                 }
 
-                return results.CompiledAssembly;
+                using (var provider = new CSharpCodeProvider())
+                {
+                    var parameters = new CompilerParameters
+                    {
+                        GenerateInMemory = true,
+                        GenerateExecutable = false,
+                        TreatWarningsAsErrors = false,
+                        CompilerOptions = "@\"" + responseFilePath + "\"",
+                    };
+
+                    var results = provider.CompileAssemblyFromSource(parameters, source);
+
+                    if (results.Errors.HasErrors)
+                    {
+                        foreach (CompilerError error in results.Errors)
+                        {
+                            if (!error.IsWarning)
+                            {
+                                int userLine = Math.Max(1, error.Line - WrapperLineOffset);
+                                errors.Add($"Line {userLine}: {error.ErrorText}");
+                            }
+                        }
+                        return null;
+                    }
+
+                    return results.CompiledAssembly;
+                }
+            }
+            finally
+            {
+                try { if (File.Exists(responseFilePath)) File.Delete(responseFilePath); }
+                catch { /* best effort */ }
             }
         }
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
@@ -332,6 +332,41 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.IsFalse(result.Value<bool>("success"), result.ToString());
         }
 
+        // ──────────────────── CodeDom backend ────────────────────
+
+        // Regression for CoplayDev/unity-mcp#1144: large projects (~100+ asmdefs) blew past the
+        // Windows 32 KB CreateProcess limit because every reference became an inline /r: flag.
+        // The fix routes references through a @responsefile, so this just verifies that the
+        // codedom path still compiles and runs end-to-end.
+        [Test]
+        public void Execute_CodedomBackend_CompilesAndRuns()
+        {
+            var result = ToJObject(ExecuteCode.HandleCommand(new JObject
+            {
+                ["action"] = "execute",
+                ["code"] = "return 1 + 1;",
+                ["compiler"] = "codedom"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual(2, result["data"]["result"].Value<int>());
+            Assert.AreEqual("codedom", result["data"]["compiler"].Value<string>());
+        }
+
+        [Test]
+        public void Execute_CodedomBackend_ResolvesUnityTypes()
+        {
+            var result = ToJObject(ExecuteCode.HandleCommand(new JObject
+            {
+                ["action"] = "execute",
+                ["code"] = "return UnityEngine.Application.unityVersion;",
+                ["compiler"] = "codedom"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsNotNull(result["data"]["result"]);
+        }
+
         // ──────────────────── Helpers ────────────────────
 
         private static JObject Execute(string code)


### PR DESCRIPTION
## Summary

Fixes #1144 — `execute_code` with `compiler=\"codedom\"` fails on Windows in large projects with:

```
SystemException: Error running …mono.exe: The filename or extension is too long.
  at MCPForUnity.Editor.Tools.ExecuteCode.HandleExecute (ExecuteCode.cs:115)
```

## Root cause

`CodeDomCompile` shoves every entry from `GetAssemblyPaths()` into `CompilerParameters.ReferencedAssemblies`. Mono's `CSharpCodeCompiler.BuildArgs` ([mcs source, lines 388-392](https://github.com/Sectoid/debian-mono/blob/master/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs)) turns each reference into a literal `/r:\"<absolute_path>\"` flag and concatenates them inline on the `mono.exe csc …` command line. Projects with ~100+ asmdefs (very common in large Unity projects) overflow Windows' 32 KB `CreateProcess` argument limit, `Process.Start` raises `ERROR_FILENAME_EXCED_RANGE`, and Mono rethrows it as `SystemException`.

Reporter's repro: Windows 10/11, Unity 2022.3.62f2, MCP for Unity 9.6.9-beta.8, project with 100+ asmdefs.

## Fix

Write all `/r:\"…\"` lines to a GUID-named temp response file under `Path.GetTempPath()`, then pass `@\"<path>\"` via `CompilerParameters.CompilerOptions`. `BuildArgs` (line 396 of the same Mono source) appends `CompilerOptions` verbatim to the csc invocation, so the inline reference flags are replaced by a single short argument regardless of reference count.

Both **legacy mcs** and **Roslyn csc** support `@responsefile` syntax (it's standard C# compiler behavior, [documented here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/miscellaneous#responsefiles)). So the change is:

- ✅ Cross-platform — same path on macOS/Linux/Windows. POSIX doesn't have the 32 KB limit, but the response file works identically.
- ✅ Backwards-compatible — no change to public API or tool surface.
- ✅ Cleanup-safe — temp file removed in `finally` (best-effort; OS reaps `Temp` on its own otherwise).

## Rejected alternatives

| Approach | Why not |
|---|---|
| Shorten paths (drive-relative tricks) | Fragile, doesn't scale, breaks on shared drives. |
| Split compilation into chunks | `CSharpCodeProvider` has no API for it; would require building a chunking layer. |
| Roslyn-only path | Defeats the codedom backend's purpose for users who can't install Microsoft.CodeAnalysis. |

## Tests

Two new EditMode regression tests in `TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs`, scoped to the codedom backend:

- `Execute_CodedomBackend_CompilesAndRuns` — basic compile + execute, asserts result + `compiler == \"codedom\"`.
- `Execute_CodedomBackend_ResolvesUnityTypes` — verifies Unity references resolve through the response file by calling `UnityEngine.Application.unityVersion`.

## What I couldn't verify

- **The exact 32 KB failure on Windows.** I'm on macOS where Mono's POSIX `Process.Start` doesn't hit the limit. The response-file path is mechanically equivalent regardless of reference count, but a Windows + ~100-asmdef smoke test from a reviewer (e.g. the reporter @lgarczyn) would confirm end-to-end.
- **Local matrix compile check.** None of the CI-matrix Unity Hub editors are installed on this machine; `tools/check-unity-versions.sh` reports all 4 as skipped.

## Test plan

- [ ] Recommend labelling **`safe-to-test`** + **`full-matrix`** so the Unity test suite fans out across 2021.3.45f2 + 2022.3.62f1 + 6000.0.75f1 + 6000.4.8f1.
- [ ] If possible, reporter or another Windows user smokes the fix against their large-asmdef project (the repro from the issue) and confirms the SystemException is gone.

## Related

- Fixes #1144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler compatibility when handling projects with many referenced assemblies on Windows systems.

* **Tests**
  * Added regression tests for the codedom compiler backend to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->