### PR TITLE
Fix execute_code failing on the BOM-only CodeDom error

### DIFF
--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -294,32 +294,58 @@ namespace MCPForUnity.Editor.Tools
                     }
                 }
 
+                // Compile to a controlled DLL path instead of in-memory. mcs prints a stray BOM line on
+                // stdout that Mono's CodeDom can't parse, so it fabricates a bogus error (no error number,
+                // text is just the BOM) and refuses to surface the assembly — even though mcs exits 0 and
+                // wrote the DLL. We skip that bogus error and Assembly.Load the produced DLL ourselves.
+                string outputAssemblyPath = Path.Combine(Path.GetTempPath(), $"mcp-codedom-{Guid.NewGuid():N}.dll");
                 using (var provider = new CSharpCodeProvider())
                 {
                     var parameters = new CompilerParameters
                     {
-                        GenerateInMemory = true,
+                        GenerateInMemory = false,
+                        OutputAssembly = outputAssemblyPath,
                         GenerateExecutable = false,
                         TreatWarningsAsErrors = false,
                         CompilerOptions = "@\"" + responseFilePath + "\"",
                     };
 
-                    var results = provider.CompileAssemblyFromSource(parameters, source);
-
-                    if (results.Errors.HasErrors)
+                    try
                     {
+                        var results = provider.CompileAssemblyFromSource(parameters, source);
+
+                        bool hasRealErrors = false;
                         foreach (CompilerError error in results.Errors)
                         {
-                            if (!error.IsWarning)
-                            {
-                                int userLine = Math.Max(1, error.Line - WrapperLineOffset);
-                                errors.Add($"Line {userLine}: {error.ErrorText}");
-                            }
-                        }
-                        return null;
-                    }
+                            if (error.IsWarning)
+                                continue;
 
-                    return results.CompiledAssembly;
+                            // The bogus BOM "error": no error number, text is just the BOM/whitespace.
+                            string text = error.ErrorText?.Trim('﻿', ' ', '\t', '\r', '\n');
+                            if (string.IsNullOrEmpty(error.ErrorNumber) && string.IsNullOrEmpty(text))
+                                continue;
+
+                            hasRealErrors = true;
+                            int userLine = Math.Max(1, error.Line - WrapperLineOffset);
+                            errors.Add($"Line {userLine}: {error.ErrorText}");
+                        }
+
+                        if (hasRealErrors)
+                            return null;
+
+                        if (!File.Exists(outputAssemblyPath))
+                        {
+                            errors.Add("CodeDom reported success but produced no assembly.");
+                            return null;
+                        }
+
+                        return Assembly.Load(File.ReadAllBytes(outputAssemblyPath));
+                    }
+                    finally
+                    {
+                        try { if (File.Exists(outputAssemblyPath)) File.Delete(outputAssemblyPath); }
+                        catch { /* best effort */ }
+                    }
                 }
             }
             finally


### PR DESCRIPTION
## Description
`execute_code` intermittently fails with a spurious `"Line 1: ﻿"` compilation error
even when the submitted code is valid. This fixes that false negative.

On Mono, `mcs` emits a stray UTF-8 BOM line on stdout. CodeDom can't parse it, so it
fabricates an error that has no error number and whose text is just the BOM, then refuses
to return the compiled assembly — even though `mcs` exited 0 and wrote the DLL. Users see
this as a spurious `"Line 1: ﻿"` compilation failure (#1186).

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made
- Compile to a temp DLL on disk (`GenerateInMemory = false` + `OutputAssembly`) instead of in-memory.
- Skip the content-less BOM "error" CodeDom fabricates (no error number, text is just the
  BOM/whitespace) while still surfacing every real compiler error exactly as before.
- `Assembly.Load` the DLL that `mcs` actually produced, and clean the temp file up in a `finally` block.

Stripping the BOM from the *input* (as suggested in #1186) doesn't help, because the BOM comes
from the compiler's own stdout, not the source. Going through a real output assembly lets us tell
"the compiler emitted junk on stdout" apart from "the code didn't compile": if there are no real
errors and a DLL exists on disk, we load it.

## Compatibility / Package Source
- Unity version(s) tested: 2022.3 (Mono backend)
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `file:` (local package)
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): N/A (local `file:` package)

## Testing/Screenshots/Recordings
- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [x] Not applicable (explain why in Additional Notes)

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

## Related Issues
Fixes #1186

## Additional Notes
Single-file change (`MCPForUnity/Editor/Tools/ExecuteCode.cs`), no tool/resource surface changes, so no docs update needed.

Not unit-tested in CI: the failure depends on the host Mono `mcs` emitting a BOM on stdout, which
isn't reproducible from a pure EditMode test. Verified manually — reproduced #1186 (valid snippet
returning `"Line 1: ﻿"`), confirmed it now executes, and confirmed genuinely broken code still
reports the real compiler errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code compilation reliability by filtering spurious compiler errors and verifying build success, resulting in more accurate error reporting and enhanced stability of the code execution system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->