### PR TITLE
Add screenshot coordinate GameObject picker

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -796,6 +796,7 @@ namespace MCPForUnity.Editor.Tools
                 { "orthographicSize", camera.orthographicSize },
                 { "nearClipPlane", camera.nearClipPlane },
                 { "farClipPlane", camera.farClipPlane },
+                { "cullingMask", camera.cullingMask },
                 { "aspect", camera.aspect },
                 { "viewportWidth", viewportWidth },
                 { "viewportHeight", viewportHeight },

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -607,7 +607,14 @@ namespace MCPForUnity.Editor.Tools
                     if (ScreenshotUtility.IsUnderAssets(result.ProjectRelativePath))
                         AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
                     string message = $"Screenshot captured to '{result.ProjectRelativePath}' (camera: {targetCamera.name}).";
-                    return new SuccessResponse(message, BuildScreenshotResponseData(result, targetCamera.name, includeImage));
+                    return new SuccessResponse(
+                        message,
+                        BuildScreenshotResponseData(
+                            result,
+                            targetCamera.name,
+                            includeImage,
+                            targetCamera,
+                            includePickView: true));
                 }
 
                 if (includeImage && Application.isPlaying)
@@ -734,7 +741,9 @@ namespace MCPForUnity.Editor.Tools
         private static Dictionary<string, object> BuildScreenshotResponseData(
             ScreenshotCaptureResult result,
             string cameraName,
-            bool includeImage)
+            bool includeImage,
+            Camera cameraForPickView = null,
+            bool includePickView = false)
         {
             var data = new Dictionary<string, object>
             {
@@ -753,7 +762,56 @@ namespace MCPForUnity.Editor.Tools
                 data["imageHeight"] = result.ImageHeight;
             }
 
+            if (includePickView && cameraForPickView != null)
+            {
+                data["pickView"] = BuildPickView(
+                    cameraForPickView,
+                    "game_view",
+                    GetCameraCaptureWidth(cameraForPickView, result.SuperSize),
+                    GetCameraCaptureHeight(cameraForPickView, result.SuperSize));
+            }
+
             return data;
+        }
+
+        private static Dictionary<string, object> BuildPickView(
+            Camera camera,
+            string captureSource,
+            int viewportWidth,
+            int viewportHeight)
+        {
+            if (camera == null)
+                return null;
+
+            var euler = camera.transform.eulerAngles;
+            var position = camera.transform.position;
+            return new Dictionary<string, object>
+            {
+                { "captureSource", captureSource },
+                { "position", new[] { position.x, position.y, position.z } },
+                { "rotation", new[] { euler.x, euler.y, euler.z } },
+                { "projection", camera.orthographic ? "orthographic" : "perspective" },
+                { "orthographic", camera.orthographic },
+                { "fieldOfView", camera.fieldOfView },
+                { "orthographicSize", camera.orthographicSize },
+                { "nearClipPlane", camera.nearClipPlane },
+                { "farClipPlane", camera.farClipPlane },
+                { "aspect", camera.aspect },
+                { "viewportWidth", viewportWidth },
+                { "viewportHeight", viewportHeight },
+            };
+        }
+
+        private static int GetCameraCaptureWidth(Camera camera, int superSize)
+        {
+            int width = Mathf.Max(1, camera.pixelWidth > 0 ? camera.pixelWidth : Screen.width);
+            return width * Mathf.Max(1, superSize);
+        }
+
+        private static int GetCameraCaptureHeight(Camera camera, int superSize)
+        {
+            int height = Mathf.Max(1, camera.pixelHeight > 0 ? camera.pixelHeight : Screen.height);
+            return height * Mathf.Max(1, superSize);
         }
 
         private static object CaptureSceneViewScreenshot(
@@ -825,6 +883,15 @@ namespace MCPForUnity.Editor.Tools
                     { "viewportWidth", viewportWidth },
                     { "viewportHeight", viewportHeight },
                 };
+
+                if (sceneView.camera != null)
+                {
+                    data["pickView"] = BuildPickView(
+                        sceneView.camera,
+                        "scene_view",
+                        viewportWidth,
+                        viewportHeight);
+                }
 
                 if (cmd.viewTarget != null && cmd.viewTarget.Type != JTokenType.Null)
                 {
@@ -1199,6 +1266,7 @@ namespace MCPForUnity.Editor.Tools
                         tempCam.transform.LookAt(targetPos.Value);
 
                     var (b64, w, h) = ScreenshotUtility.RenderCameraToBase64(tempCam, maxRes);
+                    tempCam.aspect = w > 0 && h > 0 ? (float)w / h : tempCam.aspect;
 
                     // Resolve output folder (per-call override → user pref → built-in default).
                     string resolvedFolderSpec = ScreenshotPreferences.Resolve(cmd.outputFolder);
@@ -1251,6 +1319,8 @@ namespace MCPForUnity.Editor.Tools
                         { "outputFolder", folderAbsolute.Replace('\\', '/') },
                         { "path", projectRelativePath },
                         { "fullPath", normalizedFull },
+                        { "captureSource", "game_view" },
+                        { "pickView", BuildPickView(tempCam, "game_view", w, h) },
                     };
                     if (targetPos.HasValue)
                         data["viewTarget"] = new[] { targetPos.Value.x, targetPos.Value.y, targetPos.Value.z };

--- a/MCPForUnity/Editor/Tools/PickGameObjectFromImage.cs
+++ b/MCPForUnity/Editor/Tools/PickGameObjectFromImage.cs
@@ -57,6 +57,10 @@ namespace MCPForUnity.Editor.Tools
         }
 
         internal static Func<Vector2, SceneViewPickResult> SceneViewPickOverrideForTests { get; set; }
+        private const float SceneViewPositionTolerance = 0.01f;
+        private const float SceneViewRotationTolerance = 0.1f;
+        private const float SceneViewScalarTolerance = 0.01f;
+        private const float SceneViewViewportTolerancePixels = 1f;
         private static MethodInfo _intersectRayMeshMethod;
         private static bool _intersectRayMeshMethodProbed;
 
@@ -125,7 +129,7 @@ namespace MCPForUnity.Editor.Tools
                 if (!IsFinite(viewportU) || !IsFinite(viewportV) || viewportU < 0f || viewportU > 1f || viewportV < 0f || viewportV > 1f)
                     return new ErrorResponse("Computed viewport coordinate is outside [0, 1]. Check image dimensions, scale, and viewport dimensions.");
 
-                int layerMask = ResolveLayerMask(p.GetRaw("layerMask"));
+                JToken layerMaskToken = p.GetRaw("layerMask");
                 float maxDistance = ParamCoercion.CoerceFloatNullable(p.GetRaw("maxDistance")) ?? Mathf.Infinity;
                 if (!IsFinite(maxDistance) && !float.IsPositiveInfinity(maxDistance))
                     return new ErrorResponse("'max_distance' must be a positive finite number or omitted.");
@@ -150,11 +154,12 @@ namespace MCPForUnity.Editor.Tools
                     if (camera == null)
                         return new ErrorResponse($"Camera '{cameraRef}' not found. Provide a Camera GameObject name, path, or instance ID.");
 
+                    int layerMask = ResolveLayerMask(layerMaskToken, ResolveDefaultLayerMask(pickView, camera));
                     var ray = camera.ViewportPointToRay(new Vector3(viewportU, viewportV, 0f));
                     string viewSource = pickView != null ? "pick_view" : "camera";
 
                     if (IsSceneViewPickView(pickView) &&
-                        TryPickSceneViewObject(ray, viewportU, 1f - viewportV, layerMask, maxDistance, out var sceneViewPick, out var sceneViewPickMessage))
+                        TryPickSceneViewObject(pickView, ray, viewportU, 1f - viewportV, viewportWidth, viewportHeight, layerMask, maxDistance, out var sceneViewPick, out var sceneViewPickMessage))
                     {
                         if (sceneViewPick.GameObject != null)
                         {
@@ -251,9 +256,12 @@ namespace MCPForUnity.Editor.Tools
         }
 
         private static bool TryPickSceneViewObject(
+            JObject pickView,
             Ray ray,
             float viewportU,
             float viewportTopFraction,
+            float viewportWidth,
+            float viewportHeight,
             int layerMask,
             float maxDistance,
             out SceneViewPickResult result,
@@ -275,36 +283,24 @@ namespace MCPForUnity.Editor.Tools
             if (!Application.isBatchMode)
             {
                 var sceneView = SceneView.lastActiveSceneView;
-                if (sceneView == null)
+                if (LiveSceneViewMatchesPickView(sceneView, pickView, viewportWidth, viewportHeight, out Rect viewportRect, out handleUtilityMessage))
                 {
-                    handleUtilityMessage = "No active Scene View is available.";
-                }
-                else
-                {
-                    Rect viewportRect = GetSceneViewViewportRectPoints(sceneView);
-                    if (viewportRect.width <= 0f || viewportRect.height <= 0f)
-                    {
-                        handleUtilityMessage = "Active Scene View viewport is empty.";
-                    }
-                    else
-                    {
-                        guiPoint = new Vector2(
-                            viewportRect.x + viewportU * viewportRect.width,
-                            viewportRect.y + viewportTopFraction * viewportRect.height);
+                    guiPoint = new Vector2(
+                        viewportRect.x + viewportU * viewportRect.width,
+                        viewportRect.y + viewportTopFraction * viewportRect.height);
 
-                        try
-                        {
-                            int materialIndex;
-                            GameObject picked = HandleUtility.PickGameObject(guiPoint, out materialIndex);
-                            var handleUtilityResult = new SceneViewPickResult(picked, materialIndex, "handle_utility");
-                            if (picked != null)
-                                return FilterSceneViewPickByLayerMask(handleUtilityResult, layerMask, out result, out message);
-                            handleUtilityMessage = "HandleUtility.PickGameObject did not hit a selectable object.";
-                        }
-                        catch (Exception ex)
-                        {
-                            handleUtilityMessage = $"HandleUtility.PickGameObject was unavailable: {ex.Message}";
-                        }
+                    try
+                    {
+                        int materialIndex;
+                        GameObject picked = HandleUtility.PickGameObject(guiPoint, out materialIndex);
+                        var handleUtilityResult = new SceneViewPickResult(picked, materialIndex, "handle_utility");
+                        if (picked != null)
+                            return FilterSceneViewPickByLayerMask(handleUtilityResult, layerMask, out result, out message);
+                        handleUtilityMessage = "HandleUtility.PickGameObject did not hit a selectable object.";
+                    }
+                    catch (Exception ex)
+                    {
+                        handleUtilityMessage = $"HandleUtility.PickGameObject was unavailable: {ex.Message}";
                     }
                 }
             }
@@ -356,38 +352,51 @@ namespace MCPForUnity.Editor.Tools
                     boundsDistance > maxDistance)
                     continue;
 
-                Mesh mesh = null;
-                Matrix4x4 matrix = renderer.transform.localToWorldMatrix;
-
-                if (renderer is SkinnedMeshRenderer skinnedRenderer)
+                Mesh bakedMesh = null;
+                try
                 {
-                    mesh = skinnedRenderer.sharedMesh;
+                    Mesh mesh = null;
+                    Matrix4x4 matrix = renderer.transform.localToWorldMatrix;
+
+                    if (renderer is SkinnedMeshRenderer skinnedRenderer)
+                    {
+                        if (skinnedRenderer.sharedMesh == null)
+                            continue;
+                        bakedMesh = new Mesh { hideFlags = HideFlags.HideAndDontSave };
+                        skinnedRenderer.BakeMesh(bakedMesh);
+                        mesh = bakedMesh;
+                    }
+                    else
+                    {
+                        var meshFilter = renderer.GetComponent<MeshFilter>();
+                        if (meshFilter != null)
+                            mesh = meshFilter.sharedMesh;
+                    }
+
+                    if (mesh == null)
+                        continue;
+
+                    if (TryIntersectRayMesh(ray, mesh, matrix, out RaycastHit hit) &&
+                        hit.distance >= 0f &&
+                        hit.distance <= maxDistance &&
+                        hit.distance < nearestDistance)
+                    {
+                        nearestDistance = hit.distance;
+                        result = new SceneViewPickResult(
+                            go,
+                            -1,
+                            "mesh_intersection",
+                            true,
+                            hit.point,
+                            hit.normal,
+                            hit.distance);
+                        nearestObject = go;
+                    }
                 }
-                else
+                finally
                 {
-                    var meshFilter = renderer.GetComponent<MeshFilter>();
-                    if (meshFilter != null)
-                        mesh = meshFilter.sharedMesh;
-                }
-
-                if (mesh == null)
-                    continue;
-
-                if (TryIntersectRayMesh(ray, mesh, matrix, out RaycastHit hit) &&
-                    hit.distance >= 0f &&
-                    hit.distance <= maxDistance &&
-                    hit.distance < nearestDistance)
-                {
-                    nearestDistance = hit.distance;
-                    result = new SceneViewPickResult(
-                        go,
-                        -1,
-                        "mesh_intersection",
-                        true,
-                        hit.point,
-                        hit.normal,
-                        hit.distance);
-                    nearestObject = go;
+                    if (bakedMesh != null)
+                        UnityEngine.Object.DestroyImmediate(bakedMesh);
                 }
             }
 
@@ -697,6 +706,113 @@ namespace MCPForUnity.Editor.Tools
             }
         }
 
