### PR TITLE
fix(execute_code): skip phantom CodeDom BOM error from mcs compiler

### DIFF
--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -294,32 +294,58 @@ namespace MCPForUnity.Editor.Tools
                     }
                 }
 
+                // Compile to a controlled DLL path instead of in-memory. mcs prints a stray BOM line on
+                // stdout that Mono's CodeDom can't parse, so it fabricates a bogus error (no error number,
+                // text is just the BOM) and refuses to surface the assembly — even though mcs exits 0 and
+                // wrote the DLL. We skip that bogus error and Assembly.Load the produced DLL ourselves.
+                string outputAssemblyPath = Path.Combine(Path.GetTempPath(), $"mcp-codedom-{Guid.NewGuid():N}.dll");
                 using (var provider = new CSharpCodeProvider())
                 {
                     var parameters = new CompilerParameters
                     {
-                        GenerateInMemory = true,
+                        GenerateInMemory = false,
+                        OutputAssembly = outputAssemblyPath,
                         GenerateExecutable = false,
                         TreatWarningsAsErrors = false,
                         CompilerOptions = "@\"" + responseFilePath + "\"",
                     };
 
-                    var results = provider.CompileAssemblyFromSource(parameters, source);
-
-                    if (results.Errors.HasErrors)
+                    try
                     {
+                        var results = provider.CompileAssemblyFromSource(parameters, source);
+
+                        bool hasRealErrors = false;
                         foreach (CompilerError error in results.Errors)
                         {
-                            if (!error.IsWarning)
-                            {
-                                int userLine = Math.Max(1, error.Line - WrapperLineOffset);
-                                errors.Add($"Line {userLine}: {error.ErrorText}");
-                            }
-                        }
-                        return null;
-                    }
+                            if (error.IsWarning)
+                                continue;
 
-                    return results.CompiledAssembly;
+                            // The bogus BOM "error": no error number, text is just the BOM/whitespace.
+                            string text = (error.ErrorText ?? "").Trim('\uFEFF', ' ', '\t', '\r', '\n');
+                            if (string.IsNullOrEmpty(error.ErrorNumber) && string.IsNullOrEmpty(text))
+                                continue;
+
+                            hasRealErrors = true;
+                            int userLine = Math.Max(1, error.Line - WrapperLineOffset);
+                            errors.Add($"Line {userLine}: {error.ErrorText}");
+                        }
+
+                        if (hasRealErrors)
+                            return null;
+
+                        if (!File.Exists(outputAssemblyPath))
+                        {
+                            errors.Add("CodeDom reported success but produced no assembly.");
+                            return null;
+                        }
+
+                        return Assembly.Load(File.ReadAllBytes(outputAssemblyPath));
+                    }
+                    finally
+                    {
+                        try { if (File.Exists(outputAssemblyPath)) File.Delete(outputAssemblyPath); }
+                        catch { /* best effort cleanup */ }
+                    }
                 }
             }
             finally


### PR DESCRIPTION
## Problem

The \execute_code\ tool consistently fails with a phantom compilation error when using the CodeDom compiler on Mono/Windows. The error reports a lone U+FEFF (BOM) character on line 1, even though compilation actually succeeds (mcs exits 0 and writes the output DLL).

Fixes #1186

## Root Cause

Mono's \mcs\ compiler prints a stray U+FEFF BOM character on stdout during compilation. Mono's CodeDom implementation (\CSharpCodeProvider\) can't parse this as a standard compiler error format (\ile(line,col): error CSxxxx\), so it fabricates a \CompilerError\ with:
- No \ErrorNumber\ (empty string)
- \ErrorText\ containing only the BOM character
- \IsWarning\ = false

This causes \esults.Errors.HasErrors\ to return \	rue\ and \esults.CompiledAssembly\ to be \
ull\ — even though mcs compiled successfully. The tool reports a failure for a build that was actually fine.

## Solution

Three changes to the \CodeDomCompile\ method:

1. **Compile to a temp DLL path** instead of in-memory (\GenerateInMemory=false\ + \OutputAssembly\). This bypasses CodeDom's refusal to surface the assembly when it thinks there are errors.

2. **Skip phantom BOM errors** — errors where \ErrorNumber\ is empty and \ErrorText\ is only BOM/whitespace are benign and should not block execution.

3. **Load the DLL manually** — when no real errors exist, load the produced DLL via \Assembly.Load(File.ReadAllBytes(...))\ and clean up the temp file in a \inally\ block.

## Verification

- Compilation that previously failed with the BOM phantom error now succeeds.
- Real compilation errors (syntax errors, type mismatches) are still correctly reported.
- Temp DLL files are cleaned up after loading.
- Both \On Error Resume Next\ (continue on warning/BOM) and the original \HasErrors\ guard are replaced with explicit real-error detection.

## Notes

- Community member @lgarczyn diagnosed the root cause and provided the candidate fix in the issue comments. This PR applies that fix to the latest \eta\ branch with minor adjustments.
- The \esponseFilePath\ cleanup (existing pattern) is unaffected — both temp files (RSP and DLL) are cleaned up in their respective \inally\ blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code execution reliability when compiling scripts, reducing false compiler errors caused by stray formatting characters.
  * Added safer handling for compiled output so successful runs are loaded more consistently.
  * Cleaned up temporary compilation files automatically after use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->