### PR TITLE
feat(client): add Factory Droid as a configured MCP client

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs
@@ -19,7 +19,6 @@ namespace MCPForUnity.Editor.Clients.Configurators
             windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".factory", "mcp.json"),
             macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".factory", "mcp.json"),
             linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".factory", "mcp.json"),
-            SupportsHttpTransport = true,
         })
         { }
 

--- a/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs
@@ -34,7 +34,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
         {
             "Install Factory Droid (https://factory.ai)",
             "Click Configure to add UnityMCP to ~/.factory/mcp.json\nOR open the config file at the path above",
-            "Paste the configuration JSON into the mcpServers object",
+            "Merge the manual snippet so it results in mcpServers.unityMCP (do not nest mcpServers twice)",
             "Save and restart Droid"
         };
     }

--- a/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MCPForUnity.Editor.Models;
+
+namespace MCPForUnity.Editor.Clients.Configurators
+{
+    /// <summary>
+    /// Factory Droid configurator. Droid stores MCP server config in
+    /// ~/.factory/mcp.json using the standard `mcpServers` container, so it
+    /// reuses the shared JSON-file configurator pipeline.
+    /// </summary>
+    public class DroidConfigurator : JsonFileMcpConfigurator
+    {
+        public DroidConfigurator() : base(new McpClient
+        {
+            name = "Droid",
+            // ~/.factory/mcp.json on every OS (UserProfile resolves to C:\Users\<user> on Windows).
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".factory", "mcp.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".factory", "mcp.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".factory", "mcp.json"),
+            SupportsHttpTransport = true,
+        })
+        { }
+
+        public override bool SupportsSkills => true;
+
+        public override string GetSkillInstallPath()
+        {
+            var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(userHome, ".factory", "skills", "unity-mcp-skill");
+        }
+
+        public override IList<string> GetInstallationSteps() => new List<string>
+        {
+            "Install Factory Droid (https://factory.ai)",
+            "Click Configure to add UnityMCP to ~/.factory/mcp.json\nOR open the config file at the path above",
+            "Paste the configuration JSON into the mcpServers object",
+            "Save and restart Droid"
+        };
+    }
+}

--- a/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs.meta
+++ b/MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1c8f3b9d5e74a2190f6c1d8e3b7a5f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/IsInstalledTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/IsInstalledTests.cs
@@ -41,5 +41,14 @@ namespace MCPForUnityTests.Editor.Clients
             bool expected = parent != null && Directory.Exists(parent);
             Assert.AreEqual(expected, claude.IsInstalled);
         }
+
+        [Test]
+        public void Droid_Installed_WhenFactoryDirExists()
+        {
+            var droid = new DroidConfigurator();
+            string parent = Path.GetDirectoryName(droid.GetConfigPath());
+            bool expected = parent != null && Directory.Exists(parent);
+            Assert.AreEqual(expected, droid.IsInstalled);
+        }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs
@@ -32,5 +32,14 @@ namespace MCPForUnityTests.Editor.Clients
             CollectionAssert.Contains(list, ConfiguredTransport.Stdio);
             CollectionAssert.Contains(list, ConfiguredTransport.Http);
         }
+
+        [Test]
+        public void Droid_SupportsBothTransports()
+        {
+            var droid = new DroidConfigurator();
+            var list = droid.SupportedTransports.ToList();
+            CollectionAssert.Contains(list, ConfiguredTransport.Stdio);
+            CollectionAssert.Contains(list, ConfiguredTransport.Http);
+        }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ClientConfigFormatTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ClientConfigFormatTests.cs
@@ -152,5 +152,73 @@ namespace MCPForUnityTests.Editor.Helpers
             Assert.AreEqual("http", (string)unity["type"],
                 "Clients without HttpTypeValue should keep the generic type:http");
         }
