### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -60,6 +60,14 @@ uvx --from mcpforunityserver mcp-for-unity --transport http --http-url http://lo
 }
 ```
 
+**Autohand Code (stdio):**
+
+```bash
+autohand mcp add UnityMCP uvx --from mcpforunityserver mcp-for-unity --transport stdio
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+
 ### Option 2: From GitHub Source
 
 Use this to run the latest released version from the repository. Change the version to `main` to run the latest unreleased changes from the repository.


### PR DESCRIPTION
Adds a short Autohand Code example beside the existing stdio client configuration in Server/README.md.

The command deliberately reuses the published uvx --from mcpforunityserver mcp-for-unity --transport stdio path, so it stays aligned with the server instructions instead of introducing a separate install method. It also notes the project-scoped option.

Verification:
- Checked the stdio command against the current Autohand Code MCP CLI
- Ran git diff --check

This is documentation-only; no runtime behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for configuring UnityMCP through Autohand Code using stdio.
  * Documented the optional project-level scope setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->