### PR TITLE
fix(stdio): retry same port on bind race instead of silent fallback (#1173)

### DIFF
--- a/MCPForUnity/Editor/Helpers/PortManager.cs
+++ b/MCPForUnity/Editor/Helpers/PortManager.cs
@@ -65,6 +65,25 @@ namespace MCPForUnity.Editor.Helpers
         }
 
         /// <summary>
+        /// How long the configured port may keep returning AddressAlreadyInUse before the
+        /// bridge gives up on it and discovers a new one. The common cause of a transient
+        /// conflict is our own previous listener whose OS socket has not been released yet
+        /// after a domain reload (slower on Windows/macOS); this window covers that race so
+        /// the bridge keeps the configured port instead of stranding the client on the
+        /// orphan (#1173).
+        /// </summary>
+        public const double BusyPortFallbackWindowSeconds = 3.0;
+
+        /// <summary>
+        /// Decide whether a configured port that keeps reporting AddressAlreadyInUse should be
+        /// abandoned for a freshly discovered port. Returns false (keep retrying the same port)
+        /// until it has been continuously busy for <see cref="BusyPortFallbackWindowSeconds"/>,
+        /// which distinguishes a domain-reload socket-release race from a foreign occupant (#1173).
+        /// </summary>
+        public static bool ShouldAbandonBusyPort(double busyForSeconds)
+            => busyForSeconds >= BusyPortFallbackWindowSeconds;
+
+        /// <summary>
         /// Persist a user-selected port and return the value actually stored.
         /// If <paramref name="port"/> is unavailable, the next available port is chosen instead.
         /// </summary>

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -46,6 +46,9 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         private static bool isStarting = false;
         private static double nextStartAt = 0.0f;
         private static double nextHeartbeatAt = 0.0f;
+        // EditorApplication.timeSinceStartup of the first AddressAlreadyInUse on the configured
+        // port; 0 when the port binds cleanly. Drives the same-port retry window (#1173).
+        private static double _portBusySince = 0.0;
         private static int heartbeatSeq = 0;
         private static Dictionary<string, QueuedCommand> commandQueue = new();
         private static int mainThreadId;
@@ -284,10 +287,36 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     }
                     catch (SocketException se) when (se.SocketErrorCode == SocketError.AddressAlreadyInUse)
                     {
-                        // Port is busy. Try switching to a new port once; if that also fails,
-                        // let the reload handler retry with async backoff instead of blocking here.
+                        // The configured port is busy. The usual cause is our own previous listener
+                        // whose OS socket has not been released yet after a domain reload: Stop()/
+                        // Dispose runs on the main thread, but the kernel frees the bound port a few
+                        // hundred ms later (longer on Windows/macOS).
+                        //
+                        // Do NOT silently switch to a new port on the first conflict — the Python
+                        // client stays pinned to the configured port and ends up talking to the
+                        // orphan, returning busy/timeout forever (#1173). Keep the configured port
+                        // and fail this attempt WITHOUT blocking: the reload handler's async resume
+                        // schedule and the editor-idle retry re-invoke Start() on the same port within
+                        // ~1s, by which point the OS has released it. Only after the port stays busy
+                        // past the fallback window do we treat it as a foreign occupant and switch.
+                        double now = EditorApplication.timeSinceStartup;
+                        // Start a fresh window on the first conflict, or if a stale timestamp
+                        // survived a long idle gap (a real reload + retry resolves in seconds).
+                        if (_portBusySince <= 0.0 || (now - _portBusySince) > 60.0) _portBusySince = now;
+
+                        if (!PortManager.ShouldAbandonBusyPort(now - _portBusySince))
+                        {
+                            try { listener?.Server?.Dispose(); } catch { }
+                            listener = null;
+                            McpLog.Warn($"Port {currentUnityPort} not released yet after reload; retrying same port.");
+                            WriteHeartbeat(true, "port_busy");
+                            nextStartAt = now + 0.3; // throttle the editor-idle retry loop
+                            return;
+                        }
+
                         int oldPort = currentUnityPort;
                         currentUnityPort = PortManager.DiscoverNewPort();
+                        _portBusySince = 0.0;
 
                         try
                         {
@@ -295,15 +324,13 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                         }
                         catch { }
 
-                        if (IsDebugEnabled())
-                        {
-                            McpLog.Info($"Port {oldPort} occupied, switching to port {currentUnityPort}");
-                        }
+                        McpLog.Warn($"Port {oldPort} still occupied after {PortManager.BusyPortFallbackWindowSeconds:0.#}s; falling back to port {currentUnityPort} (clients follow via the status file).");
 
                         listener = CreateConfiguredListener(currentUnityPort);
                         listener.Start();
                     }
 
