### PR TITLE
fix(editor): skip shutdown cleanup in batch mode so CI instances don't stop the interactive server

### DIFF
--- a/MCPForUnity/Editor/Services/McpEditorShutdownCleanup.cs
+++ b/MCPForUnity/Editor/Services/McpEditorShutdownCleanup.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Services.Transport;
 using UnityEditor;
+using UnityEngine;
 
 namespace MCPForUnity.Editor.Services
 {
@@ -22,8 +23,19 @@ namespace MCPForUnity.Editor.Services
             EditorApplication.quitting += OnEditorQuitting;
         }
 
+        // A -batchmode/CI instance resolves the interactive editor's server via the global
+        // pidfile+port handshake, so cleanup there would stop another user's server. Mirror the
+        // sibling guards (HttpAutoStartHandler, StdioBridgeHost): skip in batch unless opted in.
+        internal static bool ShouldRunCleanup() =>
+            ShouldRunCleanup(Application.isBatchMode, Environment.GetEnvironmentVariable("UNITY_MCP_ALLOW_BATCH"));
+
+        internal static bool ShouldRunCleanup(bool isBatchMode, string allowBatchEnv) =>
+            !isBatchMode || !string.IsNullOrWhiteSpace(allowBatchEnv);
+
         private static void OnEditorQuitting()
         {
+            if (!ShouldRunCleanup()) return;
+
             // 1) Stop transports (best-effort, bounded wait).
             try
             {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/McpEditorShutdownCleanupTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/McpEditorShutdownCleanupTests.cs
@@ -1,0 +1,49 @@
+using System;
+using NUnit.Framework;
+using MCPForUnity.Editor.Services;
+using UnityEngine;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    [TestFixture]
+    public class McpEditorShutdownCleanupTests
+    {
+        [Test]
+        public void ShouldRunCleanup_InteractiveEditor_RunsCleanup()
+        {
+            Assert.IsTrue(McpEditorShutdownCleanup.ShouldRunCleanup(isBatchMode: false, allowBatchEnv: null));
+        }
+
+        [Test]
+        public void ShouldRunCleanup_BatchWithoutOverride_IsNoOp()
+        {
+            // Regression for #1196/#1010: a -batchmode/CI instance must not stop the
+            // interactive editor's server resolved via the global pidfile+port handshake.
+            Assert.IsFalse(McpEditorShutdownCleanup.ShouldRunCleanup(isBatchMode: true, allowBatchEnv: null));
+        }
+
+        [Test]
+        public void ShouldRunCleanup_BatchWithBlankOverride_IsNoOp()
+        {
+            // Whitespace is treated as unset, mirroring string.IsNullOrWhiteSpace in the sibling guards.
+            Assert.IsFalse(McpEditorShutdownCleanup.ShouldRunCleanup(isBatchMode: true, allowBatchEnv: ""));
+            Assert.IsFalse(McpEditorShutdownCleanup.ShouldRunCleanup(isBatchMode: true, allowBatchEnv: "   "));
+        }
+
+        [Test]
+        public void ShouldRunCleanup_BatchWithOverride_RunsCleanup()
+        {
+            Assert.IsTrue(McpEditorShutdownCleanup.ShouldRunCleanup(isBatchMode: true, allowBatchEnv: "1"));
+        }
+
+        [Test]
+        public void ShouldRunCleanup_Parameterless_MatchesEnvironment()
+        {
+            // Proves the wiring to Application.isBatchMode / UNITY_MCP_ALLOW_BATCH is correct
+            // without assuming how this test run was launched (GUI Test Runner vs -batchmode CI).
+            bool expected = !Application.isBatchMode
+                || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("UNITY_MCP_ALLOW_BATCH"));
+            Assert.AreEqual(expected, McpEditorShutdownCleanup.ShouldRunCleanup());
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/McpEditorShutdownCleanupTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/McpEditorShutdownCleanupTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04b5977d361f459ea4726c6e176fa9d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Fixes #1196, fixes #1010.

## Problem

`McpEditorShutdownCleanup.OnEditorQuitting()` runs in **every** quitting editor instance, including `-batchmode -quit` runs, and unconditionally stops the managed local HTTP server. The pidfile + instance-token handshake it uses lives in EditorPrefs — per-user global state shared across all Unity instances and projects on the machine — so any headless batch run of any project containing the package (CI compile checks, agent-driven batch verifications) inherits the interactive editor's handshake, matches the running server, and kills the developer's live MCP session via `StopLocalHttpServerInternal(portOverride, allowNonLocalUrl: true)`. With AI-agent workflows running frequent batch legs, this can kill the session many times per day (#1196); the same mechanism breaks CI runners that share a machine with an interactive editor (#1010).

## Fix

Guard `OnEditorQuitting` with the same `Application.isBatchMode` + `UNITY_MCP_ALLOW_BATCH` check the sibling entry points already use (`HttpAutoStartHandler`, `StdioBridgeHost`), extracted as a testable `ShouldRunCleanup(isBatchMode, allowBatchEnv)` predicate. Batch instances that legitimately manage their own server can opt back in with `UNITY_MCP_ALLOW_BATCH`.

## Verification

- 5 EditMode tests covering the predicate matrix (interactive, batch without/with/blank override) plus a wiring test that derives its expectation from the actual run environment, so it passes in both the GUI Test Runner and `-batchmode` CI.
- Compile-only matrix via `tools/check-unity-versions.sh` (2021.3 floor passes locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shutdown cleanup now skips running in batch mode by default, preventing editor quit logic from stopping services unexpectedly.
  * Cleanup can still be enabled in batch mode when explicitly allowed through an environment override.

* **Tests**
  * Added coverage for interactive mode, batch mode with and without override, and blank override handling.
  * Added validation that the environment-based check matches the expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->