### PR TITLE
fix(stdio): handle ObjectDisposedException from disposed NetworkStream during domain reload

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -735,6 +735,10 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                 {
                     throw new IOException("Read timed out");
                 }
+                catch (ObjectDisposedException)
+                {
+                    throw new IOException("Connection closed before reading expected bytes");
+                }
             }
 
             return buffer;
@@ -758,13 +762,20 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
             }
             byte[] header = new byte[8];
             WriteUInt64BigEndian(header, (ulong)payload.LongLength);
+            try
+            {
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
-            await stream.WriteAsync(header.AsMemory(0, header.Length), cancel).ConfigureAwait(false);
-            await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancel).ConfigureAwait(false);
+                await stream.WriteAsync(header.AsMemory(0, header.Length), cancel).ConfigureAwait(false);
+                await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancel).ConfigureAwait(false);
 #else
-            await stream.WriteAsync(header, 0, header.Length, cancel).ConfigureAwait(false);
-            await stream.WriteAsync(payload, 0, payload.Length, cancel).ConfigureAwait(false);
+                await stream.WriteAsync(header, 0, header.Length, cancel).ConfigureAwait(false);
+                await stream.WriteAsync(payload, 0, payload.Length, cancel).ConfigureAwait(false);
 #endif
+            }
+            catch (ObjectDisposedException)
+            {
+                throw new IOException("Connection closed before writing frame");
+            }
         }
 
         private static async Task<string> ReadFrameAsUtf8Async(NetworkStream stream, int timeoutMs, CancellationToken cancel)


### PR DESCRIPTION
## Problem

After domain reload or compilation, `StdioBridgeHost` logs an error: `Cannot access a disposed object. Object name: 'System.Net.Sockets.NetworkStream'`. While the `HandleClientAsync` outer catch already treats `ObjectDisposedException` as benign, the I/O methods (`ReadExactAsync`, `WriteFrameAsync`) throw it raw, making the code depend on a single catch block for correctness.

Fixes #1232

## Root Cause

During domain reload, `Stop()` closes all active `TcpClient` connections via `c.Close()`. Any pending async read/write on the underlying `NetworkStream` throws `ObjectDisposedException`. While this is caught and treated as benign at the `HandleClientAsync` outer catch, the exception type is inconsistent — `ReadExactAsync` and `WriteFrameAsync` throw `ObjectDisposedException` while every other connection-closed scenario throws `IOException`.

## Solution

Two defensive changes at the I/O boundary:

1. **`ReadExactAsync`**: Added `catch (ObjectDisposedException)` that throws `IOException("Connection closed before reading expected bytes")` — matching the existing pattern when `stream.ReadAsync` returns 0 bytes.

2. **`WriteFrameAsync`**: Wrapped the `WriteAsync` calls in a try/catch that converts `ObjectDisposedException` to `IOException("Connection closed before writing frame")`.

This follows the standard .NET pattern where disposed network resources throw `IOException` rather than `ObjectDisposedException`, and ensures consistent handling at every level of the stack.

## Verification

- The existing top-level benign check (`|| ex is IOException`) now catches disposed-stream scenarios uniformly — previously it only caught `ObjectDisposedException` which was fragile.
- Read and write paths are both covered.
- No behavioral change during normal operation — only the exception type changes during shutdown races.

## Notes

- The `WriteFrameAsync` try/catch adds a small indentation change for the preprocessor conditional body, but no logic changes beyond the new catch block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a connection closes unexpectedly during read or write operations.
  * Read failures now report a clearer I/O error if the expected data cannot be received.
  * Write failures now report a clearer I/O error if a frame cannot be fully sent before the connection closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->