+        internal static bool LiveSceneViewMatchesPickView(
+            SceneView sceneView,
+            JObject pickView,
+            float fallbackViewportWidth,
+            float fallbackViewportHeight,
+            out Rect viewportRect,
+            out string message)
+        {
+            viewportRect = Rect.zero;
+            message = null;
+
+            if (sceneView == null)
+            {
+                message = "No active Scene View is available.";
+                return false;
+            }
+
+            Camera camera = sceneView.camera;
+            if (camera == null)
+            {
+                message = "Active Scene View has no camera.";
+                return false;
+            }
+
+            if (pickView == null)
+            {
+                message = "Scene View pickView metadata is missing.";
+                return false;
+            }
+
+            Vector3? expectedPosition = ReadVector3(pickView["position"]);
+            Vector3? expectedRotation = ReadVector3(pickView["rotation"] ?? pickView["eulerAngles"] ?? pickView["euler_angles"]);
+            if (!expectedPosition.HasValue || !expectedRotation.HasValue)
+            {
+                message = "Scene View pickView is missing camera position or rotation.";
+                return false;
+            }
+
+            if ((camera.transform.position - expectedPosition.Value).sqrMagnitude >
+                SceneViewPositionTolerance * SceneViewPositionTolerance)
+            {
+                message = "Active Scene View camera position no longer matches the screenshot pickView.";
+                return false;
+            }
+
+            if (Quaternion.Angle(camera.transform.rotation, Quaternion.Euler(expectedRotation.Value)) >
+                SceneViewRotationTolerance)
+            {
+                message = "Active Scene View camera rotation no longer matches the screenshot pickView.";
+                return false;
+            }
+
+            string projection = ParamCoercion.CoerceString(pickView["projection"], null)?.ToLowerInvariant();
+            bool expectedOrthographic = ParamCoercion.CoerceBool(pickView["orthographic"], projection == "orthographic");
+            if (camera.orthographic != expectedOrthographic)
+            {
+                message = "Active Scene View projection no longer matches the screenshot pickView.";
+                return false;
+            }
+
+            float? expectedScalar = expectedOrthographic
+                ? ParamCoercion.CoerceFloatNullable(pickView["orthographicSize"] ?? pickView["orthographic_size"])
+                : ParamCoercion.CoerceFloatNullable(pickView["fieldOfView"] ?? pickView["field_of_view"]);
+            float liveScalar = expectedOrthographic ? camera.orthographicSize : camera.fieldOfView;
+            if (IsFinite(expectedScalar) && Mathf.Abs(liveScalar - expectedScalar.Value) > SceneViewScalarTolerance)
+            {
+                message = "Active Scene View projection settings no longer match the screenshot pickView.";
+                return false;
+            }
+
+            float? expectedNear = ParamCoercion.CoerceFloatNullable(pickView["nearClipPlane"] ?? pickView["near_clip_plane"]);
+            if (IsFinite(expectedNear) && Mathf.Abs(camera.nearClipPlane - expectedNear.Value) > SceneViewScalarTolerance)
+            {
+                message = "Active Scene View near clip plane no longer matches the screenshot pickView.";
+                return false;
+            }
+
+            float? expectedFar = ParamCoercion.CoerceFloatNullable(pickView["farClipPlane"] ?? pickView["far_clip_plane"]);
+            if (IsFinite(expectedFar) && Mathf.Abs(camera.farClipPlane - expectedFar.Value) > SceneViewScalarTolerance)
+            {
+                message = "Active Scene View far clip plane no longer matches the screenshot pickView.";
+                return false;
+            }
+
+            viewportRect = GetSceneViewViewportRectPoints(sceneView);
+            if (viewportRect.width <= 0f || viewportRect.height <= 0f)
+            {
+                message = "Active Scene View viewport is empty.";
+                return false;
+            }
+
+            float pixelsPerPoint = Mathf.Max(0.0001f, EditorGUIUtility.pixelsPerPoint);
+            float liveViewportWidth = Mathf.Round(viewportRect.width * pixelsPerPoint);
+            float liveViewportHeight = Mathf.Round(viewportRect.height * pixelsPerPoint);
+            float expectedViewportWidth = ParamCoercion.CoerceFloatNullable(pickView["viewportWidth"] ?? pickView["viewport_width"]) ?? fallbackViewportWidth;
+            float expectedViewportHeight = ParamCoercion.CoerceFloatNullable(pickView["viewportHeight"] ?? pickView["viewport_height"]) ?? fallbackViewportHeight;
+
+            if (Mathf.Abs(liveViewportWidth - expectedViewportWidth) > SceneViewViewportTolerancePixels ||
+                Mathf.Abs(liveViewportHeight - expectedViewportHeight) > SceneViewViewportTolerancePixels)
+            {
+                message = "Active Scene View viewport size no longer matches the screenshot pickView.";
+                return false;
+            }
+
+            return true;
+        }
+
         private static JObject NormalizePickView(JToken token)
         {
             if (token == null || token.Type == JTokenType.Null)
@@ -750,6 +866,9 @@ namespace MCPForUnity.Editor.Tools
 
             camera.nearClipPlane = ParamCoercion.CoerceFloatNullable(view["nearClipPlane"] ?? view["near_clip_plane"]) ?? 0.3f;
             camera.farClipPlane = ParamCoercion.CoerceFloatNullable(view["farClipPlane"] ?? view["far_clip_plane"]) ?? 1000f;
+            int? cullingMask = ParamCoercion.CoerceIntNullable(view["cullingMask"] ?? view["culling_mask"]);
+            if (cullingMask.HasValue)
+                camera.cullingMask = cullingMask.Value;
             float aspect = ParamCoercion.CoerceFloatNullable(view["aspect"]) ?? (viewportWidth / viewportHeight);
             if (!IsFinite(aspect) || aspect <= 0f)
                 aspect = viewportWidth / viewportHeight;
@@ -817,14 +936,14 @@ namespace MCPForUnity.Editor.Tools
             return null;
         }
 
-        private static int ResolveLayerMask(JToken token)
+        private static int ResolveLayerMask(JToken token, int defaultMask)
         {
             if (token == null || token.Type == JTokenType.Null)
-                return ~0;
+                return defaultMask;
 
             string layerMaskStr = token.ToString();
             if (string.IsNullOrWhiteSpace(layerMaskStr))
-                return ~0;
+                return defaultMask;
 
             if (int.TryParse(layerMaskStr, out int mask))
                 return mask;
@@ -842,7 +961,19 @@ namespace MCPForUnity.Editor.Tools
                 resolved |= 1 << layer;
             }
 
-            return resolved == 0 ? ~0 : resolved;
+            return resolved == 0 ? defaultMask : resolved;
+        }
+
+        private static int ResolveDefaultLayerMask(JObject pickView, Camera camera)
+        {
+            int? pickViewMask = ParamCoercion.CoerceIntNullable(pickView?["cullingMask"] ?? pickView?["culling_mask"]);
+            if (pickViewMask.HasValue)
+                return pickViewMask.Value;
+
+            if (camera != null)
+                return camera.cullingMask;
+
+            return ~0;
         }
 
         private static bool IsFinite(float? value)

