### PR TITLE
fix: preserve multi-line message body in read_console

### DIFF
--- a/MCPForUnity/Editor/Tools/ReadConsole.cs
+++ b/MCPForUnity/Editor/Tools/ReadConsole.cs
@@ -319,16 +319,7 @@ namespace MCPForUnity.Editor.Tools
                         continue;
                     }
 
-                    // --- Formatting ---
-                    string stackTrace = includeStacktrace ? ExtractStackTrace(message) : null;
-                    // Always get first line for the message, use full message only if no stack trace exists
-                    string[] messageLines = message.Split(
-                        new[] { '\n', '\r' },
-                        StringSplitOptions.RemoveEmptyEntries
-                    );
-                    string messageOnly = messageLines.Length > 0 ? messageLines[0] : message;
-
-                    // If not including stacktrace, ensure we only show the first line
+                    var (messageOnly, stackTrace) = SplitMessageAndStackTrace(message);
                     if (!includeStacktrace)
                     {
                         stackTrace = null;
@@ -498,30 +489,35 @@ namespace MCPForUnity.Editor.Tools
         }
 
         /// <summary>
-        /// Attempts to extract the stack trace part from a log message.
-        /// Unity log messages often have the stack trace appended after the main message,
-        /// starting on a new line and typically indented or beginning with "at ".
+        /// Splits a Unity log message into its body and appended stack trace.
+        /// Unity concatenates both, separated by newlines, so the body may span
+        /// several lines before the stack trace begins.
         /// </summary>
-        /// <param name="fullMessage">The complete log message including potential stack trace.</param>
-        /// <returns>The extracted stack trace string, or null if none is found.</returns>
-        private static string ExtractStackTrace(string fullMessage)
+        /// <param name="fullMessage">The complete log message including any appended stack trace.</param>
+        /// <returns>The message body (line endings normalized to "\n", internal blank lines preserved) and the stack trace, or null when none is found.</returns>
+        private static (string body, string stackTrace) SplitMessageAndStackTrace(string fullMessage)
         {
             if (string.IsNullOrEmpty(fullMessage))
-                return null;
+                return (fullMessage, null);
 
-            // Split into lines, removing empty ones to handle different line endings gracefully.
-            // Using StringSplitOptions.None might be better if empty lines matter within stack trace, but RemoveEmptyEntries is usually safer here.
-            string[] lines = fullMessage.Split(
-                new[] { '\r', '\n' },
-                StringSplitOptions.RemoveEmptyEntries
-            );
+            string[] lines = fullMessage.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
 
             // If there's only one line or less, there's no separate stack trace.
             if (lines.Length <= 1)
-                return null;
+                return (fullMessage, null);
 
-            int stackStartIndex = -1;
+            int stackStartIndex = FindStackStartIndex(lines);
+            if (stackStartIndex <= 0)
+                return (string.Join("\n", lines), null);
 
+            return (
+                string.Join("\n", lines.Take(stackStartIndex)),
+                string.Join("\n", lines.Skip(stackStartIndex))
+            );
+        }
+
+        private static int FindStackStartIndex(string[] lines)
+        {
             // Start checking from the second line onwards.
             for (int i = 1; i < lines.Length; ++i)
             {
@@ -543,21 +539,11 @@ namespace MCPForUnity.Editor.Tools
                     )
                 )
                 {
-                    stackStartIndex = i;
-                    break; // Found the likely start of the stack trace
+                    return i; // Found the likely start of the stack trace
                 }
             }
 
