### PR TITLE
fix(stdio): restore 2s socket-release wait to prevent Windows port leak (#1173)

### DIFF
--- a/MCPForUnity/Editor/Services/StdioBridgeReloadHandler.cs
+++ b/MCPForUnity/Editor/Services/StdioBridgeReloadHandler.cs
@@ -70,7 +70,9 @@ namespace MCPForUnity.Editor.Services
                     // Stop only stdio before reload. This is centralized here so resume-flag updates
                     // and teardown cannot race each other via separate beforeAssemblyReload handlers.
                     var stopTask = MCPServiceLocator.TransportManager.StopAsync(TransportMode.Stdio);
-                    try { stopTask.Wait(500); } catch { }
+                    // Match StdioBridgeHost.Stop's 2s socket-release wait; 500ms is too short on
+                    // Windows and lets the next reload bind the same port before the OS frees it.
+                    try { stopTask.Wait(2000); } catch { }
 
                     // Legacy safety: stdio may have been started outside TransportManager state.
                     try { StdioBridgeHost.Stop(); } catch { }

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -396,8 +396,10 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
 
             if (toWait != null)
             {
-                // CTS is already cancelled; give the listener task a brief moment to exit.
-                try { toWait.Wait(500); } catch { }
+                // Windows needs the full 2s for the socket to release after Dispose; with 500ms
+                // the next Start() can hit AddressAlreadyInUse and silently fall back to a new
+                // port, orphaning the listener. See #1173 / #688.
+                try { toWait.Wait(2000); } catch { }
             }
 
             // ProcessCommands stays permanently hooked (guarded by _processCommandsHooked)


### PR DESCRIPTION
## Summary
- Restore `toWait.Wait(2000)` in `StdioBridgeHost.Stop()` (was reduced 2000 → 500 in PR #787, regressed since 9.7.1)
- Restore matching `stopTask.Wait(2000)` in `StdioBridgeReloadHandler.OnBeforeAssemblyReload`

## Root cause (from #1173)
PR #688 set the 2000ms wait specifically so the `TcpListener` socket could fully release on Windows before the post-reload `Start()` rebinds. PR #787 later reduced this to 500ms without flagging the Windows dependency.

On Windows, 500ms is too short for the OS to free the socket. After the 2nd play-mode entry within a single Editor session (default Enter Play Mode Options, Reload Domain enabled), the post-reload `Start()` hits `AddressAlreadyInUse`, the catch block silently falls back to a new port via `PortManager.DiscoverNewPort()`, and the Python server keeps talking to the orphan on the original port. Scene-graph tools (`find_gameobjects`, `manage_scene get_hierarchy`, `execute_code`) start returning `busy`/timeout indefinitely because OS round-robin sometimes routes calls to the orphaned listener.

Reporter (#1173) bisected to **Reload Domain** as the variable — `Reload Domain OFF` is clean across 4+ play cycles, consistent with the socket-release race.

Verified via `git log -L` that:
- `StdioBridgeHost.cs:400` `Wait(500)` came from commit `79e6c917` (PR #787) which silently reduced PR #688's `Wait(2000)` 
- `StdioBridgeReloadHandler.cs:73` was `500ms` since the file's initial 17cd543f introduction — never had the Windows-safe ceiling

## Scope
Two-line timeout restore; no behavioural change on macOS/Linux (where socket release is fast). The 1.5s extra wait only runs on `Stop()`, which is rare (domain reload / quit), so editor responsiveness is unaffected.

## Test plan
- [ ] Reproduce per #1173: 2× play-mode cycles with Reload Domain ON on Windows; verify port stays on `6400` (no silent shift to `6402`)
- [ ] Verify `find_gameobjects` / `manage_scene get_hierarchy` keep responding after cycle 2
- [ ] Existing `StdioBridgeReconnectTests` continue to pass
- [ ] No regression on macOS (Stop returns within ms on the fast path)

Closes #1173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended editor shutdown timeout durations to allow proper OS-level socket cleanup, preventing port binding conflicts that could interrupt reload operations on Windows systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoplayDev/unity-mcp/pull/1175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->