--- a/MCPForUnity/Editor/Tools/PickGameObjectFromImage.cs
+++ b/MCPForUnity/Editor/Tools/PickGameObjectFromImage.cs
@@ -1,0 +1,858 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Resources.Scene;
+using MCPForUnity.Runtime.Helpers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace MCPForUnity.Editor.Tools
+{
+    /// <summary>
+    /// Read-only screenshot coordinate picker for Unity camera and Scene View captures.
+    /// </summary>
+    [McpForUnityTool("pick_gameobject_from_image", AutoRegister = false, Group = "core")]
+    public static class PickGameObjectFromImage
+    {
+        internal struct SceneViewPickResult
+        {
+            public readonly GameObject GameObject;
+            public readonly int MaterialIndex;
+            public readonly string Backend;
+            public readonly bool HasHitDetails;
+            public readonly Vector3 Point;
+            public readonly Vector3 Normal;
+            public readonly float Distance;
+
+            public SceneViewPickResult(GameObject gameObject, int materialIndex)
+                : this(gameObject, materialIndex, "handle_utility")
+            {
+            }
+
+            public SceneViewPickResult(GameObject gameObject, int materialIndex, string backend)
+                : this(gameObject, materialIndex, backend, false, default, default, 0f)
+            {
+            }
+
+            public SceneViewPickResult(
+                GameObject gameObject,
+                int materialIndex,
+                string backend,
+                bool hasHitDetails,
+                Vector3 point,
+                Vector3 normal,
+                float distance)
+            {
+                GameObject = gameObject;
+                MaterialIndex = materialIndex;
+                Backend = backend;
+                HasHitDetails = hasHitDetails;
+                Point = point;
+                Normal = normal;
+                Distance = distance;
+            }
+        }
+
+        internal static Func<Vector2, SceneViewPickResult> SceneViewPickOverrideForTests { get; set; }
+        private static MethodInfo _intersectRayMeshMethod;
+        private static bool _intersectRayMeshMethodProbed;
+
+        public static object HandleCommand(JObject @params)
+        {
+            if (@params == null)
+                return new ErrorResponse("Parameters cannot be null.");
+
+            try
+            {
+                var p = new ToolParams(@params);
+
+                float? imageX = ParamCoercion.CoerceFloatNullable(p.GetRaw("imageX"));
+                float? imageY = ParamCoercion.CoerceFloatNullable(p.GetRaw("imageY"));
+                int? imageWidth = ParamCoercion.CoerceIntNullable(p.GetRaw("imageWidth"));
+                int? imageHeight = ParamCoercion.CoerceIntNullable(p.GetRaw("imageHeight"));
+
+                if (!IsFinite(imageX))
+                    return new ErrorResponse("'image_x' parameter is required and must be a finite number.");
+                if (!IsFinite(imageY))
+                    return new ErrorResponse("'image_y' parameter is required and must be a finite number.");
+                if (!imageWidth.HasValue || imageWidth.Value <= 0)
+                    return new ErrorResponse("'image_width' parameter is required and must be a positive integer.");
+                if (!imageHeight.HasValue || imageHeight.Value <= 0)
+                    return new ErrorResponse("'image_height' parameter is required and must be a positive integer.");
+                if (imageX.Value < 0 || imageX.Value >= imageWidth.Value)
+                    return new ErrorResponse("'image_x' must be within [0, image_width).");
+                if (imageY.Value < 0 || imageY.Value >= imageHeight.Value)
+                    return new ErrorResponse("'image_y' must be within [0, image_height).");
+
+                float scaleX = ParamCoercion.CoerceFloatNullable(p.GetRaw("scaleX")) ?? 1f;
+                float scaleY = ParamCoercion.CoerceFloatNullable(p.GetRaw("scaleY")) ?? scaleX;
+                if (!IsFinite(scaleX) || scaleX <= 0f)
+                    return new ErrorResponse("'scale_x' must be a positive finite number.");
+                if (!IsFinite(scaleY) || scaleY <= 0f)
+                    return new ErrorResponse("'scale_y' must be a positive finite number.");
+
+                string dimension = (p.Get("dimension") ?? "3d").ToLowerInvariant();
+                if (dimension != "3d" && dimension != "2d")
+                    return new ErrorResponse($"Invalid dimension: '{dimension}'. Use '3d' or '2d'.");
+
+                JObject pickView = NormalizePickView(p.GetRaw("pickView"));
+                string cameraRef = p.Get("camera");
+                if (pickView == null && string.IsNullOrWhiteSpace(cameraRef))
+                {
+                    return new ErrorResponse(
+                        "Provide either 'pick_view' from a supported screenshot response or a still-unchanged 'camera' reference.");
+                }
+
+                float viewportWidth = ParamCoercion.CoerceFloatNullable(p.GetRaw("viewportWidth"))
+                    ?? ParamCoercion.CoerceFloatNullable(pickView?["viewportWidth"] ?? pickView?["viewport_width"])
+                    ?? imageWidth.Value * scaleX;
+                float viewportHeight = ParamCoercion.CoerceFloatNullable(p.GetRaw("viewportHeight"))
+                    ?? ParamCoercion.CoerceFloatNullable(pickView?["viewportHeight"] ?? pickView?["viewport_height"])
+                    ?? imageHeight.Value * scaleY;
+
+                if (!IsFinite(viewportWidth) || viewportWidth <= 0f)
+                    return new ErrorResponse("'viewport_width' must be a positive finite number.");
+                if (!IsFinite(viewportHeight) || viewportHeight <= 0f)
+                    return new ErrorResponse("'viewport_height' must be a positive finite number.");
+
+                float viewportX = imageX.Value * scaleX;
+                float viewportYFromTop = imageY.Value * scaleY;
+                float viewportU = viewportX / viewportWidth;
+                float viewportV = 1f - (viewportYFromTop / viewportHeight);
+                if (!IsFinite(viewportU) || !IsFinite(viewportV) || viewportU < 0f || viewportU > 1f || viewportV < 0f || viewportV > 1f)
+                    return new ErrorResponse("Computed viewport coordinate is outside [0, 1]. Check image dimensions, scale, and viewport dimensions.");
+
+                int layerMask = ResolveLayerMask(p.GetRaw("layerMask"));
+                float maxDistance = ParamCoercion.CoerceFloatNullable(p.GetRaw("maxDistance")) ?? Mathf.Infinity;
+                if (!IsFinite(maxDistance) && !float.IsPositiveInfinity(maxDistance))
+                    return new ErrorResponse("'max_distance' must be a positive finite number or omitted.");
+                if (maxDistance <= 0f)
+                    return new ErrorResponse("'max_distance' must be greater than zero.");
+
+                QueryTriggerInteraction triggerInteraction = QueryTriggerInteraction.UseGlobal;
+                string qti = p.Get("queryTriggerInteraction");
+                if (!string.IsNullOrWhiteSpace(qti) &&
+                    !Enum.TryParse(qti, true, out triggerInteraction))
+                {
+                    return new ErrorResponse("Invalid query_trigger_interaction. Valid values: UseGlobal, Ignore, Collide.");
+                }
+
+                GameObject tempCameraGo = null;
+                try
+                {
+                    Camera camera = pickView != null
+                        ? CreateCameraFromPickView(pickView, viewportWidth, viewportHeight, out tempCameraGo)
+                        : ResolveCamera(cameraRef);
+
+                    if (camera == null)
+                        return new ErrorResponse($"Camera '{cameraRef}' not found. Provide a Camera GameObject name, path, or instance ID.");
+
+                    var ray = camera.ViewportPointToRay(new Vector3(viewportU, viewportV, 0f));
+                    string viewSource = pickView != null ? "pick_view" : "camera";
+
+                    if (IsSceneViewPickView(pickView) &&
+                        TryPickSceneViewObject(ray, viewportU, 1f - viewportV, layerMask, maxDistance, out var sceneViewPick, out var sceneViewPickMessage))
+                    {
+                        if (sceneViewPick.GameObject != null)
+                        {
+                            return new SuccessResponse(
+                                $"Picked GameObject '{sceneViewPick.GameObject.name}' from Scene View image coordinate.",
+                                BuildSceneViewHitData(
+                                    dimension,
+                                    ray,
+                                    imageX.Value,
+                                    imageY.Value,
+                                    imageWidth.Value,
+                                    imageHeight.Value,
+                                    scaleX,
+                                    scaleY,
+                                    viewportU,
+                                    viewportV,
+                                    viewportWidth,
+                                    viewportHeight,
+                                    viewSource,
+                                    sceneViewPick));
+                        }
+
+                        McpLog.Debug($"[PickGameObjectFromImage] Scene View editor pick did not hit: {sceneViewPickMessage}");
+                    }
+
+                    return dimension == "2d"
+                        ? Pick2D(ray, maxDistance, layerMask, imageX.Value, imageY.Value, imageWidth.Value, imageHeight.Value, scaleX, scaleY, viewportU, viewportV, viewportWidth, viewportHeight, viewSource)
+                        : Pick3D(ray, maxDistance, layerMask, triggerInteraction, imageX.Value, imageY.Value, imageWidth.Value, imageHeight.Value, scaleX, scaleY, viewportU, viewportV, viewportWidth, viewportHeight, viewSource);
+                }
+                finally
+                {
+                    if (tempCameraGo != null)
+                        UnityEngine.Object.DestroyImmediate(tempCameraGo);
+                }
+            }
+            catch (Exception ex)
+            {
+                McpLog.Error($"[PickGameObjectFromImage] Failed: {ex}");
+                return new ErrorResponse($"Error picking GameObject from image: {ex.Message}");
+            }
+        }
+
+        private static object Pick3D(
+            Ray ray,
+            float maxDistance,
+            int layerMask,
+            QueryTriggerInteraction triggerInteraction,
+            float imageX,
+            float imageY,
+            int imageWidth,
+            int imageHeight,
+            float scaleX,
+            float scaleY,
+            float viewportU,
+            float viewportV,
+            float viewportWidth,
+            float viewportHeight,
+            string viewSource)
+        {
+            UnityEngine.Physics.SyncTransforms();
+            RaycastHit[] hits = UnityEngine.Physics.RaycastAll(ray, maxDistance, layerMask, triggerInteraction);
+            Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
+
+            if (hits.Length == 0)
+            {
+                return new SuccessResponse(
+                    "No 3D Collider was hit at the requested image coordinate.",
+                    BuildNoHitData("3d", ray, imageX, imageY, imageWidth, imageHeight, scaleX, scaleY, viewportU, viewportV, viewportWidth, viewportHeight, viewSource));
+            }
+
+            var hit = hits[0];
+            var go = hit.collider.gameObject;
+            var data = BuildHitData(
+                "3d",
+                ray,
+                imageX,
+                imageY,
+                imageWidth,
+                imageHeight,
+                scaleX,
+                scaleY,
+                viewportU,
+                viewportV,
+                viewportWidth,
+                viewportHeight,
+                viewSource,
+                new[] { hit.point.x, hit.point.y, hit.point.z },
+                new[] { hit.normal.x, hit.normal.y, hit.normal.z },
+                hit.distance,
+                hit.collider.GetType().Name,
+                go);
+
+            return new SuccessResponse($"Picked GameObject '{go.name}' from image coordinate.", data);
+        }
+
+        private static bool TryPickSceneViewObject(
+            Ray ray,
+            float viewportU,
+            float viewportTopFraction,
+            int layerMask,
+            float maxDistance,
+            out SceneViewPickResult result,
+            out string message)
+        {
+            result = default;
+            message = null;
+
+            Vector2 guiPoint;
+            if (SceneViewPickOverrideForTests != null)
+            {
+                guiPoint = new Vector2(viewportU, viewportTopFraction);
+                result = SceneViewPickOverrideForTests(guiPoint);
+                return FilterSceneViewPickByLayerMask(result, layerMask, out result, out message);
+            }
+
+            string handleUtilityMessage = null;
+
+            if (!Application.isBatchMode)
+            {
+                var sceneView = SceneView.lastActiveSceneView;
+                if (sceneView == null)
+                {
+                    handleUtilityMessage = "No active Scene View is available.";
+                }
+                else
+                {
+                    Rect viewportRect = GetSceneViewViewportRectPoints(sceneView);
+                    if (viewportRect.width <= 0f || viewportRect.height <= 0f)
+                    {
+                        handleUtilityMessage = "Active Scene View viewport is empty.";
+                    }
+                    else
+                    {
+                        guiPoint = new Vector2(
+                            viewportRect.x + viewportU * viewportRect.width,
+                            viewportRect.y + viewportTopFraction * viewportRect.height);
+
+                        try
+                        {
+                            int materialIndex;
+                            GameObject picked = HandleUtility.PickGameObject(guiPoint, out materialIndex);
+                            var handleUtilityResult = new SceneViewPickResult(picked, materialIndex, "handle_utility");
+                            if (picked != null)
+                                return FilterSceneViewPickByLayerMask(handleUtilityResult, layerMask, out result, out message);
+                            handleUtilityMessage = "HandleUtility.PickGameObject did not hit a selectable object.";
+                        }
+                        catch (Exception ex)
+                        {
+                            handleUtilityMessage = $"HandleUtility.PickGameObject was unavailable: {ex.Message}";
+                        }
+                    }
+                }
+            }
+            else
+            {
+                handleUtilityMessage = "Scene View HandleUtility picking is not available in batch mode.";
+            }
+
+            if (TryPickRendererMesh(ray, layerMask, maxDistance, out result, out string meshMessage))
+            {
+                message = meshMessage;
+                return true;
+            }
+
+            message = $"{handleUtilityMessage} {meshMessage}".Trim();
+            return true;
+        }
+
+        private static bool TryPickRendererMesh(
+            Ray ray,
+            int layerMask,
+            float maxDistance,
+            out SceneViewPickResult result,
+            out string message)
+        {
+            result = default;
+            message = null;
+
+            float nearestDistance = float.PositiveInfinity;
+            GameObject nearestObject = null;
+
+            var renderers = UnityFindObjectsCompat.FindAll<Renderer>();
+            foreach (var renderer in renderers)
+            {
+                if (renderer == null || !renderer.enabled)
+                    continue;
+
+                var go = renderer.gameObject;
+                if (go == null || !go.activeInHierarchy)
+                    continue;
+                if (EditorUtility.IsPersistent(go))
+                    continue;
+                if ((go.hideFlags & (HideFlags.HideInHierarchy | HideFlags.HideAndDontSave)) != 0)
+                    continue;
+                if ((layerMask & (1 << go.layer)) == 0)
+                    continue;
+                if (!renderer.bounds.IntersectRay(ray, out float boundsDistance) ||
+                    boundsDistance > nearestDistance ||
+                    boundsDistance > maxDistance)
+                    continue;
+
+                Mesh mesh = null;
+                Matrix4x4 matrix = renderer.transform.localToWorldMatrix;
+
+                if (renderer is SkinnedMeshRenderer skinnedRenderer)
+                {
+                    mesh = skinnedRenderer.sharedMesh;
+                }
+                else
+                {
+                    var meshFilter = renderer.GetComponent<MeshFilter>();
+                    if (meshFilter != null)
+                        mesh = meshFilter.sharedMesh;
+                }
+
+                if (mesh == null)
+                    continue;
+
+                if (TryIntersectRayMesh(ray, mesh, matrix, out RaycastHit hit) &&
+                    hit.distance >= 0f &&
+                    hit.distance <= maxDistance &&
+                    hit.distance < nearestDistance)
+                {
+                    nearestDistance = hit.distance;
+                    result = new SceneViewPickResult(
+                        go,
+                        -1,
+                        "mesh_intersection",
+                        true,
+                        hit.point,
+                        hit.normal,
+                        hit.distance);
+                    nearestObject = go;
+                }
+            }
+
+            if (nearestObject == null)
+            {
+                message = "No visible MeshRenderer or SkinnedMeshRenderer intersected the Scene View ray.";
+                return false;
+            }
+
+            message = "Scene View mesh intersection hit a renderer without requiring a Collider.";
+            return true;
+        }
+
+        private static bool TryIntersectRayMesh(Ray ray, Mesh mesh, Matrix4x4 matrix, out RaycastHit hit)
+        {
+            hit = default;
+            if (mesh == null)
+                return false;
+
+            if (!_intersectRayMeshMethodProbed)
+            {
+                _intersectRayMeshMethodProbed = true;
+                _intersectRayMeshMethod = typeof(HandleUtility).GetMethod(
+                    "IntersectRayMesh",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { typeof(Ray), typeof(Mesh), typeof(Matrix4x4), typeof(RaycastHit).MakeByRefType() },
+                    null);
+            }
+
+            if (_intersectRayMeshMethod == null)
+                return false;
+
+            var args = new object[] { ray, mesh, matrix, hit };
+            try
+            {
+                bool didHit = (bool)_intersectRayMeshMethod.Invoke(null, args);
+                if (didHit)
+                    hit = (RaycastHit)args[3];
+                return didHit;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool FilterSceneViewPickByLayerMask(
+            SceneViewPickResult input,
+            int layerMask,
+            out SceneViewPickResult result,
+            out string message)
+        {
+            result = input;
+            message = null;
+
+            if (input.GameObject == null)
+            {
+                message = "No selectable Scene View object under the coordinate.";
+                return true;
+            }
+
+            int layerBit = 1 << input.GameObject.layer;
+            if ((layerMask & layerBit) == 0)
+            {
+                result = default;
+                message = $"Picked object '{input.GameObject.name}' is excluded by layer_mask.";
+                return true;
+            }
+
+            return true;
+        }
+
+        private static Dictionary<string, object> BuildSceneViewHitData(
+            string dimension,
+            Ray ray,
+            float imageX,
+            float imageY,
+            int imageWidth,
+            int imageHeight,
+            float scaleX,
+            float scaleY,
+            float viewportU,
+            float viewportV,
+            float viewportWidth,
+            float viewportHeight,
+            string viewSource,
+            SceneViewPickResult pickResult)
+        {
+            var data = BuildBaseData(dimension, ray, imageX, imageY, imageWidth, imageHeight, scaleX, scaleY, viewportU, viewportV, viewportWidth, viewportHeight, viewSource);
+            data["hit"] = true;
+            data["pickMode"] = "scene_view_editor_pick";
+            data["requiresCollider"] = false;
+            data["sceneViewPickBackend"] = string.IsNullOrEmpty(pickResult.Backend) ? "handle_utility" : pickResult.Backend;
+            data["materialIndex"] = pickResult.MaterialIndex;
+            if (pickResult.HasHitDetails)
+            {
+                data["point"] = new[] { pickResult.Point.x, pickResult.Point.y, pickResult.Point.z };
+                data["normal"] = new[] { pickResult.Normal.x, pickResult.Normal.y, pickResult.Normal.z };
+                data["distance"] = pickResult.Distance;
+            }
+            data["gameObject"] = GameObjectResource.SerializeGameObject(pickResult.GameObject);
+            data["instanceID"] = pickResult.GameObject.GetInstanceIDCompat();
+            data["gameObjectName"] = pickResult.GameObject.name;
+            return data;
+        }
+
+        private static object Pick2D(
+            Ray ray,
+            float maxDistance,
+            int layerMask,
+            float imageX,
+            float imageY,
+            int imageWidth,
+            int imageHeight,
+            float scaleX,
+            float scaleY,
+            float viewportU,
+            float viewportV,
+            float viewportWidth,
+            float viewportHeight,
+            string viewSource)
+        {
+            Physics2D.SyncTransforms();
+            RaycastHit2D[] hits = Physics2D.GetRayIntersectionAll(ray, maxDistance, layerMask);
+            Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
+
+            if (hits.Length == 0)
+            {
+                return new SuccessResponse(
+                    "No 2D Collider2D was hit at the requested image coordinate.",
+                    BuildNoHitData("2d", ray, imageX, imageY, imageWidth, imageHeight, scaleX, scaleY, viewportU, viewportV, viewportWidth, viewportHeight, viewSource));
+            }
+
+            var hit = hits[0];
+            var go = hit.collider.gameObject;
+            var data = BuildHitData(
+                "2d",
+                ray,
+                imageX,
+                imageY,
+                imageWidth,
+                imageHeight,
+                scaleX,
+                scaleY,
+                viewportU,
+                viewportV,
+                viewportWidth,
+                viewportHeight,
+                viewSource,
+                new[] { hit.point.x, hit.point.y },
+                new[] { hit.normal.x, hit.normal.y },
+                hit.distance,
+                hit.collider.GetType().Name,
+                go);
+
+            return new SuccessResponse($"Picked GameObject '{go.name}' from image coordinate.", data);
+        }
+
+        private static Dictionary<string, object> BuildNoHitData(
+            string dimension,
+            Ray ray,
+            float imageX,
+            float imageY,
+            int imageWidth,
+            int imageHeight,
+            float scaleX,
+            float scaleY,
+            float viewportU,
+            float viewportV,
+            float viewportWidth,
+            float viewportHeight,
+            string viewSource)
+        {
+            var data = BuildBaseData(dimension, ray, imageX, imageY, imageWidth, imageHeight, scaleX, scaleY, viewportU, viewportV, viewportWidth, viewportHeight, viewSource);
+            data["hit"] = false;
+            data["pickMode"] = dimension == "2d" ? "physics_2d" : "physics_3d";
+            data["requiresCollider"] = true;
+            return data;
+        }
+
+        private static Dictionary<string, object> BuildHitData(
+            string dimension,
+            Ray ray,
+            float imageX,
+            float imageY,
+            int imageWidth,
+            int imageHeight,
+            float scaleX,
+            float scaleY,
+            float viewportU,
+            float viewportV,
+            float viewportWidth,
+            float viewportHeight,
+            string viewSource,
+            float[] point,
+            float[] normal,
+            float distance,
+            string colliderType,
+            GameObject gameObject)
+        {
+            var data = BuildBaseData(dimension, ray, imageX, imageY, imageWidth, imageHeight, scaleX, scaleY, viewportU, viewportV, viewportWidth, viewportHeight, viewSource);
+            data["hit"] = true;
+            data["pickMode"] = dimension == "2d" ? "physics_2d" : "physics_3d";
+            data["requiresCollider"] = true;
+            data["point"] = point;
+            data["normal"] = normal;
+            data["distance"] = distance;
+            data["colliderType"] = colliderType;
+            data["collider_type"] = colliderType;
+            data["gameObject"] = GameObjectResource.SerializeGameObject(gameObject);
+            data["instanceID"] = gameObject.GetInstanceIDCompat();
+            data["gameObjectName"] = gameObject.name;
+            return data;
+        }
+
+        private static Dictionary<string, object> BuildBaseData(
+            string dimension,
+            Ray ray,
+            float imageX,
+            float imageY,
+            int imageWidth,
+            int imageHeight,
+            float scaleX,
+            float scaleY,
+            float viewportU,
+            float viewportV,
+            float viewportWidth,
+            float viewportHeight,
+            string viewSource)
+        {
+            return new Dictionary<string, object>
+            {
+                { "dimension", dimension },
+                { "viewSource", viewSource },
+                { "image", new Dictionary<string, object>
+                    {
+                        { "x", imageX },
+                        { "y", imageY },
+                        { "width", imageWidth },
+                        { "height", imageHeight },
+                        { "scaleX", scaleX },
+                        { "scaleY", scaleY },
+                    }
+                },
+                { "viewport", new Dictionary<string, object>
+                    {
+                        { "x", viewportU },
+                        { "y", viewportV },
+                        { "width", viewportWidth },
+                        { "height", viewportHeight },
+                    }
+                },
+                { "ray", new Dictionary<string, object>
+                    {
+                        { "origin", new[] { ray.origin.x, ray.origin.y, ray.origin.z } },
+                        { "direction", new[] { ray.direction.x, ray.direction.y, ray.direction.z } },
+                    }
+                },
+            };
+        }
+
+        private static bool IsSceneViewPickView(JObject pickView)
+        {
+            string captureSource = ParamCoercion.CoerceString(pickView?["captureSource"] ?? pickView?["capture_source"], null);
+            return string.Equals(captureSource, "scene_view", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static Rect GetSceneViewViewportRectPoints(SceneView sceneView)
+        {
+            Rect? cameraViewport = GetRectProperty(sceneView, "cameraViewport");
+            if (cameraViewport.HasValue && cameraViewport.Value.width > 0f && cameraViewport.Value.height > 0f)
+                return cameraViewport.Value;
+
+            Camera camera = sceneView.camera;
+            if (camera == null)
+                return Rect.zero;
+
+            float pixelsPerPoint = Mathf.Max(0.0001f, EditorGUIUtility.pixelsPerPoint);
+            float viewportWidth = camera.pixelWidth / pixelsPerPoint;
+            float viewportHeight = camera.pixelHeight / pixelsPerPoint;
+            Rect windowRect = sceneView.position;
+
+            return new Rect(
+                0f,
+                Mathf.Max(0f, windowRect.height - viewportHeight),
+                Mathf.Min(windowRect.width, viewportWidth),
+                Mathf.Min(windowRect.height, viewportHeight));
+        }
+
+        private static Rect? GetRectProperty(object instance, string propertyName)
+        {
+            if (instance == null)
+                return null;
+
+            var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (property == null || property.PropertyType != typeof(Rect))
+                return null;
+
+            try
+            {
+                return (Rect)property.GetValue(instance, null);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static JObject NormalizePickView(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+                return null;
+            if (token is JObject obj)
+                return obj;
+            if (token.Type == JTokenType.String)
+            {
+                string raw = token.ToString();
+                if (string.IsNullOrWhiteSpace(raw))
+                    return null;
+                return JObject.Parse(raw);
+            }
+            throw new JsonException("pick_view must be a JSON object.");
+        }
+
+        private static Camera CreateCameraFromPickView(JObject view, float viewportWidth, float viewportHeight, out GameObject tempGo)
+        {
+            Vector3? position = ReadVector3(view["position"]);
+            Vector3? rotation = ReadVector3(view["rotation"] ?? view["eulerAngles"] ?? view["euler_angles"]);
+            if (!position.HasValue)
+                throw new ArgumentException("pick_view.position is required.");
+            if (!rotation.HasValue)
+                throw new ArgumentException("pick_view.rotation is required.");
+
+            tempGo = new GameObject("__MCP_PickViewCamera_Temp__");
+            tempGo.hideFlags = HideFlags.HideAndDontSave;
+            var camera = tempGo.AddComponent<Camera>();
+            camera.enabled = false;
+            camera.transform.position = position.Value;
+            camera.transform.rotation = Quaternion.Euler(rotation.Value);
+
+            string projection = ParamCoercion.CoerceString(view["projection"], null)?.ToLowerInvariant();
+            bool orthographic = ParamCoercion.CoerceBool(view["orthographic"], projection == "orthographic");
+            camera.orthographic = orthographic;
+
+            if (orthographic)
+            {
+                float? size = ParamCoercion.CoerceFloatNullable(view["orthographicSize"] ?? view["orthographic_size"]);
+                if (!IsFinite(size) || size.Value <= 0f)
+                    throw new ArgumentException("pick_view.orthographicSize is required for orthographic screenshots.");
+                camera.orthographicSize = size.Value;
+            }
+            else
+            {
+                float? fov = ParamCoercion.CoerceFloatNullable(view["fieldOfView"] ?? view["field_of_view"]);
+                if (!IsFinite(fov) || fov.Value <= 0f || fov.Value >= 180f)
+                    throw new ArgumentException("pick_view.fieldOfView is required for perspective screenshots.");
+                camera.fieldOfView = fov.Value;
+            }
+
+            camera.nearClipPlane = ParamCoercion.CoerceFloatNullable(view["nearClipPlane"] ?? view["near_clip_plane"]) ?? 0.3f;
+            camera.farClipPlane = ParamCoercion.CoerceFloatNullable(view["farClipPlane"] ?? view["far_clip_plane"]) ?? 1000f;
+            float aspect = ParamCoercion.CoerceFloatNullable(view["aspect"]) ?? (viewportWidth / viewportHeight);
+            if (!IsFinite(aspect) || aspect <= 0f)
+                aspect = viewportWidth / viewportHeight;
+            camera.aspect = aspect;
+            return camera;
+        }
+
+        private static Vector3? ReadVector3(JToken token)
+        {
+            if (token is JArray arr && arr.Count >= 3)
+            {
+                float? x = ParamCoercion.CoerceFloatNullable(arr[0]);
+                float? y = ParamCoercion.CoerceFloatNullable(arr[1]);
+                float? z = ParamCoercion.CoerceFloatNullable(arr[2]);
+                if (IsFinite(x) && IsFinite(y) && IsFinite(z))
+                    return new Vector3(x.Value, y.Value, z.Value);
+            }
+
+            if (token is JObject obj)
+            {
+                float? x = ParamCoercion.CoerceFloatNullable(obj["x"]);
+                float? y = ParamCoercion.CoerceFloatNullable(obj["y"]);
+                float? z = ParamCoercion.CoerceFloatNullable(obj["z"]);
+                if (IsFinite(x) && IsFinite(y) && IsFinite(z))
+                    return new Vector3(x.Value, y.Value, z.Value);
+            }
+
+            return null;
+        }
+
+        private static Camera ResolveCamera(string cameraRef)
+        {
+            if (string.IsNullOrWhiteSpace(cameraRef))
+                return null;
+
+            if (int.TryParse(cameraRef, out int id))
+            {
+                var obj = GameObjectLookup.ResolveInstanceID(id);
+                if (obj is Camera cam)
+                    return cam;
+                if (obj is GameObject go)
+                    return go.GetComponent<Camera>();
+            }
+
+            var allCameras = UnityFindObjectsCompat.FindAll<Camera>();
+            foreach (var cam in allCameras)
+            {
+                if (cam == null)
+                    continue;
+                if (cam.name == cameraRef || cam.gameObject.name == cameraRef)
+                    return cam;
+            }
+
+            if (cameraRef.Contains("/"))
+            {
+                var ids = GameObjectLookup.SearchGameObjects("by_path", cameraRef, includeInactive: false, maxResults: 1);
+                if (ids.Count > 0)
+                {
+                    var go = GameObjectLookup.FindById(ids[0]);
+                    if (go != null)
+                        return go.GetComponent<Camera>();
+                }
+            }
+
+            return null;
+        }
+
+        private static int ResolveLayerMask(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+                return ~0;
+
+            string layerMaskStr = token.ToString();
+            if (string.IsNullOrWhiteSpace(layerMaskStr))
+                return ~0;
+
+            if (int.TryParse(layerMaskStr, out int mask))
+                return mask;
+
+            int resolved = 0;
+            foreach (var partRaw in layerMaskStr.Split(','))
+            {
+                string part = partRaw.Trim();
+                if (part.Length == 0)
+                    continue;
+
+                int layer = LayerMask.NameToLayer(part);
+                if (layer < 0)
+                    throw new ArgumentException($"Unknown layer name: '{part}'. Use a valid layer name, comma-separated layer names, or integer mask.");
+                resolved |= 1 << layer;
+            }
+
+            return resolved == 0 ? ~0 : resolved;
+        }
+
+        private static bool IsFinite(float? value)
+        {
+            return value.HasValue && !float.IsNaN(value.Value) && !float.IsInfinity(value.Value);
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/PickGameObjectFromImage.cs.meta
+++ b/MCPForUnity/Editor/Tools/PickGameObjectFromImage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8abf81b56c214e4f9826f8ce61ab5f9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Server/src/cli/commands/camera.py
+++ b/Server/src/cli/commands/camera.py
@@ -51,7 +51,7 @@ def ping():
         unity-mcp camera ping
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "ping"})
+    result = run_command("manage_camera", {"action": "ping"}, config)
     format_output(result, config)
 
 
@@ -65,7 +65,7 @@ def list_cameras():
         unity-mcp camera list
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "list_cameras"})
+    result = run_command("manage_camera", {"action": "list_cameras"}, config)
     format_output(result, config)
 
 
@@ -79,7 +79,7 @@ def brain_status():
         unity-mcp camera brain-status
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "get_brain_status"})
+    result = run_command("manage_camera", {"action": "get_brain_status"}, config)
     format_output(result, config)
 
 
@@ -125,7 +125,7 @@ def create(name, preset, follow, look_at, priority, fov):
     if props:
         params["properties"] = props
 
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -155,7 +155,7 @@ def ensure_brain(camera_ref, blend_style, blend_duration):
     if props:
         params["properties"] = props
 
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -189,7 +189,7 @@ def set_target(target, search_method, follow, look_at):
         "searchMethod": search_method,
         "properties": props if props else None,
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -228,7 +228,7 @@ def set_lens(target, search_method, fov, near, far, ortho_size, dutch):
         "searchMethod": search_method,
         "properties": props if props else None,
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -251,7 +251,7 @@ def set_priority(target, search_method, priority):
         "searchMethod": search_method,
         "properties": {"priority": priority},
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -286,7 +286,7 @@ def set_body(target, search_method, body_type, props):
         "searchMethod": search_method,
         "properties": properties if properties else None,
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -316,7 +316,7 @@ def set_aim(target, search_method, aim_type, props):
         "searchMethod": search_method,
         "properties": properties if properties else None,
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -346,7 +346,7 @@ def set_noise(target, search_method, amplitude, frequency):
         "searchMethod": search_method,
         "properties": props if props else None,
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -379,7 +379,7 @@ def add_extension(target, extension_type, search_method, props):
         "searchMethod": search_method,
         "properties": properties,
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -402,7 +402,7 @@ def remove_extension(target, extension_type, search_method):
         "searchMethod": search_method,
         "properties": {"extensionType": extension_type},
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -432,7 +432,7 @@ def set_blend(style, duration):
     if props:
         params["properties"] = props
 
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -453,7 +453,7 @@ def force_camera(target, search_method):
         "target": target,
         "searchMethod": search_method,
     })
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -467,7 +467,7 @@ def release_override():
         unity-mcp camera release
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "release_override"})
+    result = run_command("manage_camera", {"action": "release_override"}, config)
     format_output(result, config)
 
 