+                    _portBusySince = 0.0;
                     isRunning = true;
                     isAutoConnectMode = false;
                     string platform = Application.platform.ToString();
@@ -631,7 +658,8 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                             bool isBenign =
                                 msg.IndexOf("Connection closed before reading expected bytes", StringComparison.OrdinalIgnoreCase) >= 0
                                 || msg.IndexOf("Read timed out", StringComparison.OrdinalIgnoreCase) >= 0
-                                || ex is IOException;
+                                || ex is IOException
+                                || ex is ObjectDisposedException;
                             if (isBenign)
                             {
                                 if (IsDebugEnabled()) McpLog.Info($"Client handler: {msg}", always: false);

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -49,6 +49,9 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         // EditorApplication.timeSinceStartup of the first AddressAlreadyInUse on the configured
         // port; 0 when the port binds cleanly. Drives the same-port retry window (#1173).
         private static double _portBusySince = 0.0;
+        // If the port has been continuously busy longer than this, _portBusySince is treated as a
+        // stale leftover from an abandoned retry and a fresh window is started (#1173).
+        private const double PortBusyStaleResetSeconds = 60.0;
         private static int heartbeatSeq = 0;
         private static Dictionary<string, QueuedCommand> commandQueue = new();
         private static int mainThreadId;
@@ -302,15 +305,24 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                         double now = EditorApplication.timeSinceStartup;
                         // Start a fresh window on the first conflict, or if a stale timestamp
                         // survived a long idle gap (a real reload + retry resolves in seconds).
-                        if (_portBusySince <= 0.0 || (now - _portBusySince) > 60.0) _portBusySince = now;
+                        if (_portBusySince <= 0.0 || (now - _portBusySince) > PortBusyStaleResetSeconds) _portBusySince = now;
 
                         if (!PortManager.ShouldAbandonBusyPort(now - _portBusySince))
                         {
+                            try { listener?.Stop(); } catch { }
                             try { listener?.Server?.Dispose(); } catch { }
                             listener = null;
                             McpLog.Warn($"Port {currentUnityPort} not released yet after reload; retrying same port.");
                             WriteHeartbeat(true, "port_busy");
                             nextStartAt = now + 0.3; // throttle the editor-idle retry loop
+                            // Arm the editor-idle retry even when Start() was called directly
+                            // (e.g. StartAutoConnect), not only during reload resume — so a transient
+                            // AddressAlreadyInUse can never leave the bridge permanently stopped.
+                            if (!ensureUpdateHooked)
+                            {
+                                ensureUpdateHooked = true;
+                                EditorApplication.update += EnsureStartedOnEditorIdle;
+                            }
                             return;
                         }
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/PortManagerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/PortManagerTests.cs
@@ -110,6 +110,28 @@ namespace MCPForUnityTests.Editor.Services
 #endif
 
         [Test]
+        public void ShouldAbandonBusyPort_KeepsSamePort_WithinReleaseWindow()
+        {
+            // A port busy for less than the fallback window is treated as our own
+            // not-yet-released listener after a domain reload — keep retrying the same
+            // port instead of silently switching and stranding the client (#1173).
+            Assert.IsFalse(PortManager.ShouldAbandonBusyPort(0.0));
+            Assert.IsFalse(PortManager.ShouldAbandonBusyPort(
+                PortManager.BusyPortFallbackWindowSeconds - 0.5));
+        }
+
+        [Test]
+        public void ShouldAbandonBusyPort_FallsBack_AfterReleaseWindow()
+        {
+            // A port that stays busy past the window is a foreign occupant — only then
+            // does the bridge discover and switch to a new port.
+            Assert.IsTrue(PortManager.ShouldAbandonBusyPort(
+                PortManager.BusyPortFallbackWindowSeconds));
+            Assert.IsTrue(PortManager.ShouldAbandonBusyPort(
+                PortManager.BusyPortFallbackWindowSeconds + 5.0));
+        }
+
+        [Test]
         public void DiscoverNewPort_ReturnsAvailablePort()
         {
             int port = PortManager.DiscoverNewPort();


### PR DESCRIPTION
## Summary
After a domain reload, a transient `AddressAlreadyInUse` on the configured stdio port no longer triggers a silent permanent port switch that strands the Python client on the orphan listener (the #1173 failure). The bridge now retries the **same** port and only falls back to a new port — loudly — when the port stays busy past a short window.

## Root cause (#1173)
`Stop()`/`Dispose()` run on the main thread during `beforeAssemblyReload`, but the OS frees the bound port a few hundred ms later (slower on Windows/macOS). When the post-reload `Start()` rebinds too soon, `listener.Start()` throws `AddressAlreadyInUse`. The previous `catch` silently switched to a new port via `DiscoverNewPort()`, but the Python client stays pinned to the configured port → it talks to the orphan and returns `busy`/timeout indefinitely.

## What changed
- **`StdioBridgeHost.Start()`** — on `AddressAlreadyInUse`, keep the configured port and fail the attempt **without blocking**. The reload handler's async resume schedule (0/1/3/5/10/30s) and the editor-idle retry re-invoke `Start()` on the same port within ~1s, by which point the OS has released it. Only after the port stays busy past `PortManager.BusyPortFallbackWindowSeconds` (3s) does it fall back to a new port — via `McpLog.Warn` instead of the previous debug-only switch. The retry path also re-arms the editor-idle loop so a direct `Start()` caller (e.g. `StartAutoConnect`) can't be left permanently stopped.
- **`PortManager`** — `ShouldAbandonBusyPort(busyForSeconds)` policy + `BusyPortFallbackWindowSeconds` constant.
- **`HandleClientAsync`** — classify `ObjectDisposedException` from a torn-down `NetworkStream` as a benign disconnect (fixes the red Console spam in #1187).
- **`PortManagerTests`** — cover the retry-vs-fallback policy threshold.

## Why not just restore the 2000ms wait (the closed #1175 approach)
Bumping `Stop()`'s wait back to 2000ms re-introduces the backgrounded-Unity stall that #787 deliberately fixed by reducing it to 500ms, and it doesn't address the silent port fallback that is the actual masking layer. This PR keeps the 500ms wait untouched, adds **zero** new main-thread blocking, and is platform-agnostic (the race also reproduces on macOS, per the #1173 thread).

## Test results

**CI — full matrix green** (`safe-to-test` + `full-matrix`):

| Unity | EditMode |
|---|---|
| 2021.3.45f2 | :white_check_mark: pass |
| 2022.3.62f1 | :white_check_mark: pass |
| 6000.0.75f1 | :white_check_mark: pass |
| 6000.4.8f1 | :white_check_mark: pass |

UnityMCPTests EditMode on 2021.3.45f2: **886 passed, 0 failed, 46 skipped** (all `Explicit` side-effect / URP-gated `Inconclusive`).

**Live validation** — the fix loaded into a running Unity **2021.3.45f2** editor:
- Fix code loads + policy correct in the real runtime: `BusyPortFallbackWindowSeconds = 3s`; `ShouldAbandonBusyPort(1.0s) = false` (keep port), `ShouldAbandonBusyPort(3.5s) = true` (fall back).
- End-to-end retry (real `TcpListener` + real `PortManager`): an orphan holding a port triggers `AddressAlreadyInUse`; within the 3s window the port is kept; after the orphan releases, the **same** port rebinds — no silent switch.
- A real domain reload tore down and rebound the bridge — it **recovered** and stayed on the configured port `6400` (no silent shift).
- **#1187:** after reload churn, **0** red `Cannot access a disposed object` errors.

**A/B — same runtime, same orphan-on-`6543` scenario, before vs after the change:**

| port 6543 held → `AddressAlreadyInUse` | Before (no fix) | After (fix) |
|---|---|---|
| same-port retry policy | absent | present (3s window) |
| on conflict | **switches away to 6544** (silent — the #1173 bug) | **keeps 6543**, retries; rebinds same port on release |

## Related issues & regression sweep
- **Closes #1173** — validated above (Before switches the port away; After keeps it).
- **#1187** (disposed `NetworkStream` red errors) — primary symptom fixed by the benign `ObjectDisposedException` reclassification (0 red errors observed under reload churn). The secondary "clean up stale stdio processes" ask is largely client-side and out of scope here.
- **#1164** (HTTP transport: orphaned python server / port collision on resume) — *similar surface, different root cause*: the HTTP path has a Python-server respawn-vs-reattach problem in `HttpBridgeReloadHandler` (`ForceStop` may not kill the process, then `ResumeHttpWithRetriesAsync` spawns a fresh one that collides), not stdio's socket-release timing. **This PR does not address it** (stdio-only) and the same-port-retry approach wouldn't fix it — tracked separately.
- Diff is **stdio-only** (3 files). It does not touch the HTTP transport (#1164), the command broker / `ExecuteMenuItem` retry path (#1130), stale-worker handling (#1090), or multi-instance routing (#1023) — **no regressions introduced** in those areas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP port fallback handling by retrying the configured port for up to **3 seconds** when it’s temporarily busy, only switching to a newly discovered port after the window elapses.
  * Added clearer “port busy” signaling during reload-related race conditions and reduced log noise by treating expected disposal events as benign.
* **Tests**
  * Added unit tests covering the abandon-vs-keep retry behavior within and beyond the 3-second window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
