### PR TITLE
fix(read_console): force console severity flags ON to bypass UI filter (silent 0 entries)

### DIFF
--- a/MCPForUnity/Editor/Tools/ReadConsole.cs
+++ b/MCPForUnity/Editor/Tools/ReadConsole.cs
@@ -30,6 +30,8 @@ namespace MCPForUnity.Editor.Tools
         private static FieldInfo _messageField;
         private static FieldInfo _fileField;
         private static FieldInfo _lineField;
+        private static PropertyInfo _consoleFlagsProperty;
+        private static MethodInfo _setFilteringTextMethod;
     
         // Static constructor for reflection setup
         static ReadConsole()
@@ -99,6 +101,17 @@ namespace MCPForUnity.Editor.Tools
                 if (_lineField == null)
                     throw new Exception("Failed to reflect LogEntry.line");
 
+                // Reflect consoleFlags property to save/restore severity toggles
+                _consoleFlagsProperty = logEntriesType.GetProperty(
+                    "consoleFlags",
+                    staticFlags
+                );
+                // Reflect SetFilteringText to clear/restore the console search filter
+                _setFilteringTextMethod = logEntriesType.GetMethod(
+                    "SetFilteringText",
+                    staticFlags
+                );
+
                 // (Calibration removed)
 
             }
@@ -133,6 +146,7 @@ namespace MCPForUnity.Editor.Tools
                 || _messageField == null
                 || _fileField == null
                 || _lineField == null
+                || _consoleFlagsProperty == null
             )
             {
                 // Log the error here as well for easier debugging in Unity Console
@@ -245,6 +259,25 @@ namespace MCPForUnity.Editor.Tools
             int resolvedPageSize = Mathf.Clamp(pageSize ?? 50, 1, 500);
             int resolvedCursor = Mathf.Max(0, cursor ?? 0);
             int pageEndExclusive = resolvedCursor + resolvedPageSize;
+
+            // Save and override console severity toggles so that StartGettingEntries
+            // returns all entries regardless of the Console window's UI filter state.
+            // Unity's internal LogEntries.StartGettingEntries() respects these flags
+            // and silently returns 0 when a toggle is off.
+            int savedConsoleFlags = (int)_consoleFlagsProperty.GetValue(null);
+            int forcedFlags = savedConsoleFlags
+                | (1 << 7)  // LogLevelLog
+                | (1 << 8)  // LogLevelWarning
+                | (1 << 9); // LogLevelError
+            _consoleFlagsProperty.SetValue(null, forcedFlags);
+
+            // Also clear the console search filter to avoid text-based filtering
+            // at the source; the tool applies its own filterText parameter later.
+            // GetFilteringText may not exist, so we clear without saving.
+            if (_setFilteringTextMethod != null)
+            {
+                _setFilteringTextMethod.Invoke(null, new object[] { string.Empty });
+            }
 
             try
             {
@@ -391,6 +424,15 @@ namespace MCPForUnity.Editor.Tools
                 {
                     McpLog.Error($"[ReadConsole] Failed to call EndGettingEntries: {e}");
                     // Don't return error here as we might have valid data, but log it.
+                }
+                // Restore the original console severity toggles
+                try
+                {
+                    _consoleFlagsProperty.SetValue(null, savedConsoleFlags);
+                }
+                catch (Exception e)
+                {
+                    McpLog.Error($"[ReadConsole] Failed to restore console flags: {e}");
                 }
             }
 


### PR DESCRIPTION
## Problem

`read_console` silently returns `success: true` with **zero entries** whenever the Unity Console window's severity toggle buttons (Log / Warning / Error counters in the Console toolbar) are switched off — even for freshly logged messages, and even though logs are plainly in `Editor.log`. The tool succeeds, so an agent concludes the console is clean — worst case right after a compile, where it happily proceeds on broken state.

Fixes #1239

## Root Cause

`GetConsoleEntries` calls `LogEntries.StartGettingEntries()`, which respects the Console window's `consoleFlags` bits:

- `LogLevelLog = 1 << 7` (128)
- `LogLevelWarning = 1 << 8` (256)
- `LogLevelError = 1 << 9` (512)

With any toggle off, `StartGettingEntries()` returns 0 entries. The tool has no way to distinguish "console is clean" from "UI is hiding everything."

## Solution

Before calling `StartGettingEntries`, save the current `consoleFlags`, OR in all three log level bits (forcing them on), and clear the console search filter. After `EndGettingEntries` (in the `finally` block), restore the saved flags.

Changes:

1. **Reflect `LogEntries.consoleFlags`** — get/set property to save and restore the severity toggles.
2. **Reflect `LogEntries.SetFilteringText`** — optional method to clear the console search filter (gracefully skipped if absent on older Unity versions).
3. **`GetConsoleEntries`**: Before the try block, save flags and force bits on; in the `finally` block, restore flags.
4. **Null guard** — `_consoleFlagsProperty` added to the static constructor failure check since all log reading depends on it.

## Verification

- The OR operation is idempotent: if flags are already correct, `forcedFlags == savedConsoleFlags` and the set is a no-op.
- The restore always runs in the `finally` block — even if the iteration throws.
- `SetFilteringText` is optional; the core fix only requires `consoleFlags`.
- No behavioral change when Console toggles are already on (normal case).

## Notes

- The console search filter is cleared without saving because `GetFilteringText` is not guaranteed to exist across Unity versions. The tool applies its own `filterText` parameter client-side, so this is a minor UX trade-off — the console search box is cleared after a `read_console` call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console reads now return all log, warning, and error entries more reliably, even when Unity’s console filters are enabled.
  * Search/filter state is cleared during console capture so hidden entries are less likely to be missed.
  * Console severity settings are restored after reading, reducing the chance of leaving the editor in an altered state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->