@@ -523,7 +523,7 @@ def screenshot(camera_ref, file_name, super_size, include_image, max_resolution,
         params["viewTarget"] = view_target
     if output_folder:
         params["outputFolder"] = output_folder
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 
@@ -550,7 +550,7 @@ def screenshot_multiview(max_resolution, view_target, output_folder):
         params["viewTarget"] = view_target
     if output_folder:
         params["outputFolder"] = output_folder
-    result = run_command(config, "manage_camera", params)
+    result = run_command("manage_camera", params, config)
     format_output(result, config)
 
 

--- a/Server/src/cli/commands/camera.py
+++ b/Server/src/cli/commands/camera.py
@@ -552,3 +552,95 @@ def screenshot_multiview(max_resolution, view_target, output_folder):
         params["outputFolder"] = output_folder
     result = run_command(config, "manage_camera", params)
     format_output(result, config)
+
+
+@camera.command("pick")
+@click.option("--x", "image_x", type=float, required=True,
+              help="X coordinate in the inspected screenshot image (top-left origin).")
+@click.option("--y", "image_y", type=float, required=True,
+              help="Y coordinate in the inspected screenshot image (top-left origin).")
+@click.option("--image-width", type=int, required=True, help="Width of the inspected image in pixels.")
+@click.option("--image-height", type=int, required=True, help="Height of the inspected image in pixels.")
+@click.option("--camera-ref", default=None,
+              help="Camera name/path/ID. Use only when the camera is unchanged since capture.")
+@click.option("--view-json", default=None,
+              help="pickView JSON object returned by a supported screenshot response.")
+@click.option("--dimension", default="3d", type=click.Choice(["3d", "2d"], case_sensitive=False),
+              help="Physics dimension to query.")
+@click.option("--scale-x", type=float, default=None,
+              help="Scale from inspected image X pixels back to captured Unity viewport pixels.")
+@click.option("--scale-y", type=float, default=None,
+              help="Scale from inspected image Y pixels back to captured Unity viewport pixels. Defaults to scale-x.")
+@click.option("--viewport-width", type=int, default=None,
+              help="Original captured Unity viewport width. Use pickView.viewportWidth when present.")
+@click.option("--viewport-height", type=int, default=None,
+              help="Original captured Unity viewport height. Use pickView.viewportHeight when present.")
+@click.option("--layer-mask", default=None,
+              help="Layer mask as integer mask or layer name(s).")
+@click.option("--max-distance", type=float, default=None, help="Maximum ray distance.")
+@click.option("--query-trigger-interaction", default=None,
+              type=click.Choice(["UseGlobal", "Ignore", "Collide"], case_sensitive=False),
+              help="3D trigger query policy.")
+@handle_unity_errors
+def pick(
+    image_x,
+    image_y,
+    image_width,
+    image_height,
+    camera_ref,
+    view_json,
+    dimension,
+    scale_x,
+    scale_y,
+    viewport_width,
+    viewport_height,
+    layer_mask,
+    max_distance,
+    query_trigger_interaction,
+):
+    """Pick the GameObject at a Unity screenshot coordinate.
+
+    This is for Unity screenshots only. Prefer --view-json with the pickView
+    returned by camera screenshots. --camera-ref is valid only when that camera
+    has not moved or changed projection since the screenshot.
+
+    Scene View pickView screenshots first use Unity Editor Scene View picking,
+    then an Editor mesh-intersection fallback, which can hit visible
+    MeshRenderer/SkinnedMeshRenderer objects without Colliders. Other capture
+    modes use physics ray queries and require Collider/Collider2D.
+
+    \b
+    Examples:
+        unity-mcp camera screenshot --camera-ref MainCamera --include-image
+        unity-mcp camera pick --x 310 --y 180 --image-width 640 --image-height 360 --view-json '{"position":[0,1,-10],"rotation":[0,0,0],"projection":"perspective","fieldOfView":60,"nearClipPlane":0.3,"farClipPlane":1000,"aspect":1.777}'
+        unity-mcp camera pick --x 310 --y 180 --image-width 640 --image-height 360 --camera-ref MainCamera --dimension 3d
+    """
+    config = get_config()
+    params: dict[str, Any] = {
+        "imageX": image_x,
+        "imageY": image_y,
+        "imageWidth": image_width,
+        "imageHeight": image_height,
+        "dimension": dimension.lower(),
+    }
+    if camera_ref:
+        params["camera"] = camera_ref
+    if view_json:
+        params["pickView"] = parse_json_dict_or_exit(view_json)
+    if scale_x is not None:
+        params["scaleX"] = scale_x
+    if scale_y is not None:
+        params["scaleY"] = scale_y
+    if viewport_width is not None:
+        params["viewportWidth"] = viewport_width
+    if viewport_height is not None:
+        params["viewportHeight"] = viewport_height
+    if layer_mask:
+        params["layerMask"] = layer_mask
+    if max_distance is not None:
+        params["maxDistance"] = max_distance
+    if query_trigger_interaction:
+        params["queryTriggerInteraction"] = query_trigger_interaction
+
+    result = run_command("pick_gameobject_from_image", params, config)
+    format_output(result, config)

--- a/Server/src/services/tools/manage_camera.py
+++ b/Server/src/services/tools/manage_camera.py
@@ -68,7 +68,8 @@ ALL_ACTIONS = SETUP_ACTIONS + CREATION_ACTIONS + CONFIGURATION_ACTIONS + EXTENSI
         "Supports include_image=true for inline base64 PNG, "
         "batch='surround' for 6-angle contact sheet, batch='orbit' for configurable grid, "
         "view_target/view_position for positioned capture, and capture_source='scene_view' to capture "
-        "the active Unity Scene View viewport.\n"
+        "the active Unity Scene View viewport. Supported single-view Unity screenshots return pickView metadata "
+        "for use with pick_gameobject_from_image.\n"
         "- screenshot_multiview: Shorthand for screenshot with batch='surround' and include_image=true."
     ),
     annotations=ToolAnnotations(

--- a/Server/src/services/tools/pick_gameobject_from_image.py
+++ b/Server/src/services/tools/pick_gameobject_from_image.py
@@ -26,8 +26,9 @@ DESCRIPTION = (
     "fallback can return visible MeshRenderer/SkinnedMeshRenderer objects without Colliders; if both miss, "
     "the tool falls back to physics picking. "
     "For camera, game_view, and view_position/view_target captures, picking uses 3D Collider or 2D Collider2D "
-    "ray queries. UI GraphicRaycaster, non-selectable Scene View visuals, Renderer-only objects in non-Scene View "
-    "captures, and non-Unity images are not supported."
+    "ray queries. If layer_mask is omitted, picking defaults to the screenshot camera culling mask when available. "
+    "UI GraphicRaycaster, non-selectable Scene View visuals, Renderer-only objects in non-Scene View captures, "
+    "and non-Unity images are not supported."
 )
 
 

--- a/Server/src/services/tools/pick_gameobject_from_image.py
+++ b/Server/src/services/tools/pick_gameobject_from_image.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import math
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+
+from services.registry import mcp_for_unity_tool
+from services.tools import get_unity_instance_from_context
+from services.tools.utils import coerce_float, coerce_int, parse_json_payload
+from transport.legacy.unity_connection import async_send_command_with_retry
+from transport.unity_transport import send_with_unity_instance
+
+
+DESCRIPTION = (
+    "Pick the Unity GameObject visible at an image coordinate from a Unity screenshot. "
+    "Read-only. Preconditions: this only works for Unity screenshots, not arbitrary external images. "
+    "The caller must pass the screenshot-time pick_view returned by supported screenshot captures, or pass "
+    "a camera reference only when that Unity Camera still has the same transform/projection it had at capture time. "
+    "Supported in this first version: screenshots captured with an explicit camera, screenshots captured with "
+    "view_position/view_target, and screenshots captured with capture_source='scene_view'. "
+    "Not supported in this first version: default Game View screenshots with no camera, screenshot_multiview, "
+    "batch='surround', batch='orbit', and whole-contact-sheet coordinates. "
+    "For capture_source='scene_view', Unity Editor picking is tried first, then an Editor mesh-intersection "
+    "fallback can return visible MeshRenderer/SkinnedMeshRenderer objects without Colliders; if both miss, "
+    "the tool falls back to physics picking. "
+    "For camera, game_view, and view_position/view_target captures, picking uses 3D Collider or 2D Collider2D "
+    "ray queries. UI GraphicRaycaster, non-selectable Scene View visuals, Renderer-only objects in non-Scene View "
+    "captures, and non-Unity images are not supported."
+)
+
+
+def _finite_float(value: Any, name: str) -> tuple[float | None, str | None]:
+    parsed = coerce_float(value)
+    if parsed is None or not math.isfinite(parsed):
+        return None, f"{name} must be a finite number."
+    return parsed, None
+
+
+def _positive_int(value: Any, name: str) -> tuple[int | None, str | None]:
+    parsed = coerce_int(value)
+    if parsed is None or parsed <= 0:
+        return None, f"{name} must be a positive integer."
+    return parsed, None
+
+
+def _positive_float(value: Any, name: str) -> tuple[float | None, str | None]:
+    parsed = coerce_float(value)
+    if parsed is None or not math.isfinite(parsed) or parsed <= 0:
+        return None, f"{name} must be a positive finite number."
+    return parsed, None
+
+
+@mcp_for_unity_tool(
+    group="core",
+    description=DESCRIPTION,
+    annotations=ToolAnnotations(title="Pick GameObject From Image", destructiveHint=False),
+)
+async def pick_gameobject_from_image(
+    ctx: Context,
+    image_x: Annotated[float | int | str, "X coordinate in the screenshot image, origin at top-left, increasing right."],
+    image_y: Annotated[float | int | str, "Y coordinate in the screenshot image, origin at top-left, increasing down."],
+    image_width: Annotated[int | str, "Width of the image the AI is inspecting, in pixels."],
+    image_height: Annotated[int | str, "Height of the image the AI is inspecting, in pixels."],
+    scale_x: Annotated[float | int | str | None, "Scale from inspected image X pixels back to the captured Unity viewport pixels. Default 1."] = None,
+    scale_y: Annotated[float | int | str | None, "Scale from inspected image Y pixels back to the captured Unity viewport pixels. Defaults to scale_x."] = None,
+    viewport_width: Annotated[int | str | None, "Optional original captured Unity viewport width. Use pick_view.viewportWidth when present."] = None,
+    viewport_height: Annotated[int | str | None, "Optional original captured Unity viewport height. Use pick_view.viewportHeight when present."] = None,
+    dimension: Annotated[Literal["3d", "2d"] | str | None, "Physics dimension to query: '3d' for Collider, '2d' for Collider2D."] = "3d",
+    camera: Annotated[str | None, "Camera name, path, or instance ID. Use only if the camera has not changed since capture."] = None,
+    pick_view: Annotated[dict[str, Any] | str | None, "Screenshot-time pickView object returned by supported Unity screenshots. Preferred over camera."] = None,
+    layer_mask: Annotated[str | int | None, "Layer mask as integer mask or layer name(s). Optional."] = None,
+    max_distance: Annotated[float | int | str | None, "Maximum ray distance. Default infinity."] = None,
+    query_trigger_interaction: Annotated[str | None, "3D trigger policy: UseGlobal, Ignore, or Collide."] = None,
+) -> dict[str, Any]:
+    """Pick a GameObject from a Unity screenshot coordinate."""
+
+    x, error = _finite_float(image_x, "image_x")
+    if error:
+        return {"success": False, "message": error}
+    y, error = _finite_float(image_y, "image_y")
+    if error:
+        return {"success": False, "message": error}
+    width, error = _positive_int(image_width, "image_width")
+    if error:
+        return {"success": False, "message": error}
+    height, error = _positive_int(image_height, "image_height")
+    if error:
+        return {"success": False, "message": error}
+
+    if x < 0 or x >= width:
+        return {"success": False, "message": "image_x must be within [0, image_width)."}
+    if y < 0 or y >= height:
+        return {"success": False, "message": "image_y must be within [0, image_height)."}
+
+    sx = 1.0
+    if scale_x is not None:
+        sx, error = _positive_float(scale_x, "scale_x")
+        if error:
+            return {"success": False, "message": error}
+
+    sy = sx
+    if scale_y is not None:
+        sy, error = _positive_float(scale_y, "scale_y")
+        if error:
+            return {"success": False, "message": error}
+
+    vw = None
+    if viewport_width is not None:
+        vw, error = _positive_int(viewport_width, "viewport_width")
+        if error:
+            return {"success": False, "message": error}
+
+    vh = None
+    if viewport_height is not None:
+        vh, error = _positive_int(viewport_height, "viewport_height")
+        if error:
+            return {"success": False, "message": error}
+
+    dim = (dimension or "3d").lower()
+    if dim not in {"3d", "2d"}:
+        return {"success": False, "message": "dimension must be '3d' or '2d'."}
+
+    parsed_pick_view = parse_json_payload(pick_view)
+    if isinstance(parsed_pick_view, str):
+        return {"success": False, "message": "pick_view must be a JSON object when provided."}
+    if parsed_pick_view is not None and not isinstance(parsed_pick_view, dict):
+        return {"success": False, "message": "pick_view must be a JSON object when provided."}
+
+    camera_ref = camera.strip() if isinstance(camera, str) else camera
+    if parsed_pick_view is None and not camera_ref:
+        return {
+            "success": False,
+            "message": "Provide either pick_view from the screenshot response or a still-unchanged camera reference.",
+        }
+
+    max_dist = None
+    if max_distance is not None:
+        max_dist, error = _positive_float(max_distance, "max_distance")
+        if error:
+            return {"success": False, "message": error}
+
+    qti = None
+    if query_trigger_interaction is not None:
+        qti_key = str(query_trigger_interaction).strip().lower()
+        qti_values = {
+            "useglobal": "UseGlobal",
+            "ignore": "Ignore",
+            "collide": "Collide",
+        }
+        qti = qti_values.get(qti_key)
+        if qti is None:
+            return {
+                "success": False,
+                "message": "query_trigger_interaction must be UseGlobal, Ignore, or Collide.",
+            }
+
+    params: dict[str, Any] = {
+        "imageX": x,
+        "imageY": y,
+        "imageWidth": width,
+        "imageHeight": height,
+        "scaleX": sx,
+        "scaleY": sy,
+        "dimension": dim,
+    }
+    if vw is not None:
+        params["viewportWidth"] = vw
+    if vh is not None:
+        params["viewportHeight"] = vh
+    if parsed_pick_view is not None:
+        params["pickView"] = parsed_pick_view
+    if camera_ref:
+        params["camera"] = camera_ref
+    if layer_mask is not None:
+        params["layerMask"] = layer_mask
+    if max_dist is not None:
+        params["maxDistance"] = max_dist
+    if qti is not None:
+        params["queryTriggerInteraction"] = qti
+
+    unity_instance = await get_unity_instance_from_context(ctx)
+    result = await send_with_unity_instance(
+        async_send_command_with_retry,
+        unity_instance,
+        "pick_gameobject_from_image",
+        params,
+    )
+    return result if isinstance(result, dict) else {"success": False, "message": str(result)}

--- a/Server/tests/test_cli.py
+++ b/Server/tests/test_cli.py
@@ -470,7 +470,8 @@ class TestCameraCommands:
             ])
             assert result.exit_code == 0
             mock_run.assert_called_once()