+
+        [Test]
+        public void DroidConfigurator_DeclaresStandardMcpServersFormat()
+        {
+            // Droid stores MCP config in ~/.factory/mcp.json using the standard mcpServers
+            // container, so it must not override ServerContainerKey/HttpTypeValue/StdioTypeValue
+            // (those overrides are for clients with non-standard schemas like Kilo Code).
+            var client = new DroidConfigurator().Client;
+
+            Assert.IsTrue(string.IsNullOrEmpty(client.ServerContainerKey),
+                "Droid must use the default mcpServers container, not a client-specific one");
+            Assert.IsTrue(string.IsNullOrEmpty(client.HttpTypeValue),
+                "Droid must use the generic type:http for HTTP transport");
+            Assert.IsTrue(string.IsNullOrEmpty(client.StdioTypeValue),
+                "Droid must use the generic type:stdio for stdio transport");
+            Assert.IsFalse(client.IsVsCodeLayout,
+                "Droid must not use the VS Code servers/mcp.servers layout");
+            Assert.IsTrue(client.SupportsHttpTransport,
+                "Droid supports both stdio and HTTP transports");
+        }
+
+        [Test]
+        public void BuildManualConfigJson_ForDroid_UsesMcpServersContainerAndPlainHttp()
+        {
+            var client = new DroidConfigurator().Client;
+
+            var root = JObject.Parse(ConfigJsonBuilder.BuildManualConfigJson(uvPath: null, client));
+
+            Assert.IsNull(root["$schema"], "Droid must not write a $schema");
+            Assert.IsNull(root["mcp"], "Droid must not use a client-specific container");
+
+            var unity = (JObject)root.SelectToken("mcpServers.unityMCP");
+            Assert.NotNull(unity, "Expected mcpServers.unityMCP node");
+            Assert.AreEqual("http", (string)unity["type"],
+                "Droid HTTP config must use the generic type:http, not streamableHttp/remote");
+            Assert.IsNotNull(unity["url"], "HTTP transport should set a url");
+            Assert.IsNull(unity["command"], "HTTP transport should not include a command");
+        }
+
+        [Test]
+        public void DroidConfigurator_TargetsFactoryMcpJson_OnAllPlatforms()
+        {
+            var client = new DroidConfigurator().Client;
+            const string expectedFileName = "mcp.json";
+            const string expectedParentDirName = ".factory";
+
+            foreach (var path in new[] { client.windowsConfigPath, client.macConfigPath, client.linuxConfigPath })
+            {
+                Assert.AreEqual(expectedFileName, System.IO.Path.GetFileName(path),
+                    "Droid config must target mcp.json");
+                Assert.AreEqual(expectedParentDirName, System.IO.Path.GetFileName(System.IO.Path.GetDirectoryName(path)),
+                    "Droid config must live inside ~/.factory/");
+            }
+        }
+
+        [Test]
+        public void DroidConfigurator_SupportsSkills_AndInstallsUnderFactorySkills()
+        {
+            var droid = new DroidConfigurator();
+
+            Assert.IsTrue(droid.SupportsSkills, "Droid should support skill installation");
+            string skillPath = droid.GetSkillInstallPath();
+            Assert.IsNotNull(skillPath, "Skill install path must not be null when SupportsSkills is true");
+            StringAssert.Contains(".factory", skillPath,
+                "Droid skills should install under ~/.factory/skills/");
+            StringAssert.EndsWith("unity-mcp-skill", skillPath,
+                "Droid skill install path should end with the unity-mcp-skill subdirectory");
+        }
     }
 }

--- a/website/docs/getting-started/clients.md
+++ b/website/docs/getting-started/clients.md
@@ -26,6 +26,7 @@ MCP for Unity auto-configures every client the package detects on your machine. 
 | **Gemini CLI** | HTTP | yes | yes | yes | Auto-connects. |
 | **OpenClaw** | HTTP / stdio | yes | yes | yes | Requires `openclaw-mcp-bridge` plugin enabled. Follows MCP for Unity's transport choice. |
 | **Antigravity** | HTTP | yes | yes | varies | Requires an MCP toggle in Antigravity settings. |
+| **Droid** | HTTP | yes | yes | yes | Factory's agent. Config written to `~/.factory/mcp.json`. |
 
 ## How to pick
 

--- a/website/docs/getting-started/clients.md
+++ b/website/docs/getting-started/clients.md
@@ -26,7 +26,7 @@ MCP for Unity auto-configures every client the package detects on your machine. 
 | **Gemini CLI** | HTTP | yes | yes | yes | Auto-connects. |
 | **OpenClaw** | HTTP / stdio | yes | yes | yes | Requires `openclaw-mcp-bridge` plugin enabled. Follows MCP for Unity's transport choice. |
 | **Antigravity** | HTTP | yes | yes | varies | Requires an MCP toggle in Antigravity settings. |