-            // If a potential start index was found...
-            if (stackStartIndex > 0)
-            {
-                // Join the lines from the stack start index onwards using standard newline characters.
-                // This reconstructs the stack trace part of the message.
-                return string.Join("\n", lines.Skip(stackStartIndex));
-            }
-
-            // No clear stack trace found based on the patterns.
-            return null;
+            return -1;
         }
 
         /* LogEntry.mode bits exploration (based on Unity decompilation/observation):

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
@@ -75,5 +75,42 @@ namespace MCPForUnityTests.Editor.Tools
             }
             Assert.IsTrue(found, $"The unique log message '{uniqueMessage}' was not found in retrieved logs.");
         }
+
+        [Test]
+        public void HandleCommand_Get_PreservesMultilineMessageBody()
+        {
+            string id = Guid.NewGuid().ToString();
+            string firstLine = $"First line {id}";
+            string secondLine = $"Second line {id}";
+            Debug.Log($"{firstLine}\n\n{secondLine}");
+
+            var paramsObj = new JObject
+            {
+                ["action"] = "get",
+                ["types"] = new JArray { "error", "warning", "log" },
+                ["format"] = "detailed",
+                ["count"] = 1000
+            };
+
+            var result = ToJObject(ReadConsole.HandleCommand(paramsObj));
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JArray;
+            Assert.IsNotNull(data, "Data array should not be null.");
+
+            string message = null;
+            foreach (var entry in data)
+            {
+                string candidate = entry["message"]?.ToString();
+                if (candidate != null && candidate.Contains(firstLine))
+                {
+                    message = candidate;
+                    break;
+                }
+            }
+
+            Assert.IsNotNull(message, "Multi-line log entry was not found.");
+            StringAssert.Contains($"{firstLine}\n\n{secondLine}", message);
+            StringAssert.DoesNotContain("UnityEngine.Debug", message);
+        }
     }
 }


### PR DESCRIPTION
## Description
`read_console` truncated every log entry's `message` to its first line, so a multi-line `Debug.Log("a\nb\nc")` came back as just `"a"` — lines `b` and `c` were dropped from `message` and never surfaced in `stackTrace` either, with no parameter or resource to recover them. This preserves the full multi-line message body while still separating the appended stack trace into its own gated field.

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made
<!-- List the specific changes in this PR -->
- Replaced `ExtractStackTrace` with `SplitMessageAndStackTrace` (+ extracted `FindStackStartIndex`) in `MCPForUnity/Editor/Tools/ReadConsole.cs`: the log entry is split into body and appended stack trace at the first stack-frame boundary, and `message` now receives the **entire body** instead of only the first line.
- Line endings are normalized (`\r\n`/`\r` → `\n`) and split without `RemoveEmptyEntries`, so **internal blank lines in the body are preserved** (e.g. `"a\n\nc"` stays `"a\n\nc"`).
- `include_stacktrace` behavior is unchanged: it still only gates the separate `stackTrace` field; `message` is returned independently of it.
- The stack-frame detection heuristic is intentionally **unchanged** (only extracted into `FindStackStartIndex`), so severity classification and stack detection carry no regression.
- Added EditMode test `HandleCommand_Get_PreservesMultilineMessageBody` (multi-line log with an internal blank line; asserts the body is preserved and that the appended stack does not leak into `message`).

## Compatibility / Package Source
<!-- Especially important for Unity API compatibility, package-source, or transport changes -->
- Unity version(s) tested: 2021.3.43f1, 6000.3.12f1
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): local checkout of CoplayDev/unity-mcp#beta
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): N/A (C#-only change, no package-source change)

## Testing/Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->
- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)
ReadConsole EditMode tests pass on Unity 2021.3.43f1.

## Documentation Updates
<!-- Check if you updated documentation for changes to tools/resources -->
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

No tool/resource surface changed — no new tools, resources, or parameters. Only the value of the existing `message` field changed (now multi-line), and the auto-generated docs are driven by the parameter registry, which is untouched.

## Related Issues
<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->
N/A

## Additional Notes
<!-- Any other information that reviewers should know -->
- Change is C#-only; the Python `read_console` tool passes `message` through unchanged, and no consumer parses the `plain` output line-by-line (verified against `Server/src/services/tools/read_console.py` and the CLI), so a multi-line `message` breaks nothing downstream.
- Validated by running Editor tests in UnityMCPTests project on Unity 2021.3.43f1 and by calling `read_console` via HTTP server on Unity 6000.3.12f1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console log entries now preserve multi-line message bodies correctly, including blank lines.
  * Stack traces are separated more reliably from the main message, and can still be hidden when not requested.
* **Tests**
  * Added coverage for retrieving detailed console output with multi-line messages to ensure the message text is returned in the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->