-            params = mock_run.call_args[0][2]
+            command_type, params, _config = mock_run.call_args[0]
+            assert command_type == "manage_camera"
             assert params["captureSource"] == "scene_view"
             assert params["viewTarget"] == "Canvas"
             assert params["includeImage"] is True

--- a/Server/tests/test_cli.py
+++ b/Server/tests/test_cli.py
@@ -475,6 +475,41 @@ class TestCameraCommands:
             assert params["viewTarget"] == "Canvas"
             assert params["includeImage"] is True
 
+    def test_camera_pick(self, runner, mock_unity_response):
+        view_json = (
+            '{"captureSource":"scene_view","position":[0,1,-10],'
+            '"rotation":[0,0,0],"projection":"perspective",'
+            '"fieldOfView":60,"nearClipPlane":0.3,"farClipPlane":1000}'
+        )
+        with patch("cli.commands.camera.run_command", return_value=mock_unity_response) as mock_run:
+            result = runner.invoke(cli, [
+                "camera", "pick",
+                "--x", "310",
+                "--y", "180",
+                "--image-width", "640",
+                "--image-height", "360",
+                "--view-json", view_json,
+                "--dimension", "3d",
+                "--scale-x", "2",
+                "--layer-mask", "Default",
+                "--max-distance", "100",
+                "--query-trigger-interaction", "Ignore",
+            ])
+
+            assert result.exit_code == 0
+            command_type, params, _config = mock_run.call_args[0]
+            assert command_type == "pick_gameobject_from_image"
+            assert params["imageX"] == 310
+            assert params["imageY"] == 180
+            assert params["imageWidth"] == 640
+            assert params["imageHeight"] == 360
+            assert params["pickView"]["captureSource"] == "scene_view"
+            assert params["dimension"] == "3d"
+            assert params["scaleX"] == 2
+            assert params["layerMask"] == "Default"
+            assert params["maxDistance"] == 100
+            assert params["queryTriggerInteraction"] == "Ignore"
+
 
 
 # =============================================================================

