### PR TITLE
Fix Codex config detection scope

### DIFF
--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -436,138 +436,44 @@ namespace MCPForUnity.Editor.Clients
     {
         public CodexMcpConfigurator(McpClient client) : base(client) { }
 
-        public override string GetConfigPath() => CurrentOsPath();
+        public override string GetConfigPath() => GetPreferredWriteConfigPath();
 
-        public override bool IsInstalled => ParentDirectoryExists(GetConfigPath());
+        public override bool IsInstalled
+        {
+            get
+            {
+                foreach (var path in GetCandidateConfigPaths())
+                {
+                    if (ParentDirectoryExists(path)) return true;
+                }
+                return false;
+            }
+        }
 
         public override McpStatus CheckStatus(bool attemptAutoRewrite = true)
         {
             try
             {
-                string path = GetConfigPath();
-                if (!File.Exists(path))
+                bool sawConfigFile = false;
+                foreach (string path in GetCandidateConfigPaths())
                 {
-                    client.SetStatus(McpStatus.NotConfigured);
-                    client.configuredTransport = Models.ConfiguredTransport.Unknown;
-                    return client.status;
+                    if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                    {
+                        continue;
+                    }
+
+                    sawConfigFile = true;
+                    string toml = File.ReadAllText(path);
+                    if (!CodexConfigHelper.TryParseCodexServer(toml, out _, out var args, out var url))
+                    {
+                        continue;
+                    }
+
+                    return CheckParsedCodexServer(path, args, url, attemptAutoRewrite);
                 }
 
-                string toml = File.ReadAllText(path);
-                if (CodexConfigHelper.TryParseCodexServer(toml, out _, out var args, out var url))
-                {
-                    // Determine and set the configured transport type
-                    if (!string.IsNullOrEmpty(url))
-                    {
-                        // Distinguish HTTP Local from HTTP Remote
-                        string remoteRpcUrl = HttpEndpointUtility.GetRemoteMcpRpcUrl();
-                        if (!string.IsNullOrEmpty(remoteRpcUrl) && UrlsEqual(url, remoteRpcUrl))
-                        {
-                            client.configuredTransport = Models.ConfiguredTransport.HttpRemote;
-                        }
-                        else
-                        {
-                            client.configuredTransport = Models.ConfiguredTransport.Http;
-                        }
-                    }
-                    else if (args != null && args.Length > 0)
-                    {
-                        client.configuredTransport = Models.ConfiguredTransport.Stdio;
-                    }
-                    else
-                    {
-                        client.configuredTransport = Models.ConfiguredTransport.Unknown;
-                    }
-
-                    bool matches = false;
-                    bool hasVersionMismatch = false;
-                    string mismatchReason = null;
-
-                    if (!string.IsNullOrEmpty(url))
-                    {
-                        // Match against the active scope's URL
-                        matches = UrlsEqual(url, HttpEndpointUtility.GetMcpRpcUrl());
-                    }
-                    else if (args != null && args.Length > 0)
-                    {
-                        // Use beta-aware expected package source for comparison
-                        string expected = GetExpectedPackageSourceForValidation();
-                        string configured = McpConfigurationHelper.ExtractUvxUrl(args);
-
-                        if (!string.IsNullOrEmpty(configured) && !string.IsNullOrEmpty(expected))
-                        {
-                            if (McpConfigurationHelper.PathsEqual(configured, expected))
-                            {
-                                matches = true;
-                            }
-                            else
-                            {
-                                // Check for beta/stable mismatch
-                                bool configuredIsBeta = IsBetaPackageSource(configured);
-                                bool expectedIsBeta = IsBetaPackageSource(expected);
-
-                                if (configuredIsBeta && !expectedIsBeta)
-                                {
-                                    hasVersionMismatch = true;
-                                    mismatchReason = "Configured for prerelease server, but this package is stable. Re-configure to switch to stable.";
-                                }
-                                else if (!configuredIsBeta && expectedIsBeta)
-                                {
-                                    hasVersionMismatch = true;
-                                    mismatchReason = "Configured for stable server, but this package is prerelease. Re-configure to switch to prerelease.";
-                                }
-                                else
-                                {
-                                    hasVersionMismatch = true;
-                                    mismatchReason = "Server version doesn't match the plugin. Re-configure to update.";
-                                }
-                            }
-                        }
-                    }
-
-                    if (matches)
-                    {
-                        client.SetStatus(McpStatus.Configured);
-                        return client.status;
-                    }
-
-                    if (hasVersionMismatch)
-                    {
-                        if (attemptAutoRewrite)
-                        {
-                            string result = McpConfigurationHelper.ConfigureCodexClient(path, client);
-                            if (result == "Configured successfully")
-                            {
-                                client.SetStatus(McpStatus.Configured);
-                                client.configuredTransport = HttpEndpointUtility.GetCurrentServerTransport();
-                                return client.status;
-                            }
-                        }
-                        client.SetStatus(McpStatus.VersionMismatch, mismatchReason);
-                        return client.status;
-                    }
-                }
-                else
-                {
-                    client.configuredTransport = Models.ConfiguredTransport.Unknown;
-                }
-
-                if (attemptAutoRewrite)
-                {
-                    string result = McpConfigurationHelper.ConfigureCodexClient(path, client);
-                    if (result == "Configured successfully")
-                    {
-                        client.SetStatus(McpStatus.Configured);
-                        client.configuredTransport = HttpEndpointUtility.GetCurrentServerTransport();
-                    }
-                    else
-                    {
-                        client.SetStatus(McpStatus.IncorrectPath);
-                    }
-                }
-                else
-                {
-                    client.SetStatus(McpStatus.IncorrectPath);
-                }
+                client.SetStatus(sawConfigFile ? McpStatus.MissingConfig : McpStatus.NotConfigured);
+                client.configuredTransport = Models.ConfiguredTransport.Unknown;
             }
             catch (Exception ex)
             {
@@ -578,9 +484,112 @@ namespace MCPForUnity.Editor.Clients
             return client.status;
         }
 
+        private McpStatus CheckParsedCodexServer(string path, string[] args, string url, bool attemptAutoRewrite)
+        {
+            if (!string.IsNullOrEmpty(url))
+            {
+                string remoteRpcUrl = HttpEndpointUtility.GetRemoteMcpRpcUrl();
+                client.configuredTransport =
+                    !string.IsNullOrEmpty(remoteRpcUrl) && UrlsEqual(url, remoteRpcUrl)
+                        ? Models.ConfiguredTransport.HttpRemote
+                        : Models.ConfiguredTransport.Http;
+            }
+            else if (args != null && args.Length > 0)
+            {
+                client.configuredTransport = Models.ConfiguredTransport.Stdio;
+            }
+            else
+            {
+                client.configuredTransport = Models.ConfiguredTransport.Unknown;
+            }
+
+            bool matches = false;
+            bool hasVersionMismatch = false;
+            string mismatchReason = null;
+
+            if (!string.IsNullOrEmpty(url))
+            {
+                matches = UrlsEqual(url, HttpEndpointUtility.GetMcpRpcUrl());
+            }
+            else if (args != null && args.Length > 0)
+            {
+                string expected = GetExpectedPackageSourceForValidation();
+                string configured = McpConfigurationHelper.ExtractUvxUrl(args);
+
+                if (!string.IsNullOrEmpty(configured) && !string.IsNullOrEmpty(expected))
+                {
+                    if (McpConfigurationHelper.PathsEqual(configured, expected))
+                    {
+                        matches = true;
+                    }
+                    else
+                    {
+                        bool configuredIsBeta = IsBetaPackageSource(configured);
+                        bool expectedIsBeta = IsBetaPackageSource(expected);
+
+                        hasVersionMismatch = true;
+                        if (configuredIsBeta && !expectedIsBeta)
+                        {
+                            mismatchReason = "Configured for prerelease server, but this package is stable. Re-configure to switch to stable.";
+                        }
+                        else if (!configuredIsBeta && expectedIsBeta)
+                        {
+                            mismatchReason = "Configured for stable server, but this package is prerelease. Re-configure to switch to prerelease.";
+                        }
+                        else
+                        {
+                            mismatchReason = "Server version doesn't match the plugin. Re-configure to update.";
+                        }
+                    }
+                }
+            }
+
+            if (matches)
+            {
+                client.SetStatus(McpStatus.Configured);
+                return client.status;
+            }
+
+            if (hasVersionMismatch)
+            {
+                if (attemptAutoRewrite)
+                {
+                    string result = McpConfigurationHelper.ConfigureCodexClient(path, client);
+                    if (result == "Configured successfully")
+                    {
+                        client.SetStatus(McpStatus.Configured);
+                        client.configuredTransport = HttpEndpointUtility.GetCurrentServerTransport();
+                        return client.status;
+                    }
+                }
+                client.SetStatus(McpStatus.VersionMismatch, mismatchReason);
+                return client.status;
+            }
+
+            if (attemptAutoRewrite)
+            {
+                string result = McpConfigurationHelper.ConfigureCodexClient(path, client);
+                if (result == "Configured successfully")
+                {
+                    client.SetStatus(McpStatus.Configured);
+                    client.configuredTransport = HttpEndpointUtility.GetCurrentServerTransport();
+                }
+                else
+                {
+                    client.SetStatus(McpStatus.IncorrectPath);
+                }
+            }
+            else
+            {
+                client.SetStatus(McpStatus.IncorrectPath);
+            }
+
+            return client.status;
+        }
+
         public override void Configure()
         {
-            string path = GetConfigPath();
+            string path = GetPreferredWriteConfigPath();
             McpConfigurationHelper.EnsureConfigDirectoryExists(path);
             string result = McpConfigurationHelper.ConfigureCodexClient(path, client);
             if (result == "Configured successfully")
@@ -591,6 +600,34 @@ namespace MCPForUnity.Editor.Clients
             else
             {
                 throw new InvalidOperationException(result);
+            }
+        }
+
+        public override void Unregister()
+        {
+            try
+            {
+                foreach (string path in GetCandidateConfigPaths())
+                {
+                    if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                    {
+                        continue;
+                    }
+
+                    string toml = File.ReadAllText(path);
+                    string updatedToml = CodexConfigHelper.RemoveCodexServerBlock(toml, out bool removed);
+                    if (removed)
+                    {
+                        File.WriteAllText(path, updatedToml);
+                    }
+                }
+
+                client.SetStatus(McpStatus.NotConfigured);
+                client.configuredTransport = Models.ConfiguredTransport.Unknown;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to unregister: {ex.Message}", ex);
             }
         }
 
@@ -613,6 +650,55 @@ namespace MCPForUnity.Editor.Clients
             "Paste the TOML",
             "Save and restart Codex"
         };
+
+        protected virtual string GetProjectConfigPath()
+        {
+            string projectDir = GetClientProjectDir();
+            return string.IsNullOrEmpty(projectDir)
+                ? null
+                : Path.Combine(projectDir, ".codex", "config.toml");
+        }
+
+        private string GetUserConfigPath() => CurrentOsPath();
+
+        private string GetPreferredWriteConfigPath()
+        {
+            string projectPath = GetProjectConfigPath();
+            return string.IsNullOrEmpty(projectPath) ? GetUserConfigPath() : projectPath;
+        }
+
+        private IEnumerable<string> GetCandidateConfigPaths()
+        {
+            string projectPath = GetProjectConfigPath();
+            string userPath = GetUserConfigPath();
+
+            if (!string.IsNullOrEmpty(projectPath)) yield return projectPath;
+            if (!string.IsNullOrEmpty(userPath) && !PathsEqual(projectPath, userPath)) yield return userPath;
+        }
+
+        private static bool PathsEqual(string a, string b)
+        {
+            if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return false;
+            try
+            {
+                return string.Equals(
+                    Path.GetFullPath(a).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                    Path.GetFullPath(b).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private static string GetClientProjectDir()
+        {
+            string overrideDir = EditorPrefs.GetString(EditorPrefKeys.ClientProjectDirOverride, string.Empty);
+            if (!string.IsNullOrEmpty(overrideDir) && Directory.Exists(overrideDir))
+                return overrideDir;
+            return Path.GetDirectoryName(Application.dataPath);
+        }
     }
 
     /// <summary>CLI-based configurator (Claude Code).</summary>

--- a/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
+++ b/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
@@ -111,6 +111,29 @@ namespace MCPForUnity.Editor.Helpers
             return writer.ToString();
         }
 
+        public static string RemoveCodexServerBlock(string existingToml, out bool removed)
+        {
+            removed = false;
+            var root = TryParseToml(existingToml);
+            if (root == null) return existingToml;
+
+            if (TryGetTable(root, "mcp_servers", out var snakeCaseServers))
+            {
+                removed |= RemoveUnityMcpServer(snakeCaseServers);
+            }
+
+            if (TryGetTable(root, "mcpServers", out var camelCaseServers))
+            {
+                removed |= RemoveUnityMcpServer(camelCaseServers);
+            }
+
+            if (!removed) return existingToml;
+
+            using var writer = new StringWriter();
+            root.WriteTo(writer);
+            return writer.ToString();
+        }
+
         public static bool TryParseCodexServer(string toml, out string command, out string[] args)
         {
             return TryParseCodexServer(toml, out command, out args, out _);
@@ -270,6 +293,18 @@ namespace MCPForUnity.Editor.Helpers
             }
 
             return false;
+        }
+
+        private static bool RemoveUnityMcpServer(TomlTable servers)
+        {
+            if (servers == null) return false;
+
+            string key = servers.Keys.FirstOrDefault(k =>
+                string.Equals(k, "unityMCP", StringComparison.OrdinalIgnoreCase));
+            if (string.IsNullOrEmpty(key)) return false;
+
+            servers.Delete(key);
+            return true;
         }
 
         private static string GetTomlString(TomlTable table, string key)

--- a/MCPForUnity/Editor/Services/StartupConfigRewrite.cs
+++ b/MCPForUnity/Editor/Services/StartupConfigRewrite.cs
@@ -9,10 +9,8 @@ using UnityEditor;
 namespace MCPForUnity.Editor.Services
 {
     /// <summary>
-    /// Once per Editor session, sweeps registered configurators and re-runs CheckStatus(attemptAutoRewrite: true)
-    /// for any installed client that already has a config on disk. Catches the case where the user updated the
-    /// MCP for Unity package while the Editor was closed — without this sweep, stale package versions in client
-    /// configs would persist until the user opens the MCP window.
+    /// Once per Editor session, sweeps registered configurators and refreshes existing UnityMCP entries that
+    /// drifted while the Editor was closed. Missing registrations stay user-driven through Configure buttons.
     /// </summary>
     [InitializeOnLoad]
     public static class StartupConfigRewrite
@@ -43,10 +41,14 @@ namespace MCPForUnity.Editor.Services
                 try
                 {
                     if (!c.IsInstalled) continue;
-                    // Always let CheckStatus read the current state from disk before deciding —
+                    // Always let CheckStatus read the current state from disk before deciding.
                     // the in-memory Status can be NotConfigured on a fresh editor load even
                     // though the file already has a valid config.
                     var before = c.Status;
+                    var current = c.CheckStatus(attemptAutoRewrite: false);
+                    if (current != McpStatus.VersionMismatch && current != McpStatus.IncorrectPath)
+                        continue;
+
                     var after = c.CheckStatus(attemptAutoRewrite: true);
                     if (before != after && after == McpStatus.Configured) rewrote++;
                 }


### PR DESCRIPTION
## Summary
- Check Codex project config before user config.
- Avoid auto-writing Codex MCP config when UnityMCP is missing.
- Add Codex TOML removal support for unregister.

## Test Plan
- git diff --check HEAD
- Unity EditMode tests not run locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to unregister Codex clients from configuration
  * Expanded configuration to support both project-level and user-level locations

* **Improvements**
  * Enhanced configuration status detection and verification logic
  * Optimized startup rewrite process to activate only when necessary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->