### PR TITLE
docs(server): guide agents to read resources by URI, not name

### DIFF
--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -315,6 +315,11 @@ Resources vs Tools:
 - Use TOOLS to perform actions and mutations (manage_editor for play mode control, tag/layer management, etc)
 - Always check related resources before modifying the engine state with tools
 
+Reading resources (read this before using ANY resource named below):
+- Resources are addressed by URI, never by name. A resource's name and URI are NOT interchangeable: names use underscores (e.g. editor_state) while URIs use slashes (e.g. mcpforunity://editor/state). Do NOT build a URI by swapping separators in the name — you will 404.
+- Always read the exact URI from your MCP client's resource listing (resources/list). Where these instructions mention a resource by name, look up its URI in that listing rather than guessing it.
+- Resource payloads are wrapped: the content lives under a top-level `data` object, so field paths are `data.<section>.<field>` (e.g. `data.advice.ready_for_tools`), not bare top-level fields.
+
 Script Management:
 - After creating or modifying scripts (by your own tools or the `manage_script` tool) use `read_console` to check for compilation errors before proceeding
 - Only after successful compilation can new components/types be used


### PR DESCRIPTION
I noticed that asking Claude to read editor state often caused it to get 404 errors and have to retry to generate the right URI.  With these changes in place, Claude gets the call right on the first time, every time, which makes development faster.

## Description
Add a "Reading resources" section to the FastMCP server instructions string. It states that resources are addressed by URI (slashes), never by name (underscores); that the exact URI should be taken from the client's resources/list rather than constructed from the name; and that payloads are wrapped under a top-level `data` object (field paths look like data.section.field).

Prevents the common naive failure where an agent turns a resource name into a URI (e.g. editor_state -> mcpforunity://editor_state) and 404s, and the matching failure of guessing a bare top-level field instead of the nested data.* path.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made
Updated instructions to the agent on how to use resource URIs

## Compatibility / Package Source
<!-- Especially important for Unity API compatibility, package-source, or transport changes -->
- Unity version(s) tested: 6000.3.19f1
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): #main
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): 78ee5418415953b79c358bfe6355fcc3fde7912b

## Testing/Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->
- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [ ] Package import/compile check
- [x] Not applicable (explain why in Additional Notes)

Text of Claude conversation:
"There are errors in the console.  Please debug and solve these"

01:32 PM claude-opus-4-8
I'll start by checking the Unity console for the errors. Let me first pin the correct Unity instance for this project.

● readMcpResource(Read resource "mcpforunity://instances" from server "UnityMCP")
{
  "contents": [
    {
      "uri": "mcpforunity://instances",
      "mimeType": "text/plain",
      "text": "{\"success\": true, \"transport\": \"stdio\", \"instance_count\": 2, \"instances\": [{\"id\": \"xxx@e5746cd5\", \"name\": \"xxx\", \"path\": \"D:/work/xxx/Assets\", \"hash\": \"e5746cd5\", \"port\": 6405, \"status\": \"running\", \"last_heartbeat\": \"2026-07-05T17:32:40.083693+00:00\", \"unity_version\": \"6000.3.19f1\", \"project_scoped_tools\": false}, {\"id\": \"xxx2@586c3840\", \"name\": \"xxx2\", \"path\": \"D:/work/xxx2/Assets\", \"hash\": \"586c3840\", \"port\": 6402, \"status\": \"running\", \"last_heartbeat\": \"2026-07-05T17:32:39.927504+00:00\", \"unity_version\": \"6000.3.19f1\", \"project_scoped_tools\": false}]}"
    }
  ]
}

01:32 PM claude-opus-4-8
The instance for this project is xxx@e5746cd5 (path D:/work/xxx/Assets). Let me pin it and read the console.

● UnityMCP - Set Active Instance (MCP)(instance: "xxx@e5746cd5")
{
  "success": true,
  "message": "Active instance set to xxx@e5746cd5",
  "data": {
    "instance": "xxx@e5746cd5",
    "session_key": "global"
  }
}

● UnityMCP - Read Console (MCP)(action: "get", types: ["error"], count: 50, include_stacktrace: true, format: "detailed")
{"success":true,"message":"Retrieved 50 log entries."


## Documentation Updates
<!-- Check if you updated documentation for changes to tools/resources -->
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes


## Related Issues
None

## Additional Notes
Feel free to reach out to me if you have any questions or concerns.  Code changes were AI generated by Claude but I personally have reviewed, tested, and vouch for them (aka: not slop)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified server guidance for working with resources.
  * Added instructions to use resource URIs from the resource list rather than resource names.
  * Noted that payload fields are available under a top-level `data` object for easier field access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->