--- a/Server/tests/test_pick_gameobject_from_image.py
+++ b/Server/tests/test_pick_gameobject_from_image.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.tools.pick_gameobject_from_image import DESCRIPTION, pick_gameobject_from_image
+
+
+@pytest.fixture
+def mock_unity(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_send(send_fn, unity_instance, tool_name, params):
+        captured["unity_instance"] = unity_instance
+        captured["tool_name"] = tool_name
+        captured["params"] = params
+        return {"success": True, "message": "ok", "data": {"hit": False}}
+
+    monkeypatch.setattr(
+        "services.tools.pick_gameobject_from_image.get_unity_instance_from_context",
+        AsyncMock(return_value="unity-instance-1"),
+    )
+    monkeypatch.setattr(
+        "services.tools.pick_gameobject_from_image.send_with_unity_instance",
+        fake_send,
+    )
+    return captured
+
+
+def test_forwards_core_parameters(mock_unity):
+    pick_view = {
+        "position": [0, 1, -10],
+        "rotation": [0, 0, 0],
+        "projection": "perspective",
+        "fieldOfView": 60,
+        "nearClipPlane": 0.3,
+        "farClipPlane": 1000,
+        "aspect": 1.777,
+        "viewportWidth": 1280,
+        "viewportHeight": 720,
+    }
+
+    result = asyncio.run(
+        pick_gameobject_from_image(
+            SimpleNamespace(),
+            image_x=320,
+            image_y=180,
+            image_width=640,
+            image_height=360,
+            scale_x=2,
+            scale_y=2,
+            viewport_width=1280,
+            viewport_height=720,
+            dimension="3d",
+            camera="MainCamera",
+            pick_view=pick_view,
+            layer_mask="Default",
+            max_distance=200,
+            query_trigger_interaction="Ignore",
+        )
+    )
+
+    assert result["success"] is True
+    assert mock_unity["tool_name"] == "pick_gameobject_from_image"
+    params = mock_unity["params"]
+    assert params["imageX"] == 320
+    assert params["imageY"] == 180
+    assert params["imageWidth"] == 640
+    assert params["imageHeight"] == 360
+    assert params["scaleX"] == 2
+    assert params["scaleY"] == 2
+    assert params["viewportWidth"] == 1280
+    assert params["viewportHeight"] == 720
+    assert params["dimension"] == "3d"
+    assert params["camera"] == "MainCamera"
+    assert params["pickView"] == pick_view
+    assert params["layerMask"] == "Default"
+    assert params["maxDistance"] == 200
+    assert params["queryTriggerInteraction"] == "Ignore"
+
+
+def test_requires_pick_view_or_camera(mock_unity):
+    result = asyncio.run(
+        pick_gameobject_from_image(
+            SimpleNamespace(),
+            image_x=10,
+            image_y=10,
+            image_width=100,
+            image_height=100,
+        )
+    )
+
+    assert result["success"] is False
+    assert "pick_view" in result["message"]
+    assert "tool_name" not in mock_unity
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"image_width": 0}, "image_width"),
+        ({"image_height": -1}, "image_height"),
+        ({"image_x": 100}, "image_x"),
+        ({"image_y": 100}, "image_y"),
+        ({"dimension": "4d"}, "dimension"),
+        ({"scale_x": 0}, "scale_x"),
+        ({"scale_y": -2}, "scale_y"),
+        ({"viewport_width": 0}, "viewport_width"),
+        ({"viewport_height": 0}, "viewport_height"),
+        ({"max_distance": 0}, "max_distance"),
+    ],
+)
+def test_invalid_values_return_errors(mock_unity, kwargs, message):
+    args = {
+        "image_x": 10,
+        "image_y": 10,
+        "image_width": 100,
+        "image_height": 100,
+        "camera": "MainCamera",
+    }
+    args.update(kwargs)
+
+    result = asyncio.run(pick_gameobject_from_image(SimpleNamespace(), **args))
+
+    assert result["success"] is False
+    assert message in result["message"]
+    assert "tool_name" not in mock_unity
+
+
+def test_pick_view_json_string_is_parsed(mock_unity):
+    result = asyncio.run(
+        pick_gameobject_from_image(
+            SimpleNamespace(),
+            image_x=10,
+            image_y=10,
+            image_width=100,
+            image_height=100,
+            pick_view='{"position":[0,0,-10],"rotation":[0,0,0],"projection":"perspective","fieldOfView":60}',
+        )
+    )
+
+    assert result["success"] is True
+    assert mock_unity["params"]["pickView"]["position"] == [0, 0, -10]
+
+
+def test_description_mentions_preconditions_and_unsupported_modes():
+    assert "Unity screenshots" in DESCRIPTION
+    assert "not arbitrary external images" in DESCRIPTION
+    assert "pick_view" in DESCRIPTION
+    assert "capture_source='scene_view'" in DESCRIPTION
+    assert "mesh-intersection" in DESCRIPTION
+    assert "without Colliders" in DESCRIPTION
+    assert "screenshot_multiview" in DESCRIPTION
+    assert "batch='surround'" in DESCRIPTION
+    assert "batch='orbit'" in DESCRIPTION
+    assert "UI GraphicRaycaster" in DESCRIPTION
+    assert "Renderer-only objects in non-Scene View" in DESCRIPTION

