### PR TITLE
fix(stdio): recover from a reload-orphaned socket instead of hanging

### DIFF
--- a/Server/src/core/config.py
+++ b/Server/src/core/config.py
@@ -32,6 +32,8 @@ class ServerConfig:
 
     # Connection settings
     connection_timeout: float = 30.0
+    # Hard ceiling on a command's total time across all retries (wedged-socket guard).
+    command_total_timeout: float = 90.0
     buffer_size: int = 16 * 1024 * 1024  # 16MB buffer
 
     # STDIO framing behaviour

--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -50,7 +50,7 @@ class UnityConnection:
         except OSError as exc:
             logger.debug(f"Unable to set TCP_NODELAY: {exc}")
 
-    def connect(self) -> bool:
+    def connect(self, connect_timeout: float | None = None) -> bool:
         """Establish a connection to the Unity Editor."""
         if self.sock:
             return True
@@ -59,8 +59,9 @@ class UnityConnection:
                 return True
             try:
                 # Bounded connect to avoid indefinite blocking
-                connect_timeout = float(
-                    getattr(config, "connection_timeout", 1.0))
+                if connect_timeout is None:
+                    connect_timeout = float(
+                        getattr(config, "connection_timeout", 1.0))
                 # We trust config.unity_host (default 127.0.0.1) but future improvements
                 # could dynamically prefer 'localhost' depending on OS resolver behavior.
                 self.sock = socket.create_connection(
@@ -265,7 +266,13 @@ class UnityConnection:
             logger.error(f"Error during receive: {str(e)}")
             raise
 
-    def send_command(self, command_type: str, params: dict[str, Any] = None, max_attempts: int | None = None, deadline: float | None = None) -> dict[str, Any]:
+    def _cap_to_deadline(self, timeout: float, deadline: float | None, floor: float = 0.05) -> float:
+        """Shrink a blocking timeout to whatever budget remains before the deadline."""
+        if deadline is None:
+            return timeout
+        return max(floor, min(timeout, deadline - time.monotonic()))
+
+    def send_command(self, command_type: str, params: dict[str, Any] | None = None, max_attempts: int | None = None, deadline: float | None = None) -> dict[str, Any]:
         """Send a command with retry/backoff and port rediscovery. Pings only when requested.
 
         Args:
@@ -320,8 +327,6 @@ class UnityConnection:
                 logger.debug(f"Preflight status check failed: {exc}")
                 return None
 
-        last_short_timeout = None
-
         # Extract hash suffix from instance id (e.g., Project@hash)
         target_hash: str | None = None
         if self.instance_id and '@' in self.instance_id:
@@ -356,7 +361,7 @@ class UnityConnection:
                 self._ensure_live_connection()
                 # Ensure connected (handshake occurs within connect())
                 t_conn_start = time.time()
-                if not self.sock and not self.connect():
+                if not self.sock and not self.connect(self._cap_to_deadline(config.connection_timeout, deadline)):
                     raise ConnectionError("Could not connect to Unity")
                 logger.info("[TIMING-STDIO] connect took %.3fs command=%s", time.time() - t_conn_start, command_type)
 
@@ -384,11 +389,17 @@ class UnityConnection:
                         self.sock.sendall(payload)
                     logger.info("[TIMING-STDIO] sendall took %.3fs command=%s", time.time() - t_send_start, command_type)
 
-                    # During retry bursts use a short receive timeout and ensure restoration
+                    # Cap the receive timeout to the remaining command budget (and use a
+                    # short timeout during retry bursts) so a wedged socket can't block
+                    # past the deadline.
                     restore_timeout = None
-                    if attempt > 0 and last_short_timeout is None:
+                    recv_timeout = 1.0 if attempt > 0 else self.sock.gettimeout()
+                    if deadline is not None:
+                        recv_timeout = self._cap_to_deadline(
+                            recv_timeout or config.connection_timeout, deadline)
+                    if recv_timeout is not None and recv_timeout != self.sock.gettimeout():
                         restore_timeout = self.sock.gettimeout()
-                        self.sock.settimeout(1.0)
+                        self.sock.settimeout(recv_timeout)
                     try:
                         t_recv_start = time.time()
                         response_data = self.receive_full_response(self.sock)
@@ -399,7 +410,6 @@ class UnityConnection:
                     finally:
                         if restore_timeout is not None:
                             self.sock.settimeout(restore_timeout)
-                            last_short_timeout = None
 
                 # Parse
                 if command_type == 'ping':
@@ -482,6 +492,7 @@ class UnityConnection:
                         cap = 3.0
 
                     sleep_s = min(cap, jitter * (2 ** attempt))
+                    sleep_s = self._cap_to_deadline(sleep_s, deadline, floor=0.0)
                     time.sleep(sleep_s)
                     continue
                 raise

--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -130,12 +130,13 @@ class UnityConnection:
                 self.sock = None
 
     def _ensure_live_connection(self) -> None:
-        """Detect and discard stale (peer-closed) sockets before sending.
+        """Detect and discard cleanly-closed sockets before sending.
 
-        After domain reload Unity closes all TCP connections. The Python side
-        may still hold a reference to the dead socket. A non-blocking peek
-        detects this so send_command can reconnect instead of writing to a dead
-        socket and getting 'Connection closed before reading expected bytes'.
+        A graceful domain reload closes the bridge's TCP connections (FIN), so a
+        non-blocking peek sees EOF and lets send_command reconnect instead of
+        writing to a dead socket. A half-open socket left without a FIN is not
+        caught here; that case is bounded by the per-command deadline and the
+        reloading-status preflight.
         """
         if not self.sock:
             return
@@ -338,8 +339,8 @@ class UnityConnection:
         try:
             status = read_status_file(target_hash)
             if status and (status.get('reloading') or status.get('reason') == 'reloading'):
-                # Reload invalidates the socket; drop it under the I/O lock so we never
-                # close it under a concurrent send/recv, then reconnect on the next call.
+                # Reload invalidates the socket; drop it under the I/O lock so this
+                # close is serialized against the send/recv block, then reconnect next call.
                 with self._io_lock:
                     self.disconnect()
                 return MCPResponse(
@@ -352,6 +353,9 @@ class UnityConnection:
 
         for attempt in range(attempts + 1):
             if deadline is not None and time.monotonic() >= deadline:
+                logger.warning(
+                    "Command '%s' exceeded total deadline of %.1fs after %d attempt(s); giving up",
+                    command_type, total_timeout, attempt)
                 raise TimeoutError(
                     f"Command '{command_type}' exceeded total deadline of "
                     f"{total_timeout:.1f}s (connection wedged or Unity unresponsive)")

--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -265,13 +265,14 @@ class UnityConnection:
             logger.error(f"Error during receive: {str(e)}")
             raise
 
-    def send_command(self, command_type: str, params: dict[str, Any] = None, max_attempts: int | None = None) -> dict[str, Any]:
+    def send_command(self, command_type: str, params: dict[str, Any] = None, max_attempts: int | None = None, deadline: float | None = None) -> dict[str, Any]:
         """Send a command with retry/backoff and port rediscovery. Pings only when requested.
 
         Args:
             command_type: The Unity command to send
             params: Command parameters
             max_attempts: Maximum retry attempts (None = use config default, 0 = no retries)
+            deadline: Shared monotonic() ceiling across retries (None = derive from command_total_timeout)
         """
         # Defensive guard: catch empty/placeholder invocations early
         if not command_type:
@@ -281,6 +282,11 @@ class UnityConnection:
         attempts = max(config.max_retries,
                        5) if max_attempts is None else max_attempts
         base_backoff = max(0.5, config.retry_delay)
+
+        # Cap total time across all retries so a wedged socket can't block unbounded.
+        total_timeout = max(0.0, float(getattr(config, "command_total_timeout", 90.0)))
+        if deadline is None and total_timeout > 0:
+            deadline = time.monotonic() + total_timeout
 
         def read_status_file(target_hash: str | None = None) -> dict | None:
             try:
@@ -327,6 +333,10 @@ class UnityConnection:
         try:
             status = read_status_file(target_hash)
             if status and (status.get('reloading') or status.get('reason') == 'reloading'):
+                # Reload invalidates the socket; drop it under the I/O lock so we never
+                # close it under a concurrent send/recv, then reconnect on the next call.
+                with self._io_lock:
+                    self.disconnect()
                 return MCPResponse(
                     success=False,
                     error="Unity is reloading; please retry",
@@ -336,6 +346,10 @@ class UnityConnection:
             logger.debug(f"Preflight status check failed: {exc}")
 
         for attempt in range(attempts + 1):
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Command '{command_type}' exceeded total deadline of "
+                    f"{total_timeout:.1f}s (connection wedged or Unity unresponsive)")
             try:
                 # Discard stale sockets left over from a previous domain reload
                 # so we reconnect instead of writing to a dead connection.
@@ -834,16 +848,19 @@ def send_command_with_retry(
     # Clamp to [0, 20] to prevent misconfiguration from causing excessive waits
     max_wait_s = max(0.0, min(max_wait_s, 20.0))
 
+    total_timeout = max(0.0, float(getattr(config, "command_total_timeout", 90.0)))
+    deadline = time.monotonic() + total_timeout if total_timeout > 0 else None
+
     # If retry_on_reload=False, disable connection-level retries too (issue #577)
     # Commands that trigger compilation/reload shouldn't retry on disconnect
     send_max_attempts = None if retry_on_reload else 0
 
     response = conn.send_command(
-        command_type, params, max_attempts=send_max_attempts)
+        command_type, params, max_attempts=send_max_attempts, deadline=deadline)
     retries = 0
     wait_started = None
     reason = _extract_response_reason(response)
-    while retry_on_reload and _is_reloading_response(response) and retries < max_retries:
+    while retry_on_reload and _is_reloading_response(response) and retries < max_retries and (deadline is None or time.monotonic() < deadline):
         if wait_started is None:
             wait_started = time.monotonic()
             logger.debug(
@@ -876,7 +893,7 @@ def send_command_with_retry(
         )
         time.sleep(max(0.0, sleep_ms / 1000.0))
         retries += 1
-        response = conn.send_command(command_type, params)
+        response = conn.send_command(command_type, params, deadline=deadline)
         reason = _extract_response_reason(response)
 
     if wait_started is not None:

--- a/Server/tests/integration/test_connection_deadline.py
+++ b/Server/tests/integration/test_connection_deadline.py
@@ -74,8 +74,11 @@ def silent_bridge(monkeypatch, tmp_path):
                 pass
 
 
-def test_send_command_against_wedged_socket_is_bounded(silent_bridge):
-    """send_command on a silent socket hits the deadline instead of stacking retries."""
+def test_send_command_against_wedged_socket_is_bounded(silent_bridge, monkeypatch):
+    """A connection_timeout longer than the total budget must not let a single blocking
+    recv overrun the ceiling: the deadline caps each recv, so the call still stops near
+    command_total_timeout rather than connection_timeout."""
+    monkeypatch.setattr(config, "connection_timeout", 5.0)
     conn = UnityConnection(port=silent_bridge, instance_id="Repro@deadbeef")
     start = time.monotonic()
     with pytest.raises(TimeoutError, match="exceeded total deadline"):

--- a/Server/tests/integration/test_connection_deadline.py
+++ b/Server/tests/integration/test_connection_deadline.py
@@ -1,0 +1,107 @@
+"""Connection resilience when a domain reload leaves the Unity socket half-open."""
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from core.config import config
+import transport.legacy.unity_connection as uc
+from transport.legacy.unity_connection import UnityConnection
+
+
+def _start_silent_bridge():
+    """Accept and handshake, then never answer (a wedged half-open bridge)."""
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(8)
+    port = srv.getsockname()[1]
+    accepted: list[socket.socket] = []
+    stop = threading.Event()
+
+    def serve():
+        srv.settimeout(0.5)
+        while not stop.is_set():
+            try:
+                client, _ = srv.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            accepted.append(client)
+            try:
+                client.sendall(b"WELCOME UNITY-MCP 1 FRAMING=1\n")
+            except OSError:
+                pass
+
+    threading.Thread(target=serve, daemon=True).start()
+    return srv, port, stop, accepted
+
+
+def _write_reloading_status(tmp_path):
+    status_dir = Path(tmp_path) / ".unity-mcp"
+    status_dir.mkdir(parents=True, exist_ok=True)
+    (status_dir / "unity-mcp-status-deadbeef.json").write_text(
+        json.dumps({"reloading": True, "reason": "reloading", "project_path": "x"})
+    )
+
+
+@pytest.fixture
+def silent_bridge(monkeypatch, tmp_path):
+    srv, port, stop, accepted = _start_silent_bridge()
+    monkeypatch.setattr(uc.Path, "home", lambda: Path(tmp_path))
+    monkeypatch.setattr(uc.stdio_port_registry, "get_port", lambda instance_id=None: port)
+    monkeypatch.setattr(uc.stdio_port_registry, "get_instance", lambda instance_id: None)
+    monkeypatch.setattr(config, "connection_timeout", 1.0)
+    monkeypatch.setattr(config, "command_total_timeout", 2.0, raising=False)
+    try:
+        yield port
+    finally:
+        stop.set()
+        try:
+            srv.close()
+        except OSError:
+            pass
+        for client in accepted:
+            try:
+                client.close()
+            except OSError:
+                pass
+
+
+def test_send_command_against_wedged_socket_is_bounded(silent_bridge):
+    """send_command on a silent socket hits the deadline instead of stacking retries."""
+    conn = UnityConnection(port=silent_bridge, instance_id="Repro@deadbeef")
+    start = time.monotonic()
+    with pytest.raises(TimeoutError, match="exceeded total deadline"):
+        conn.send_command("get_editor_state", {})
+    assert time.monotonic() - start < 4.0
+
+
+def test_send_command_with_retry_is_bounded_by_deadline(silent_bridge, tmp_path, monkeypatch):
+    """The reload-wait loop honours command_total_timeout, not just max_wait_s."""
+    conn = UnityConnection(port=silent_bridge, instance_id="Repro@deadbeef")
+    monkeypatch.setattr(uc, "get_unity_connection", lambda instance_id=None: conn)
+    _write_reloading_status(tmp_path)
+
+    start = time.monotonic()
+    resp = uc.send_command_with_retry("get_editor_state", {}, instance_id="Repro@deadbeef")
+    assert time.monotonic() - start < 6.0
+    assert uc._extract_response_reason(resp) == "reloading"
+
+
+def test_reload_signal_drops_socket_for_fresh_reconnect(silent_bridge, tmp_path):
+    """A 'reloading' status drops the socket so the next command reconnects."""
+    conn = UnityConnection(port=silent_bridge, instance_id="Repro@deadbeef")
+    assert conn.connect() is True
+    assert conn.sock is not None
+    _write_reloading_status(tmp_path)
+
+    response = conn.send_command("get_editor_state", {})
+    assert conn.sock is None
+    assert uc._extract_response_reason(response) == "reloading"


### PR DESCRIPTION
## Description
Every script recompile makes Unity do a domain reload, which tears down and rebuilds the bridge. The Unity process itself keeps running, so the OS never resets the old loopback connection, and the Python client is left holding a socket that still looks connected but is actually dead. The old code kept reusing that socket: each recv waited the full connection_timeout, and those waits piled up across retries with no overall limit, so a tool call could hang for several minutes. I ran into this with refresh_unity, run_tests, and get_test_job stuck for 10+ minutes at a time.

The fix does two things. When the client sees that Unity is reloading, it drops the stale socket so the next command reconnects to the fresh bridge instead of writing into the dead one. And it puts a single time limit on the whole command, so retries can't stack up forever.

## Type of Change
<!-- Check all that apply -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made
1. Server/src/transport/legacy/unity_connection.py
  - Reconnect-on-reload: when the preflight status reports reloading, drop the socket (under _io_lock, so it is never closed under a concurrent send/recv) so the next command reconnects to the rebuilt bridge instead of reusing a half-open one.
  - Per-command total deadline: new optional deadline arg on send_command, derived from command_total_timeout and enforced at the top of the attempt loop; threaded through send_command_with_retry (one shared deadline across the reload-wait loop) so the whole call has a single ceiling rather than one per inner send.
2. Server/src/core/config.py: new command_total_timeout (default 90s).
3. Server/tests/integration/test_connection_deadline.py: deterministic regression tests using a fake bridge that completes the handshake then goes silent.

## Compatibility / Package Source
- Unity version(s) tested: 6000.5.0f1 (Unity 6.5)
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): Python server run from local Server/ source (uvx --from <path>); the Unity C# package was unchanged (beta).
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): N/A -- this PR changes only the Python server; no Unity C# package change.

## Testing/Screenshots/Recordings
- [X] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [ ] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)


## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes


## Related Issues
Relates to #891 (MCP gets stuck after a Unity reload until manually nudged) and #657 (more deterministic / bounded reload-wait in unity_connection.py). The same reload/test-boundary connection-drop pattern also affects the HTTP transport (e.g. #1207, #1164) via a different code path; this PR addresses the stdio client only.

## Additional Notes
1. This change is Python-only (no C# / Unity API change), so the Unity EditMode/PlayMode and package-import/compile checks are not applicable.
3. The bug is timing/state-dependent and does not reproduce on demand, so the new test reproduces it deterministically: a fake bridge that handshakes then goes silent drives the real connection code, failing (unbounded) before the fix and bounded after. It was also verified live on Unity 6.5 against the exact workflow that originally hung (repeated edit -> force refresh -> run_tests / get_test_job): previously wedged for minutes; now every call returns within ~10s and reconnects cleanly across each reload.
4. Related but intentionally out of scope: after heavy reload churn the Unity-side bridge sometimes fails to resume (its status file is deleted on stop and not recreated, leaving the bridge down until the editor restarts). That is a separate, bridge-side issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a `command_total_timeout` configuration to cap how long commands can run across retries.

* **Bug Fixes**
  * Improved Unity command sending so timeouts are enforced consistently, even after a reload leaves the socket half-open.
  * Strengthened reload handling to prevent concurrent send/receive races and to ensure timed-out sockets are reset.

* **Tests**
  * Added integration coverage for silent/half-open TCP behavior and reload-related retry timing and error reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->