-| **Droid** | HTTP | yes | yes | yes | Factory's agent. Config written to `~/.factory/mcp.json`. |
+| **Droid** | HTTP / stdio | yes | yes | yes | Factory's agent. Config written to `~/.factory/mcp.json`. Follows MCP for Unity's transport choice. |
 
 ## How to pick
 

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -14,7 +14,7 @@ Three install paths are supported. Pick one. **Git URL** is the fastest if you j
 
 - **Unity 2021.3 LTS or newer** — [Download Unity](https://unity.com/download)
 - **Python 3.10+** with [`uv`](https://docs.astral.sh/uv/getting-started/installation/) — the setup wizard guides you through both if missing
-- **An MCP client** — [Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Cursor](https://www.cursor.com/), [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview), [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli), [Windsurf](https://windsurf.com/), [Cline](https://cline.bot/), [OpenClaw](https://openclaw.ai/), and more
+- **An MCP client** — [Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Cursor](https://www.cursor.com/), [VS Code Copilot](https://code.visualstudio.com/docs/copilot/overview), [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli), [Windsurf](https://windsurf.com/), [Cline](https://cline.bot/), [OpenClaw](https://openclaw.ai/), [Factory Droid](https://factory.ai/), and more
 
 ## Option 1 — Git URL (fastest)
 

--- a/website/docs/guides/client-configurators.md
+++ b/website/docs/guides/client-configurators.md
@@ -89,6 +89,7 @@ At a high level:
 Most MCP clients use a JSON config file that defines one or more MCP servers. Examples:
 
 - **Cursor** – `JsonFileMcpConfigurator` (global `~/.cursor/mcp.json`).
+- **Droid** – `JsonFileMcpConfigurator` (global `~/.factory/mcp.json`, standard `mcpServers` layout; skills install to `~/.factory/skills/unity-mcp-skill`).
 - **VSCode GitHub Copilot** – `JsonFileMcpConfigurator` with `IsVsCodeLayout = true`.
 - **VSCode Insiders GitHub Copilot** – `JsonFileMcpConfigurator` with `IsVsCodeLayout = true` and Insider-specific `Code - Insiders/User/mcp.json` paths.
 - **GitHub Copilot CLI** – `JsonFileMcpConfigurator` with standard HTTP transport.


### PR DESCRIPTION
## Summary

Adds a first-class `DroidConfigurator` so **Factory Droid** is detected and auto-configured on parity with the other 20+ supported MCP clients (Cursor, VS Code, Windsurf, Claude Code, Codex, etc.). Droid users currently have to hand-edit `~/.factory/mcp.json`; with this change they get a one-click **Configure** button in `Window → MCP for Unity`.

Resolves #1240.

## What changed

- **New `MCPForUnity/Editor/Clients/Configurators/DroidConfigurator.cs`** (+ `.meta`) — subclasses `JsonFileMcpConfigurator` and targets `~/.factory/mcp.json` on Windows/macOS/Linux. Droid uses the standard `mcpServers` schema (same as Cursor/Claude Desktop), so no new base class is needed.
- **Skill support enabled** — `SupportsSkills = true` with install path `~/.factory/skills/unity-mcp-skill`, matching how Claude Code and Codex expose skill installation.
- **Auto-discovery** — `McpClientRegistry` picks up the new class via `TypeCache.GetTypesDerivedFrom<IMcpClientConfigurator>()`, so no manual registration was required.
- **EditMode tests** added to:
  - `SupportedTransportsTests.cs` — Droid supports both stdio and HTTP transports
  - `IsInstalledTests.cs` — `IsInstalled` tracks whether `~/.factory` exists
  - `ClientConfigFormatTests.cs` — Droid declares the standard `mcpServers` container, generic `type:http`, targets `mcp.json` on all platforms, and exposes the correct skill install path
- **Docs**:
  - `website/docs/getting-started/clients.md` — added Droid to the capability matrix
  - `website/docs/getting-started/install.md` — added Factory Droid to the prerequisites client list
  - `website/docs/guides/client-configurators.md` — added Droid to the typical JSON-file clients list

## Why

Droid stores MCP config in `~/.factory/mcp.json` using the **standard `mcpServers` container**, so it reuses the existing `JsonFileMcpConfigurator` pipeline. The cost is one small class + tests, with zero risk to existing clients (auto-discovery only adds the new entry; nothing else changes).

## How to verify

1. Open Unity with the MCP for Unity package built from this branch.
2. Open `Window → MCP for Unity`.
3. Confirm **Droid** appears in the client list (sorted alphabetically).
4. With `~/.factory/` present, the status shows as a configurable client; click **Configure**.
5. Verify `~/.factory/mcp.json` is written with a `mcpServers.unityMCP` entry matching the selected transport (HTTP `url` or stdio `command`/`args`).
6. Click **Unregister** and confirm the `unityMCP` entry is removed cleanly.
7. Run EditMode tests in `TestProjects/UnityMCPTests` — the new Droid cases pass alongside the existing client suite.

## Testing

- Python suite: `cd Server && uv run --extra dev python -m pytest tests/ -q` → 1306 passed, 3 skipped.
- Unity EditMode: new tests follow the same pattern as the existing `Cursor`/`ClaudeDesktop`/`KiloCode` cases. Local Unity Editor was not installed in the dev environment, so `tools/check-unity-versions.sh` skipped the compile check; CI will cover it.

## Notes

- Droid supports both **stdio** and **HTTP** transports (the `~/.factory/mcp.json` schema accepts the standard `command`/`args` form as well as the `url` form), so `SupportsHttpTransport = true` is correct.
- Transport detection reuses the existing `JsonFileMcpConfigurator.CheckStatus` logic, which already understands `url`, `serverUrl`, and `httpUrl` URL properties plus the `command`/`args` stdio form.
- Branched off `beta` per the contributing guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Droid** MCP client with automatic JSON config generation in `~/.factory/mcp.json`.
  * Enabled **skills installation support** and documented its default skills path under `~/.factory/skills/`.
  * Droid supports **both HTTP and stdio** transports.
* **Tests**
  * Added EditMode coverage for Droid install status, generated config format, skills support, and supported transports.
* **Documentation**
  * Updated the capability matrix and client configurator guides to include Droid, plus minor install-page wording adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->