--- a/Server/tests/test_pick_gameobject_from_image.py
+++ b/Server/tests/test_pick_gameobject_from_image.py
@@ -153,6 +153,7 @@ def test_description_mentions_preconditions_and_unsupported_modes():
     assert "capture_source='scene_view'" in DESCRIPTION
     assert "mesh-intersection" in DESCRIPTION
     assert "without Colliders" in DESCRIPTION
+    assert "culling mask" in DESCRIPTION
     assert "screenshot_multiview" in DESCRIPTION
     assert "batch='surround'" in DESCRIPTION
     assert "batch='orbit'" in DESCRIPTION

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/PickGameObjectFromImageTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/PickGameObjectFromImageTests.cs
@@ -114,6 +114,32 @@ namespace MCPForUnityTests.Editor.Tools
         }
 
         [Test]
+        public void PickView_CullingMaskExcludesTargetWhenLayerMaskOmitted()
+        {
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            target.name = "PickTest_CullingMaskTarget";
+            target.transform.position = new Vector3(1400, 1400, 0);
+            target.layer = LayerMask.NameToLayer("Ignore Raycast");
+            Physics.SyncTransforms();
+
+            var pickView = PerspectivePickView(new Vector3(1400, 1400, -10));
+            pickView["cullingMask"] = 1 << LayerMask.NameToLayer("Default");
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["pickView"] = pickView,
+                ["dimension"] = "3d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsFalse(result["data"].Value<bool>("hit"), result.ToString());
+        }
+
+        [Test]
         public void Pick3D_ScaleCoordinatesMapBackToViewport()
         {
             var camera = CreatePerspectiveCamera("PickTest_ScaleCamera", new Vector3(1500, 1500, -10));
@@ -202,6 +228,54 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.IsNotNull(result["data"]["point"], result.ToString());
             Assert.IsNotNull(result["data"]["normal"], result.ToString());
             Assert.Greater(result["data"].Value<float>("distance"), 0f);
+        }
+
+        [Test]
+        public void SceneViewPickView_MeshIntersectionHitsSkinnedRendererWithoutCollider()
+        {
+            Mesh mesh = null;
+            try
+            {
+                var target = new GameObject("PickTest_SceneViewSkinnedRendererOnly");
+                target.transform.position = new Vector3(3060, 3060, 0);
+                mesh = new Mesh { hideFlags = HideFlags.HideAndDontSave };
+                mesh.vertices = new[]
+                {
+                    new Vector3(-1, -1, 0),
+                    new Vector3(1, -1, 0),
+                    new Vector3(-1, 1, 0),
+                    new Vector3(1, 1, 0),
+                };
+                mesh.triangles = new[] { 0, 2, 1, 2, 3, 1 };
+                mesh.RecalculateNormals();
+                mesh.RecalculateBounds();
+
+                var renderer = target.AddComponent<SkinnedMeshRenderer>();
+                renderer.sharedMesh = mesh;
+                renderer.localBounds = new Bounds(Vector3.zero, new Vector3(2, 2, 0.1f));
+                renderer.updateWhenOffscreen = true;
+
+                var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+                {
+                    ["imageX"] = 50,
+                    ["imageY"] = 50,
+                    ["imageWidth"] = 100,
+                    ["imageHeight"] = 100,
+                    ["pickView"] = PerspectivePickView(new Vector3(3060, 3060, -10), "scene_view"),
+                    ["dimension"] = "3d"
+                }));
+
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+                Assert.AreEqual("PickTest_SceneViewSkinnedRendererOnly", result["data"]["gameObject"]["name"].ToString());
+                Assert.AreEqual("mesh_intersection", result["data"]["sceneViewPickBackend"].ToString());
+                Assert.IsFalse(result["data"].Value<bool>("requiresCollider"));
+            }
+            finally
+            {
+                if (mesh != null)
+                    UnityEngine.Object.DestroyImmediate(mesh);
+            }
         }
 
         [Test]
@@ -324,6 +398,7 @@ namespace MCPForUnityTests.Editor.Tools
         public void Screenshot_WithExplicitCamera_ReturnsPickView()
         {
             var camera = CreatePerspectiveCamera("PickTest_ScreenshotCamera", new Vector3(2400, 2400, -10));
+            camera.cullingMask = 1 << LayerMask.NameToLayer("Default");
 
             var result = ToJObject(ManageScene.HandleCommand(new JObject
             {
@@ -338,6 +413,7 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.IsNotNull(pickView, result.ToString());
             Assert.AreEqual("game_view", pickView.Value<string>("captureSource"));
             Assert.AreEqual("perspective", pickView.Value<string>("projection"));
+            Assert.AreEqual(camera.cullingMask, pickView.Value<int>("cullingMask"));
             Assert.Greater(pickView.Value<int>("viewportWidth"), 0);
             Assert.Greater(pickView.Value<int>("viewportHeight"), 0);
         }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/PickGameObjectFromImageTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/PickGameObjectFromImageTests.cs
@@ -1,0 +1,452 @@
+using MCPForUnity.Editor.Tools;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using static MCPForUnityTests.Editor.TestUtilities;
+
+namespace MCPForUnityTests.Editor.Tools
+{
+    public class PickGameObjectFromImageTests
+    {
+        private const string TempRoot = "Assets/Temp/PickGameObjectFromImageTests";
+
+        [SetUp]
+        public void SetUp()
+        {
+            EnsureFolder(TempRoot);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PickGameObjectFromImage.SceneViewPickOverrideForTests = null;
+
+#if UNITY_2022_2_OR_NEWER
+            foreach (var go in UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None))
+#else
+            foreach (var go in UnityEngine.Object.FindObjectsOfType<GameObject>())
+#endif
+            {
+                if (go.name.StartsWith("PickTest_"))
+                    UnityEngine.Object.DestroyImmediate(go);
+            }
+
+            if (AssetDatabase.IsValidFolder(TempRoot))
+                AssetDatabase.DeleteAsset(TempRoot);
+            CleanupEmptyParentFolders(TempRoot);
+        }
+
+        [Test]
+        public void Pick3D_CameraCenterPixelHitsBoxCollider()
+        {
+            var camera = CreatePerspectiveCamera("PickTest_3DCamera", new Vector3(500, 500, -10));
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.name = "PickTest_3DTarget";
+            cube.transform.position = new Vector3(500, 500, 0);
+            Physics.SyncTransforms();
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["camera"] = camera.gameObject.name,
+                ["dimension"] = "3d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("PickTest_3DTarget", result["data"]["gameObject"]["name"].ToString());
+            Assert.AreEqual("BoxCollider", result["data"]["colliderType"].ToString());
+        }
+
+        [Test]
+        public void Pick2D_OrthographicCameraCenterPixelHitsCollider2D()
+        {
+            var camera = CreateOrthographicCamera("PickTest_2DCamera", new Vector3(900, 900, -10));
+            var target = new GameObject("PickTest_2DTarget");
+            target.transform.position = new Vector3(900, 900, 0);
+            target.AddComponent<BoxCollider2D>();
+            Physics2D.SyncTransforms();
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["camera"] = camera.gameObject.name,
+                ["dimension"] = "2d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("PickTest_2DTarget", result["data"]["gameObject"]["name"].ToString());
+            Assert.AreEqual("BoxCollider2D", result["data"]["colliderType"].ToString());
+        }
+
+        [Test]
+        public void PickView_TakesPriorityOverCurrentCameraState()
+        {
+            var camera = CreatePerspectiveCamera("PickTest_BadCamera", new Vector3(0, 0, -10));
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            target.name = "PickTest_PickViewTarget";
+            target.transform.position = new Vector3(1300, 1300, 0);
+            Physics.SyncTransforms();
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["camera"] = camera.gameObject.name,
+                ["pickView"] = PerspectivePickView(new Vector3(1300, 1300, -10)),
+                ["dimension"] = "3d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("pick_view", result["data"]["viewSource"].ToString());
+            Assert.AreEqual("PickTest_PickViewTarget", result["data"]["gameObject"]["name"].ToString());
+        }
+
+        [Test]
+        public void Pick3D_ScaleCoordinatesMapBackToViewport()
+        {
+            var camera = CreatePerspectiveCamera("PickTest_ScaleCamera", new Vector3(1500, 1500, -10));
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.name = "PickTest_ScaleTarget";
+            cube.transform.position = new Vector3(1500, 1500, 0);
+            Physics.SyncTransforms();
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 25,
+                ["imageY"] = 25,
+                ["imageWidth"] = 50,
+                ["imageHeight"] = 50,
+                ["scaleX"] = 2,
+                ["scaleY"] = 2,
+                ["viewportWidth"] = 100,
+                ["viewportHeight"] = 100,
+                ["camera"] = camera.gameObject.name,
+                ["dimension"] = "3d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("PickTest_ScaleTarget", result["data"]["gameObject"]["name"].ToString());
+        }
+
+        [Test]
+        public void SceneViewPickView_EditorPickHitsRendererWithoutCollider()
+        {
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            target.name = "PickTest_SceneViewRendererOnly";
+            UnityEngine.Object.DestroyImmediate(target.GetComponent<Collider>());
+            Vector2 observedPoint = Vector2.zero;
+            PickGameObjectFromImage.SceneViewPickOverrideForTests = point =>
+            {
+                observedPoint = point;
+                return new PickGameObjectFromImage.SceneViewPickResult(target, 0);
+            };
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["pickView"] = PerspectivePickView(new Vector3(3000, 3000, -10), "scene_view"),
+                ["dimension"] = "3d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("PickTest_SceneViewRendererOnly", result["data"]["gameObject"]["name"].ToString());
+            Assert.AreEqual("scene_view_editor_pick", result["data"]["pickMode"].ToString());
+            Assert.IsFalse(result["data"].Value<bool>("requiresCollider"));
+            Assert.AreEqual(0, result["data"].Value<int>("materialIndex"));
+            Assert.That(observedPoint.x, Is.EqualTo(0.5f).Within(0.0001f));
+            Assert.That(observedPoint.y, Is.EqualTo(0.5f).Within(0.0001f));
+        }
+
+        [Test]
+        public void SceneViewPickView_MeshIntersectionHitsRendererWithoutCollider()
+        {
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            target.name = "PickTest_SceneViewMeshRendererOnly";
+            target.transform.position = new Vector3(3050, 3050, 0);
+            UnityEngine.Object.DestroyImmediate(target.GetComponent<Collider>());
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["pickView"] = PerspectivePickView(new Vector3(3050, 3050, -10), "scene_view"),
+                ["dimension"] = "3d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("PickTest_SceneViewMeshRendererOnly", result["data"]["gameObject"]["name"].ToString());
+            Assert.AreEqual("scene_view_editor_pick", result["data"]["pickMode"].ToString());
+            Assert.AreEqual("mesh_intersection", result["data"]["sceneViewPickBackend"].ToString());
+            Assert.IsFalse(result["data"].Value<bool>("requiresCollider"));
+            Assert.AreEqual(-1, result["data"].Value<int>("materialIndex"));
+            Assert.IsNotNull(result["data"]["point"], result.ToString());
+            Assert.IsNotNull(result["data"]["normal"], result.ToString());
+            Assert.Greater(result["data"].Value<float>("distance"), 0f);
+        }
+
+        [Test]
+        public void SceneViewPickView_LayerMaskExcludesEditorPickAndFallsBackToNoHit()
+        {
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            target.name = "PickTest_SceneViewExcludedRendererOnly";
+            target.layer = LayerMask.NameToLayer("Default");
+            UnityEngine.Object.DestroyImmediate(target.GetComponent<Collider>());
+            PickGameObjectFromImage.SceneViewPickOverrideForTests = _ =>
+                new PickGameObjectFromImage.SceneViewPickResult(target, 0);
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["pickView"] = PerspectivePickView(new Vector3(3100, 3100, -10), "scene_view"),
+                ["dimension"] = "3d",
+                ["layerMask"] = "Ignore Raycast",
+                ["maxDistance"] = 20
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsFalse(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("physics_3d", result["data"]["pickMode"].ToString());
+            Assert.IsTrue(result["data"].Value<bool>("requiresCollider"));
+        }
+
+        [Test]
+        public void SceneViewPickView_EditorPickMissFallsBackTo3DRaycast()
+        {
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            target.name = "PickTest_SceneViewFallbackCollider";
+            target.transform.position = new Vector3(3200, 3200, 0);
+            Physics.SyncTransforms();
+            PickGameObjectFromImage.SceneViewPickOverrideForTests = _ =>
+                new PickGameObjectFromImage.SceneViewPickResult(null, -1);
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["pickView"] = PerspectivePickView(new Vector3(3200, 3200, -10), "scene_view"),
+                ["dimension"] = "3d"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"].Value<bool>("hit"), result.ToString());
+            Assert.AreEqual("PickTest_SceneViewFallbackCollider", result["data"]["gameObject"]["name"].ToString());
+            Assert.AreEqual("physics_3d", result["data"]["pickMode"].ToString());
+            Assert.IsTrue(result["data"].Value<bool>("requiresCollider"));
+            Assert.AreEqual("BoxCollider", result["data"]["colliderType"].ToString());
+        }
+
+        [Test]
+        public void Pick3D_NoHitReturnsSuccessfulFalseHit()
+        {
+            var camera = CreatePerspectiveCamera("PickTest_MissCamera", new Vector3(1800, 1800, -10));
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["camera"] = camera.gameObject.name,
+                ["dimension"] = "3d",
+                ["maxDistance"] = 20
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsFalse(result["data"].Value<bool>("hit"), result.ToString());
+        }
+
+        [Test]
+        public void Pick3D_LayerMaskExcludesTarget()
+        {
+            var camera = CreatePerspectiveCamera("PickTest_LayerCamera", new Vector3(2100, 2100, -10));
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.name = "PickTest_LayerTarget";
+            cube.transform.position = new Vector3(2100, 2100, 0);
+            cube.layer = LayerMask.NameToLayer("Default");
+            Physics.SyncTransforms();
+
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100,
+                ["camera"] = camera.gameObject.name,
+                ["dimension"] = "3d",
+                ["layerMask"] = "Ignore Raycast"
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsFalse(result["data"].Value<bool>("hit"), result.ToString());
+        }
+
+        [Test]
+        public void MissingPickViewAndCameraReturnsError()
+        {
+            var result = ToJObject(PickGameObjectFromImage.HandleCommand(new JObject
+            {
+                ["imageX"] = 50,
+                ["imageY"] = 50,
+                ["imageWidth"] = 100,
+                ["imageHeight"] = 100
+            }));
+
+            Assert.IsFalse(result.Value<bool>("success"));
+            Assert.That(result["error"].ToString(), Does.Contain("pick_view"));
+        }
+
+        [Test]
+        public void Screenshot_WithExplicitCamera_ReturnsPickView()
+        {
+            var camera = CreatePerspectiveCamera("PickTest_ScreenshotCamera", new Vector3(2400, 2400, -10));
+
+            var result = ToJObject(ManageScene.HandleCommand(new JObject
+            {
+                ["action"] = "screenshot",
+                ["camera"] = camera.gameObject.name,
+                ["fileName"] = "explicit-camera-pick-view",
+                ["outputFolder"] = TempRoot
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var pickView = result["data"]?["pickView"] as JObject;
+            Assert.IsNotNull(pickView, result.ToString());
+            Assert.AreEqual("game_view", pickView.Value<string>("captureSource"));
+            Assert.AreEqual("perspective", pickView.Value<string>("projection"));
+            Assert.Greater(pickView.Value<int>("viewportWidth"), 0);
+            Assert.Greater(pickView.Value<int>("viewportHeight"), 0);
+        }
+
+        [Test]
+        public void Screenshot_PositionedCapture_ReturnsPickView()
+        {
+            var result = ToJObject(ManageScene.HandleCommand(new JObject
+            {
+                ["action"] = "screenshot",
+                ["viewPosition"] = new JArray(2600, 2600, -10),
+                ["viewRotation"] = new JArray(0, 0, 0),
+                ["maxResolution"] = 64,
+                ["fileName"] = "positioned-pick-view",
+                ["outputFolder"] = TempRoot
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var pickView = result["data"]?["pickView"] as JObject;
+            Assert.IsNotNull(pickView, result.ToString());
+            Assert.AreEqual("game_view", pickView.Value<string>("captureSource"));
+            Assert.AreEqual("perspective", pickView.Value<string>("projection"));
+            Assert.Greater(pickView.Value<int>("viewportWidth"), 0);
+            Assert.Greater(pickView.Value<int>("viewportHeight"), 0);
+        }
+
+        [Test]
+        public void Screenshot_SceneView_ReturnsSceneViewPickView()
+        {
+            if (Application.isBatchMode)
+                Assert.Ignore("Scene View screenshot requires a non-batch Unity Editor window.");
+
+            var sceneView = SceneView.lastActiveSceneView ?? EditorWindow.GetWindow<SceneView>();
+            if (sceneView == null)
+                Assert.Ignore("No Scene View window is available.");
+
+            var result = ToJObject(ManageScene.HandleCommand(new JObject
+            {
+                ["action"] = "screenshot",
+                ["captureSource"] = "scene_view",
+                ["fileName"] = "scene-view-pick-view",
+                ["outputFolder"] = TempRoot
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("scene_view", result["data"].Value<string>("captureSource"));
+            var pickView = result["data"]?["pickView"] as JObject;
+            Assert.IsNotNull(pickView, result.ToString());
+            Assert.AreEqual("scene_view", pickView.Value<string>("captureSource"));
+            Assert.Greater(pickView.Value<int>("viewportWidth"), 0);
+            Assert.Greater(pickView.Value<int>("viewportHeight"), 0);
+        }
+
+        [Test]
+        public void Screenshot_MultiviewDoesNotReturnSinglePickView()
+        {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.name = "PickTest_MultiviewRenderer";
+            cube.transform.position = new Vector3(2800, 2800, 0);
+
+            var result = ToJObject(ManageScene.HandleCommand(new JObject
+            {
+                ["action"] = "screenshot",
+                ["batch"] = "surround",
+                ["maxResolution"] = 32,
+                ["outputFolder"] = TempRoot
+            }));
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsNull(result["data"]?["pickView"], result.ToString());
+            Assert.IsNotNull(result["data"]?["shots"], result.ToString());
+        }
+
+        private static Camera CreatePerspectiveCamera(string name, Vector3 position)
+        {
+            var go = new GameObject(name);
+            var camera = go.AddComponent<Camera>();
+            camera.transform.position = position;
+            camera.transform.rotation = Quaternion.identity;
+            camera.fieldOfView = 60f;
+            camera.nearClipPlane = 0.1f;
+            camera.farClipPlane = 1000f;
+            camera.aspect = 1f;
+            return camera;
+        }
+
+        private static Camera CreateOrthographicCamera(string name, Vector3 position)
+        {
+            var camera = CreatePerspectiveCamera(name, position);
+            camera.orthographic = true;
+            camera.orthographicSize = 5f;
+            return camera;
+        }
+
+        private static JObject PerspectivePickView(Vector3 position, string captureSource = "game_view")
+        {
+            return new JObject
+            {
+                ["captureSource"] = captureSource,
+                ["position"] = new JArray(position.x, position.y, position.z),
+                ["rotation"] = new JArray(0, 0, 0),
+                ["projection"] = "perspective",
+                ["fieldOfView"] = 60,
+                ["nearClipPlane"] = 0.1,
+                ["farClipPlane"] = 1000,
+                ["aspect"] = 1,
+                ["viewportWidth"] = 100,
+                ["viewportHeight"] = 100
+            };
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/PickGameObjectFromImageTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/PickGameObjectFromImageTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d82440f94d146b994bb81d138ff1387
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `pick_gameobject_from_image` MCP tool and Unity handler for reverse-picking GameObjects from supported Unity screenshot coordinates
- attach `pickView` metadata to explicit camera, positioned, and Scene View screenshots
- add `unity-mcp camera pick` CLI command and tests

## Details
- supports 3D Physics raycasts, 2D Collider2D ray intersections, and Scene View editor/mesh picking without Colliders for visible MeshRenderer/SkinnedMeshRenderer objects
- documents preconditions and unsupported screenshot modes directly in the tool description
- returns ray/image/viewport metadata plus hit GameObject summaries and hit details where available

## Tests
- `python -m pytest tests/test_pick_gameobject_from_image.py tests/test_cli.py::TestCameraCommands -v`
- `uv run --extra dev pytest tests/ -q` (1242 passed)
- Tuanjie EditMode `MCPForUnityTests.Editor.Tools.PickGameObjectFromImageTests` (15 total, 14 passed, 0 failed, 1 skipped: Scene View screenshot skipped in batchmode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added screenshot-based GameObject picking supporting both 2D and 3D physics with Scene View compatibility.
  * Introduced `unity-mcp camera pick` to select GameObjects from screenshot pixel coordinates.
  * Scene View and positioned/explicit screenshots can now return optional `pickView` metadata (multiview returns `shots` instead of a single `pickView`) for accurate coordinate mapping.
  * Picking supports layer masking, max-distance filtering, and configurable trigger interaction.
* **Tests**
  * Added CLI and Unity EditMode test coverage for picking and `pickView` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->