### PR TITLE
feat(asset-gen): AI audio generation + shared model panel (hardened)

### DIFF
--- a/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
+++ b/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
@@ -77,6 +77,11 @@ namespace MCPForUnity.Editor.Constants
         // secure store (MCPForUnity.Editor.Security.SecureKeyStore), never in EditorPrefs.
         internal const string AssetGenSelectedModelProvider = "MCPForUnity.AssetGen.ModelProvider";
         internal const string AssetGenSelectedImageProvider = "MCPForUnity.AssetGen.ImageProvider";
+        internal const string AssetGenSelectedAudioProvider = "MCPForUnity.AssetGen.AudioProvider";
+        // Selected model id per (kind, provider): key = prefix + "<kind>.<provider>". Empty => use
+        // the catalog default. Per-provider (not per-type) so e.g. the Tripo and Meshy 3D dropdowns
+        // — which have disjoint model lists — never clobber each other's selection.
+        internal const string AssetGenSelectedModelPrefix = "MCPForUnity.AssetGen.Model.";
         internal const string AssetGenDefaultFormat = "MCPForUnity.AssetGen.Format";
         internal const string AssetGenOutputRoot = "MCPForUnity.AssetGen.OutputRoot";
         internal const string AssetGenAutoNormalize = "MCPForUnity.AssetGen.AutoNormalize";

--- a/MCPForUnity/Editor/Helpers/AssetGenPaths.cs
+++ b/MCPForUnity/Editor/Helpers/AssetGenPaths.cs
@@ -81,6 +81,21 @@ namespace MCPForUnity.Editor.Helpers
             return true;
         }
 
+        /// <summary>
+        /// Validate an optional caller-supplied output folder. Empty is allowed (the tool picks a
+        /// default); a non-empty value must resolve under the project's Assets folder. Shared by the
+        /// generate_* tools.
+        /// </summary>
+        public static bool NormalizeOutputFolder(string outputFolder, out string normalized, out string error)
+        {
+            normalized = outputFolder;
+            error = null;
+            if (string.IsNullOrWhiteSpace(outputFolder)) return true;
+            if (TryGetAssetsFolder(outputFolder, out normalized)) return true;
+            error = "'output_folder' must resolve under the project's Assets folder.";
+            return false;
+        }
+
         private static string ProjectRoot()
         {
             string dataPath = Path.GetFullPath(Application.dataPath).Replace('\\', '/');

--- a/MCPForUnity/Editor/Helpers/AssetGenPrefs.cs
+++ b/MCPForUnity/Editor/Helpers/AssetGenPrefs.cs
@@ -16,6 +16,7 @@ namespace MCPForUnity.Editor.Helpers
         public const string DefaultOutputRoot = "Assets/Generated";
         public const string DefaultModelProvider = "tripo";
         public const string DefaultImageProvider = "fal";
+        public const string DefaultAudioProvider = "fal";
         public const string DefaultFormatValue = "glb";
 
         public static string ModelProvider
@@ -29,6 +30,33 @@ namespace MCPForUnity.Editor.Helpers
             get => EditorPrefs.GetString(EditorPrefKeys.AssetGenSelectedImageProvider, DefaultImageProvider);
             set => SetOrDelete(EditorPrefKeys.AssetGenSelectedImageProvider, value);
         }
+
+        public static string AudioProvider
+        {
+            get => EditorPrefs.GetString(EditorPrefKeys.AssetGenSelectedAudioProvider, DefaultAudioProvider);
+            set => SetOrDelete(EditorPrefKeys.AssetGenSelectedAudioProvider, value);
+        }
+
+        /// <summary>
+        /// Selected model id for a (kind, provider) pair — the GUI dropdown writes it and the
+        /// generate_* tools read it when the caller omits `model`. Empty by design: the tool's
+        /// empty -> catalog-default chain is the single source of the default, so a blank value
+        /// means "use the catalog default for this provider". Per-provider (not per-type) so
+        /// disjoint provider model lists (Tripo vs Meshy, fal vs OpenRouter) never clobber each other.
+        /// </summary>
+        public static string GetSelectedModel(string kind, string providerId)
+            => string.IsNullOrEmpty(providerId)
+                ? string.Empty
+                : EditorPrefs.GetString(ModelKey(kind, providerId), string.Empty);
+
+        public static void SetSelectedModel(string kind, string providerId, string value)
+        {
+            if (string.IsNullOrEmpty(providerId)) return;
+            SetOrDelete(ModelKey(kind, providerId), value);
+        }
+
+        private static string ModelKey(string kind, string providerId)
+            => EditorPrefKeys.AssetGenSelectedModelPrefix + kind + "." + providerId;
 
         public static string DefaultFormat
         {

--- a/MCPForUnity/Editor/Services/AssetGen/AssetGenJobManager.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/AssetGenJobManager.cs
@@ -23,7 +23,7 @@ namespace MCPForUnity.Editor.Services.AssetGen
     public sealed class AssetGenJob
     {
         public string JobId;
-        public string Kind;       // model | image | marketplace
+        public string Kind;       // model | image | audio | marketplace
         public string Provider;
         public string Action;
         public AssetGenJobState State;
@@ -140,6 +140,34 @@ namespace MCPForUnity.Editor.Services.AssetGen
                 Ext = "png",
                 Name = NameFrom(req.Name, req.Prompt, job.JobId),
                 Subfolder = "Images",
+            };
+            Register(job, runner);
+            return job;
+        }
+
+        public static AssetGenJob StartAudioGeneration(AudioGenRequest req)
+        {
+            if (req == null) throw new ArgumentNullException(nameof(req));
+            string provider = string.IsNullOrEmpty(req.Provider) ? "fal" : req.Provider;
+            IAudioProviderAdapter adapter = AssetGenProviders.Audio(provider); // throws NotSupportedException if unimplemented
+
+            var job = NewJob("audio", provider, "generate");
+            job.Format = "wav";
+
+            if (!TryResolveKey(provider, job, out string apiKey)) return job;
+
+            IHttpTransport transport = TransportOverrideForTests ?? new UnityWebRequestTransport();
+            var runner = new Runner
+            {
+                Job = job,
+                SubmitFn = ct => adapter.SubmitAsync(req, apiKey, transport, ct),
+                PollFn = (pid, ct) => adapter.PollAsync(pid, apiKey, transport, ct),
+                ImportFn = ImportOverrideForTests ?? AudioImportPipeline.ImportInto,
+                Transport = transport,
+                OutputFolder = req.OutputFolder,
+                Ext = "wav", // default; the poll's ResultExt (wav/mp3) overrides at write time
+                Name = NameFrom(req.Name, req.Prompt, job.JobId),
+                Subfolder = "Audio",
             };
             Register(job, runner);
             return job;

--- a/MCPForUnity/Editor/Services/AssetGen/AssetGenJobManager.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/AssetGenJobManager.cs
@@ -437,10 +437,47 @@ namespace MCPForUnity.Editor.Services.AssetGen
             }
         }
 
+        // Per-kind allowlist of result file extensions. The write extension can come from a
+        // provider-controlled result URL (OverrideExt), so a rogue provider could otherwise land a
+        // .cs/.asmdef/.meta/.asset under Assets/ and get it compiled/imported on Refresh — Editor
+        // RCE. Anything outside these sets is rejected. Mirrors ModelImportPipeline's allowlist style.
+        private static readonly HashSet<string> AudioAllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "wav", "mp3", "ogg", "aiff", "aif", "flac",
+        };
+        private static readonly HashSet<string> ImageAllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "png", "jpg", "jpeg", "exr", "tga", "psd", "tiff", "webp", "gif", "bmp",
+        };
+        private static readonly HashSet<string> ModelAllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "glb", "gltf", "fbx", "obj", "usd", "usdz", "dae", "ply", "stl", "zip",
+        };
+
+        /// <summary>
+        /// Whether <paramref name="ext"/> (no leading dot) is an allowed result extension for the
+        /// job <paramref name="kind"/> (audio | image | model | marketplace). Internal so the
+        /// allowlist can be unit-tested directly.
+        /// </summary>
+        internal static bool IsAllowedResultExtension(string kind, string ext)
+            => AllowedExtensionsFor(kind).Contains((ext ?? string.Empty).TrimStart('.'));
+
+        private static HashSet<string> AllowedExtensionsFor(string kind)
+        {
+            switch ((kind ?? string.Empty).ToLowerInvariant())
+            {
+                case "audio": return AudioAllowedExtensions;
+                case "image": return ImageAllowedExtensions;
+                default: return ModelAllowedExtensions; // model + marketplace
+            }
+        }
+
         private static string WriteFile(Runner r, byte[] bytes)
         {
             string chosen = !string.IsNullOrEmpty(r.OverrideExt) ? r.OverrideExt : r.Ext;
             string ext = string.IsNullOrEmpty(chosen) ? "bin" : chosen.TrimStart('.').ToLowerInvariant();
+            if (!IsAllowedResultExtension(r.Job.Kind, ext))
+                throw new Exception($"provider returned a disallowed file type '.{ext}'");
             string requestedRoot = !string.IsNullOrEmpty(r.OutputFolder) ? r.OutputFolder
                                                                          : (AssetGenPrefs.OutputRoot + "/" + r.Subfolder);
             if (!AssetGenPaths.TryGetAssetsFolder(requestedRoot, out string root))

--- a/MCPForUnity/Editor/Services/AssetGen/AssetGenJobManager.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/AssetGenJobManager.cs
@@ -453,6 +453,8 @@ namespace MCPForUnity.Editor.Services.AssetGen
         {
             "glb", "gltf", "fbx", "obj", "usd", "usdz", "dae", "ply", "stl", "zip",
         };
+        // Fail closed: an unexpected kind allows nothing, so the RCE boundary never opens by default.
+        private static readonly HashSet<string> NoAllowedExtensions = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Whether <paramref name="ext"/> (no leading dot) is an allowed result extension for the
@@ -468,7 +470,9 @@ namespace MCPForUnity.Editor.Services.AssetGen
             {
                 case "audio": return AudioAllowedExtensions;
                 case "image": return ImageAllowedExtensions;
-                default: return ModelAllowedExtensions; // model + marketplace
+                case "model":
+                case "marketplace": return ModelAllowedExtensions;
+                default: return NoAllowedExtensions; // fail closed for unexpected kinds
             }
         }
 

--- a/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Services.AssetGen.Providers;
 
 namespace MCPForUnity.Editor.Services.AssetGen
@@ -21,6 +22,13 @@ namespace MCPForUnity.Editor.Services.AssetGen
         public string UseCase;
         public string PriceLabel;
         public float MaxDurationSeconds; // 0 => not time-bounded (image / 3D)
+        // Audio duration knob. DurationField is the request key ("seconds_total" / "duration");
+        // null => the model has no duration control (prompt-only). DefaultDurationSeconds is used
+        // when the caller passes 0 to a model whose endpoint requires a duration. MinDurationSeconds
+        // is the clamp floor.
+        public string DurationField;
+        public float DefaultDurationSeconds;
+        public float MinDurationSeconds;
         public bool Loopable;
         public string CommercialNote;    // non-null => show a license caveat under the dropdown
         public bool FromRefresh;         // true => merged from a fal-catalog refresh (Phase 5)
@@ -50,11 +58,15 @@ namespace MCPForUnity.Editor.Services.AssetGen
             new ModelEntry { Id = "P1-20260311", Label = "Tripo P1 (premium)", Provider = "tripo", Kind = "model", UseCase = "Premium 3D" },
             new ModelEntry { Id = MeshyAdapter.DefaultModel, Label = "Meshy 6", Provider = "meshy", Kind = "model", UseCase = "Text / image -> 3D" },
 
-            // Audio — fal (order: stable-audio, cassette SFX, cassette music, lyria)
+            // Audio — fal (order: stable-audio, cassette SFX, cassette music, lyria). DurationField
+            // is the request key each endpoint expects; null (Lyria) => prompt-only, no duration knob.
             new ModelEntry { Id = FalAudioAdapter.DefaultModel, Label = "Stable Audio 2.5", Provider = "fal", Kind = "audio", UseCase = "Music + SFX", PriceLabel = "$0.20/gen", MaxDurationSeconds = 190f,
+                DurationField = "seconds_total", DefaultDurationSeconds = 30f,
                 CommercialNote = "Free under $1M annual revenue (Stability Community License); an Enterprise license is required at or above $1M." },
-            new ModelEntry { Id = "cassetteai/sound-effects-generator", Label = "CassetteAI SFX", Provider = "fal", Kind = "audio", UseCase = "Sound effects", PriceLabel = "$0.01/gen", MaxDurationSeconds = 30f },
-            new ModelEntry { Id = "cassetteai/music-generator", Label = "CassetteAI Music", Provider = "fal", Kind = "audio", UseCase = "Background music", PriceLabel = "$0.02/min", MaxDurationSeconds = 180f },
+            new ModelEntry { Id = "cassetteai/sound-effects-generator", Label = "CassetteAI SFX", Provider = "fal", Kind = "audio", UseCase = "Sound effects", PriceLabel = "$0.01/gen", MaxDurationSeconds = 30f,
+                DurationField = "duration", DefaultDurationSeconds = 10f, MinDurationSeconds = 1f },
+            new ModelEntry { Id = "cassetteai/music-generator", Label = "CassetteAI Music", Provider = "fal", Kind = "audio", UseCase = "Background music", PriceLabel = "$0.02/min", MaxDurationSeconds = 180f,
+                DurationField = "duration", DefaultDurationSeconds = 10f, MinDurationSeconds = 1f },
             new ModelEntry { Id = "fal-ai/lyria2", Label = "Google Lyria 2", Provider = "fal", Kind = "audio", UseCase = "Background music", PriceLabel = "$0.10/30s", MaxDurationSeconds = 30f },
         };
 
@@ -78,7 +90,25 @@ namespace MCPForUnity.Editor.Services.AssetGen
 
         /// <summary>The default model id for a provider+kind (the first curated entry), or null.</summary>
         public static string DefaultModelId(string provider, string kind)
-            => ForProvider(provider, kind).FirstOrDefault()?.Id;
+        {
+            foreach (ModelEntry e in Curated)
+                if (Eq(e.Provider, provider) && Eq(e.Kind, kind)) return e.Id;
+            return null;
+        }
+
+        /// <summary>
+        /// The model id a generate_* tool should use: an explicit <paramref name="requested"/> wins,
+        /// else the GUI-selected model for this (kind, provider), else the curated default. Null when
+        /// nothing resolves (the adapter then falls back to its own constant). Single home for the
+        /// empty -> GUI-selected -> catalog-default precedence shared by all three generate tools.
+        /// </summary>
+        public static string ResolveModel(string kind, string provider, string requested)
+        {
+            string model = requested;
+            if (string.IsNullOrWhiteSpace(model)) model = AssetGenPrefs.GetSelectedModel(kind, provider);
+            if (string.IsNullOrWhiteSpace(model)) model = DefaultModelId(provider, kind);
+            return string.IsNullOrWhiteSpace(model) ? null : model;
+        }
 
         /// <summary>Clears any test/refresh state. The refresh overlay is added in Phase 5; no-op today.</summary>
         internal static void ResetForTests() { }

--- a/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MCPForUnity.Editor.Services.AssetGen.Providers;
+
+namespace MCPForUnity.Editor.Services.AssetGen
+{
+    /// <summary>
+    /// One selectable model in the Asset Generation panel, plus the metadata the GUI shows
+    /// (use-case / price / max duration) and the license caveat to surface. <see cref="Id"/> is the
+    /// exact string passed as the tool's <c>model</c> param — it reaches the adapter request as the
+    /// fal endpoint, the Tripo <c>model_version</c>, the Meshy <c>ai_model</c>, or the OpenRouter
+    /// model slug.
+    /// </summary>
+    public sealed class ModelEntry
+    {
+        public string Id;
+        public string Label;
+        public string Provider;
+        public string Kind;              // image | model | audio
+        public string UseCase;
+        public string PriceLabel;
+        public float MaxDurationSeconds; // 0 => not time-bounded (image / 3D)
+        public bool Loopable;
+        public string CommercialNote;    // non-null => show a license caveat under the dropdown
+        public bool FromRefresh;         // true => merged from a fal-catalog refresh (Phase 5)
+    }
+
+    /// <summary>
+    /// Curated, always-present registry of selectable models per provider+kind, with metadata for
+    /// the Asset Generation panel. The first curated entry per (provider, kind) is the default, and
+    /// each default's <see cref="ModelEntry.Id"/> references the owning adapter's constant directly
+    /// — so the panel's shown default always equals what an omitted <c>model</c> param resolves to
+    /// (a drift-guard test pins the two). A fal-catalog refresh overlay is layered on in Phase 5.
+    /// </summary>
+    public static class AssetGenModelCatalog
+    {
+        private static readonly ModelEntry[] Curated =
+        {
+            // Image — fal (FalAdapter.DefaultModel is first => the default)
+            new ModelEntry { Id = FalAdapter.DefaultModel, Label = "FLUX.2", Provider = "fal", Kind = "image", UseCase = "General image" },
+            new ModelEntry { Id = "fal-ai/flux-2/flash", Label = "FLUX.2 Flash", Provider = "fal", Kind = "image", UseCase = "Fast / cheap image" },
+            new ModelEntry { Id = "fal-ai/flux-2-pro", Label = "FLUX.2 Pro", Provider = "fal", Kind = "image", UseCase = "Top-quality image" },
+
+            // Image — openrouter
+            new ModelEntry { Id = OpenRouterAdapter.DefaultModel, Label = "Gemini 2.5 Flash Image", Provider = "openrouter", Kind = "image", UseCase = "General image" },
+
+            // 3D — tripo / meshy (defaults reference the adapter constants)
+            new ModelEntry { Id = TripoAdapter.ModelVersion, Label = "Tripo v3.1", Provider = "tripo", Kind = "model", UseCase = "Text / image -> 3D" },
+            new ModelEntry { Id = "P1-20260311", Label = "Tripo P1 (premium)", Provider = "tripo", Kind = "model", UseCase = "Premium 3D" },
+            new ModelEntry { Id = MeshyAdapter.DefaultModel, Label = "Meshy 6", Provider = "meshy", Kind = "model", UseCase = "Text / image -> 3D" },
+
+            // Audio — fal (order: stable-audio, cassette SFX, cassette music, lyria)
+            new ModelEntry { Id = FalAudioAdapter.DefaultModel, Label = "Stable Audio 2.5", Provider = "fal", Kind = "audio", UseCase = "Music + SFX", PriceLabel = "$0.20/gen", MaxDurationSeconds = 190f,
+                CommercialNote = "Free under $1M annual revenue (Stability Community License); an Enterprise license is required at or above $1M." },
+            new ModelEntry { Id = "cassetteai/sound-effects-generator", Label = "CassetteAI SFX", Provider = "fal", Kind = "audio", UseCase = "Sound effects", PriceLabel = "$0.01/gen", MaxDurationSeconds = 30f },
+            new ModelEntry { Id = "cassetteai/music-generator", Label = "CassetteAI Music", Provider = "fal", Kind = "audio", UseCase = "Background music", PriceLabel = "$0.02/min", MaxDurationSeconds = 180f },
+            new ModelEntry { Id = "fal-ai/lyria2", Label = "Google Lyria 2", Provider = "fal", Kind = "audio", UseCase = "Background music", PriceLabel = "$0.10/30s", MaxDurationSeconds = 30f },
+        };
+
+        /// <summary>Curated entries for a provider+kind, in curated order (default first). Never null.</summary>
+        public static IReadOnlyList<ModelEntry> ForProvider(string provider, string kind)
+        {
+            var result = new List<ModelEntry>();
+            foreach (ModelEntry e in Curated)
+                if (Eq(e.Provider, provider) && Eq(e.Kind, kind)) result.Add(e);
+            return result;
+        }
+
+        /// <summary>The curated entry with this exact id, or null.</summary>
+        public static ModelEntry Find(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return null;
+            foreach (ModelEntry e in Curated)
+                if (Eq(e.Id, id)) return e;
+            return null;
+        }
+
+        /// <summary>The default model id for a provider+kind (the first curated entry), or null.</summary>
+        public static string DefaultModelId(string provider, string kind)
+            => ForProvider(provider, kind).FirstOrDefault()?.Id;
+
+        /// <summary>Clears any test/refresh state. The refresh overlay is added in Phase 5; no-op today.</summary>
+        internal static void ResetForTests() { }
+
+        private static bool Eq(string a, string b)
+            => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs.meta
+++ b/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6497ad09f4143c4a4a27bb6c00a6e3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Services/AssetGen/Http/UnityWebRequestTransport.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Http/UnityWebRequestTransport.cs
@@ -38,6 +38,10 @@ namespace MCPForUnity.Editor.Services.AssetGen.Http
                     request.SetRequestHeader(kv.Key, kv.Value);
                 }
             }
+            // UnityWebRequest re-sends the Authorization header to a 3xx target by default. Never
+            // follow a redirect on an auth-bearing request — the key must not leak to the redirect
+            // host. No-auth downloads may still follow.
+            if (CarriesAuth(spec)) request.redirectLimit = 0;
 
             CancellationTokenRegistration ctReg = default;
             if (ct.CanBeCanceled)
@@ -75,6 +79,16 @@ namespace MCPForUnity.Editor.Services.AssetGen.Http
             };
 
             return tcs.Task;
+        }
+
+        /// <summary>True iff the request carries an Authorization header (case-insensitive key).</summary>
+        internal static bool CarriesAuth(HttpRequestSpec spec)
+        {
+            if (spec?.Headers == null) return false;
+            foreach (var kv in spec.Headers)
+                if (string.Equals(kv.Key, "Authorization", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            return false;
         }
     }
 }

--- a/MCPForUnity/Editor/Services/AssetGen/Import/AudioImportPipeline.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Import/AudioImportPipeline.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
 using UnityEditor;
@@ -24,6 +25,10 @@ namespace MCPForUnity.Editor.Services.AssetGen.Import
 
                 if (!AssetGenPaths.TryGetAssetsRelativePath(localFilePath, out string rel))
                     return Fail(job, "Generated file is not under the Assets folder.");
+
+                // Defense-in-depth: never import a non-audio file even if one slipped past WriteFile.
+                if (!AssetGenJobManager.IsAllowedResultExtension("audio", Path.GetExtension(rel)))
+                    return Fail(job, "Refusing to import a non-audio file type.");
 
                 AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate);
                 ApplyAudioImporterSettings(rel);

--- a/MCPForUnity/Editor/Services/AssetGen/Import/AudioImportPipeline.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Import/AudioImportPipeline.cs
@@ -1,0 +1,71 @@
+using System;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Security;
+using UnityEditor;
+using UnityEngine;
+
+namespace MCPForUnity.Editor.Services.AssetGen.Import
+{
+    /// <summary>
+    /// Imports a downloaded audio clip (already under Assets/) and applies AudioImporter settings.
+    /// Load type is chosen by clip length: short one-shots (SFX) decompress into memory for
+    /// zero-latency playback; medium clips stay compressed in memory; long BGM streams — so a
+    /// generated soundtrack doesn't sit fully decompressed in RAM.
+    /// </summary>
+    public static class AudioImportPipeline
+    {
+        public static AssetGenJob ImportInto(AssetGenJob job, string localFilePath)
+        {
+            if (job == null) return null;
+            try
+            {
+                if (string.IsNullOrEmpty(localFilePath))
+                    return Fail(job, "No file to import.");
+
+                if (!AssetGenPaths.TryGetAssetsRelativePath(localFilePath, out string rel))
+                    return Fail(job, "Generated file is not under the Assets folder.");
+
+                AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate);
+                ApplyAudioImporterSettings(rel);
+
+                job.AssetPath = rel;
+                job.AssetGuid = AssetDatabase.AssetPathToGUID(rel);
+                if (string.IsNullOrEmpty(job.AssetGuid))
+                    return Fail(job, "Imported the audio but Unity did not register it as an asset.");
+
+                if (job.State != AssetGenJobState.Failed)
+                    job.State = AssetGenJobState.Done;
+                return job;
+            }
+            catch (Exception e)
+            {
+                return Fail(job, SecretRedactor.Scrub(e.Message));
+            }
+        }
+
+        private static void ApplyAudioImporterSettings(string rel)
+        {
+            if (!(AssetImporter.GetAtPath(rel) is AudioImporter importer)) return;
+
+            AudioClip clip = AssetDatabase.LoadAssetAtPath<AudioClip>(rel);
+            float len = clip != null ? clip.length : 0f;
+
+            AudioImporterSampleSettings s = importer.defaultSampleSettings;
+            if (len > 30f) s.loadType = AudioClipLoadType.Streaming;              // long BGM
+            else if (len > 10f) s.loadType = AudioClipLoadType.CompressedInMemory; // medium track
+            else s.loadType = AudioClipLoadType.DecompressOnLoad;                  // short SFX one-shot
+            importer.defaultSampleSettings = s;
+
+            importer.forceToMono = false;
+            importer.loadInBackground = false;
+            importer.SaveAndReimport();
+        }
+
+        private static AssetGenJob Fail(AssetGenJob job, string message)
+        {
+            job.State = AssetGenJobState.Failed;
+            job.Error = message;
+            return job;
+        }
+    }
+}

--- a/MCPForUnity/Editor/Services/AssetGen/Import/AudioImportPipeline.cs.meta
+++ b/MCPForUnity/Editor/Services/AssetGen/Import/AudioImportPipeline.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb94201110f1247c7bdf60548a93a30e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MCPForUnity/Editor/Services/AssetGen/Import/ImageImportPipeline.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Import/ImageImportPipeline.cs
@@ -23,6 +23,10 @@ namespace MCPForUnity.Editor.Services.AssetGen.Import
                 if (!AssetGenPaths.TryGetAssetsRelativePath(localFilePath, out string rel))
                     return Fail(job, "Generated file is not under the Assets folder.");
 
+                // Defense-in-depth: never import a non-image file even if one slipped past WriteFile.
+                if (!AssetGenJobManager.IsAllowedResultExtension("image", Path.GetExtension(rel)))
+                    return Fail(job, "Refusing to import a non-image file type.");
+
                 AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate);
 
                 if (AssetImporter.GetAtPath(rel) is TextureImporter importer)

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/AssetGenProviders.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/AssetGenProviders.cs
@@ -6,8 +6,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
 {
     /// <summary>
     /// Factory + registry for asset-gen provider adapters. Resolves a provider id to its adapter
-    /// (model: tripo/meshy; image: fal/openrouter; marketplace: sketchfab); unknown ids throw
-    /// <see cref="NotSupportedException"/>. <see cref="List"/> advertises providers and reports
+    /// (model: tripo/meshy; image: fal/openrouter; audio: fal; marketplace: sketchfab); unknown ids
+    /// throw <see cref="NotSupportedException"/>. <see cref="List"/> advertises providers and reports
     /// <c>Configured</c> existence only — never a key value.
     /// </summary>
     public static class AssetGenProviders
@@ -38,6 +38,17 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
             }
         }
 
+        public static IAudioProviderAdapter Audio(string id)
+        {
+            switch ((id ?? string.Empty).ToLowerInvariant())
+            {
+                case "fal":
+                    return new FalAudioAdapter();
+                default:
+                    throw new NotSupportedException($"Unknown audio provider '{id}'.");
+            }
+        }
+
         public static IMarketplaceProviderAdapter Marketplace(string id)
         {
             switch ((id ?? string.Empty).ToLowerInvariant())
@@ -58,6 +69,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 new ProviderInfo { Id = "sketchfab", Kind = "marketplace", Configured = IsConfigured("sketchfab"), Capabilities = new[] { "search", "import" } },
                 new ProviderInfo { Id = "fal", Kind = "image", Configured = IsConfigured("fal"), Capabilities = new[] { "text", "image" } },
                 new ProviderInfo { Id = "openrouter", Kind = "image", Configured = IsConfigured("openrouter"), Capabilities = new[] { "text", "image" } },
+                // fal appears twice by design — once per kind (image + audio) — sharing the single "fal" key.
+                new ProviderInfo { Id = "fal", Kind = "audio", Configured = IsConfigured("fal"), Capabilities = new[] { "text", "music", "sfx" } },
             };
         }
 

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/FalAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/FalAdapter.cs
@@ -19,7 +19,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
         private const string QueueBase = "https://queue.fal.run/";
         // FLUX.2 [dev] — current SOTA default (cheaper and better than FLUX.1 dev). Alternatives:
         // fal-ai/flux-2/flash (fastest/cheapest), fal-ai/flux-2-pro (top quality).
-        private const string DefaultModel = "fal-ai/flux-2";
+        // internal so the model catalog references it directly (single source of truth, drift-guarded).
+        internal const string DefaultModel = "fal-ai/flux-2";
 
         public string Id => "fal";
 

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/FalAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/FalAdapter.cs
@@ -17,6 +17,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     public sealed class FalAdapter : IImageProviderAdapter
     {
         private const string QueueBase = "https://queue.fal.run/";
+        private const string QueueHost = "queue.fal.run";
         // FLUX.2 [dev] — current SOTA default (cheaper and better than FLUX.1 dev). Alternatives:
         // fal-ai/flux-2/flash (fastest/cheapest), fal-ai/flux-2-pro (top quality).
         // internal so the model catalog references it directly (single source of truth, drift-guarded).
@@ -53,6 +54,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
             if (!image && req.Width > 0 && req.Height > 0)
                 body["image_size"] = new JObject { ["width"] = req.Width, ["height"] = req.Height };
 
+            ProviderHttp.RequireHost(url, QueueHost, apiKey, "fal submit");
+
             var spec = new HttpRequestSpec
             {
                 Method = "POST",
@@ -76,6 +79,9 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 // so build from the base model id (not `url`, which may end in /edit).
                 responseUrl = QueueBase + model + "/requests/" + requestId;
             }
+            // The response_url is provider-controlled; refuse to later attach the key to any host
+            // other than the fal queue.
+            ProviderHttp.RequireHost(responseUrl, QueueHost, apiKey, "fal submit response_url");
             return responseUrl;
         }
 
@@ -83,6 +89,9 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
         {
             if (string.IsNullOrEmpty(providerJobId)) throw new ArgumentNullException(nameof(providerJobId));
             string responseUrl = providerJobId;
+            // providerJobId is provider-supplied (the submit-time response_url). Re-validate before
+            // attaching the key so a poisoned URL can never exfiltrate it.
+            ProviderHttp.RequireHost(responseUrl, QueueHost, apiKey, "fal poll");
 
             var statusSpec = new HttpRequestSpec { Method = "GET", Url = responseUrl + "/status" };
             statusSpec.Headers["Authorization"] = "Key " + apiKey;
@@ -109,7 +118,10 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                     result.Error = SecretRedactor.Scrub(statusJson["error"]?.ToString() ?? "fal task failed.", apiKey);
                     return result;
                 default:
-                    result.State = ProviderPollState.Running;
+                    // An unmapped terminal status would otherwise poll until the 600s job timeout —
+                    // fail fast instead.
+                    result.State = ProviderPollState.Failed;
+                    result.Error = SecretRedactor.Scrub($"fal returned an unexpected status '{status}'.", apiKey);
                     return result;
             }
 

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
@@ -77,8 +77,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 float dur = req.Duration > 0f ? req.Duration : entry.DefaultDurationSeconds;
                 float floor = Math.Max(1f, entry.MinDurationSeconds);
                 dur = Math.Min(Math.Max(dur, floor), entry.MaxDurationSeconds);
-                int seconds = (int)Math.Round(dur);
-                if (seconds < 1) seconds = 1;
+                // Floor (not round) so we never exceed the requested duration, then enforce >= 1.
+                int seconds = Math.Max(1, (int)Math.Floor(dur));
                 body[entry.DurationField] = seconds;
             }
             return body;

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MCPForUnity.Editor.Security;
+using MCPForUnity.Editor.Services.AssetGen.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MCPForUnity.Editor.Services.AssetGen.Providers
+{
+    /// <summary>
+    /// fal.ai audio provider via the queue API. One adapter fronts every v1 audio model
+    /// (stable-audio-25, cassetteai/*, lyria2); the model id in <see cref="AudioGenRequest.Model"/>
+    /// selects the endpoint. Submits to queue.fal.run/{model} (auth header
+    /// "Authorization: Key &lt;key&gt;"), polls status, then returns the result audio URL for the job
+    /// manager to download. Reuses the single existing "fal" secure key.
+    /// </summary>
+    public sealed class FalAudioAdapter : IAudioProviderAdapter
+    {
+        private const string QueueBase = "https://queue.fal.run/";
+        // Stable Audio 2.5: music + SFX in one model, up to ~190s. The catalog default.
+        private const string DefaultModel = "fal-ai/stable-audio-25/text-to-audio";
+
+        public string Id => "fal";
+
+        public async Task<string> SubmitAsync(AudioGenRequest req, string apiKey, IHttpTransport http, CancellationToken ct)
+        {
+            if (req == null) throw new ArgumentNullException(nameof(req));
+            if (http == null) throw new ArgumentNullException(nameof(http));
+
+            string model = string.IsNullOrEmpty(req.Model) ? DefaultModel : req.Model;
+            string url = QueueBase + model;
+
+            var spec = new HttpRequestSpec
+            {
+                Method = "POST",
+                Url = url,
+                ContentType = "application/json",
+                Body = Encoding.UTF8.GetBytes(BuildBody(model, req).ToString(Formatting.None))
+            };
+            spec.Headers["Authorization"] = "Key " + apiKey;
+
+            HttpResult res = await http.SendAsync(spec, ct);
+            JObject json = ParseOk(res, apiKey, "submit");
+
+            string responseUrl = json["response_url"]?.ToString();
+            if (string.IsNullOrEmpty(responseUrl))
+            {
+                string requestId = json["request_id"]?.ToString();
+                if (string.IsNullOrEmpty(requestId))
+                    throw new Exception(SecretRedactor.Scrub("fal submit returned no request_id: " + ProviderHttp.Truncate(res?.Text), apiKey));
+                responseUrl = QueueBase + model + "/requests/" + requestId;
+            }
+            return responseUrl;
+        }
+
+        // Only Stable Audio and CassetteAI SFX have a confirmed duration knob. CassetteAI Music and
+        // Lyria 2 ship prompt-only until their body schemas are verified against a live response.
+        private static JObject BuildBody(string model, AudioGenRequest req)
+        {
+            var body = new JObject { ["prompt"] = req.Prompt ?? string.Empty };
+            if (req.Duration > 0f)
+            {
+                if (model.IndexOf("stable-audio-25", StringComparison.OrdinalIgnoreCase) >= 0)
+                    body["seconds_total"] = (int)Math.Min(req.Duration, 190f);
+                else if (model.IndexOf("sound-effects", StringComparison.OrdinalIgnoreCase) >= 0)
+                    body["duration"] = (int)Math.Min(req.Duration, 30f);
+            }
+            return body;
+        }
+
+        public async Task<ProviderPollResult> PollAsync(string providerJobId, string apiKey, IHttpTransport http, CancellationToken ct)
+        {
+            if (string.IsNullOrEmpty(providerJobId)) throw new ArgumentNullException(nameof(providerJobId));
+            string responseUrl = providerJobId;
+
+            var statusSpec = new HttpRequestSpec { Method = "GET", Url = responseUrl + "/status" };
+            statusSpec.Headers["Authorization"] = "Key " + apiKey;
+            HttpResult statusRes = await http.SendAsync(statusSpec, ct);
+            JObject statusJson = ParseOk(statusRes, apiKey, "status");
+
+            string status = (statusJson["status"]?.ToString() ?? string.Empty).ToUpperInvariant();
+            var result = new ProviderPollResult();
+            switch (status)
+            {
+                case "COMPLETED":
+                case "OK":
+                    result.State = ProviderPollState.Succeeded;
+                    break;
+                case "IN_PROGRESS":
+                    result.State = ProviderPollState.Running;
+                    return result;
+                case "IN_QUEUE":
+                    result.State = ProviderPollState.Queued;
+                    return result;
+                case "ERROR":
+                case "FAILED":
+                    result.State = ProviderPollState.Failed;
+                    result.Error = SecretRedactor.Scrub(statusJson["error"]?.ToString() ?? "fal task failed.", apiKey);
+                    return result;
+                default:
+                    result.State = ProviderPollState.Running;
+                    return result;
+            }
+
+            var resultSpec = new HttpRequestSpec { Method = "GET", Url = responseUrl };
+            resultSpec.Headers["Authorization"] = "Key " + apiKey;
+            HttpResult resultRes = await http.SendAsync(resultSpec, ct);
+            JObject resultJson = ParseOk(resultRes, apiKey, "result");
+
+            string audioUrl = ExtractAudioUrl(resultJson);
+            if (string.IsNullOrEmpty(audioUrl))
+            {
+                result.State = ProviderPollState.Failed;
+                result.Error = "fal completed but no audio URL was present in the result.";
+                return result;
+            }
+            result.Progress = 1f;
+            result.DownloadUrl = audioUrl;
+            // CassetteAI/Lyria return mp3, Stable Audio wav — derive the ext from the result URL.
+            result.ResultExt = ExtractExt(audioUrl);
+            return result;
+        }
+
+        private static string ExtractAudioUrl(JObject result)
+        {
+            string u = result["audio"]?["url"]?.ToString();
+            if (!string.IsNullOrEmpty(u)) return u;
+            u = result["audio_file"]?["url"]?.ToString();
+            if (!string.IsNullOrEmpty(u)) return u;
+            u = result["audio_url"]?.ToString();
+            return string.IsNullOrEmpty(u) ? null : u;
+        }
+
+        private static string ExtractExt(string url)
+        {
+            try
+            {
+                string ext = Path.GetExtension(new Uri(url).AbsolutePath).TrimStart('.').ToLowerInvariant();
+                return string.IsNullOrEmpty(ext) ? "wav" : ext;
+            }
+            catch { return "wav"; }
+        }
+
+        private static JObject ParseOk(HttpResult res, string apiKey, string phase)
+        {
+            string text = ProviderHttp.BodyText(res);
+
+            JObject json = null;
+            if (!string.IsNullOrEmpty(text))
+            {
+                try { json = JObject.Parse(text); } catch { /* non-JSON */ }
+            }
+
+            bool ok = res?.Ok == true;
+            if (!ok)
+            {
+                string detail = json?["detail"]?.ToString() ?? json?["error"]?.ToString() ?? ProviderHttp.Truncate(text);
+                throw new Exception(SecretRedactor.Scrub($"fal {phase} failed (status={res?.Status}): {detail}", apiKey));
+            }
+            return json ?? new JObject();
+        }
+    }
+}

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
@@ -21,7 +21,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     {
         private const string QueueBase = "https://queue.fal.run/";
         // Stable Audio 2.5: music + SFX in one model, up to ~190s. The catalog default.
-        private const string DefaultModel = "fal-ai/stable-audio-25/text-to-audio";
+        // internal so the model catalog references it directly (single source of truth, drift-guarded).
+        internal const string DefaultModel = "fal-ai/stable-audio-25/text-to-audio";
 
         public string Id => "fal";
 

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs
@@ -20,6 +20,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     public sealed class FalAudioAdapter : IAudioProviderAdapter
     {
         private const string QueueBase = "https://queue.fal.run/";
+        private const string QueueHost = "queue.fal.run";
         // Stable Audio 2.5: music + SFX in one model, up to ~190s. The catalog default.
         // internal so the model catalog references it directly (single source of truth, drift-guarded).
         internal const string DefaultModel = "fal-ai/stable-audio-25/text-to-audio";
@@ -33,6 +34,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
 
             string model = string.IsNullOrEmpty(req.Model) ? DefaultModel : req.Model;
             string url = QueueBase + model;
+            ProviderHttp.RequireHost(url, QueueHost, apiKey, "fal submit");
 
             var spec = new HttpRequestSpec
             {
@@ -54,20 +56,30 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                     throw new Exception(SecretRedactor.Scrub("fal submit returned no request_id: " + ProviderHttp.Truncate(res?.Text), apiKey));
                 responseUrl = QueueBase + model + "/requests/" + requestId;
             }
+            // The response_url is provider-controlled; refuse to later attach the key to any host
+            // other than the fal queue.
+            ProviderHttp.RequireHost(responseUrl, QueueHost, apiKey, "fal submit response_url");
             return responseUrl;
         }
 
-        // Only Stable Audio and CassetteAI SFX have a confirmed duration knob. CassetteAI Music and
-        // Lyria 2 ship prompt-only until their body schemas are verified against a live response.
+        // Duration is catalog-driven: the model's ModelEntry names the request key (seconds_total /
+        // duration) and the clamp bounds. A duration-controllable endpoint (e.g. CassetteAI Music)
+        // always sends a duration >= 1 — a prompt-only body is rejected with fal 422
+        // "duration Field required" — while a non-duration model (Lyria) or an unknown model stays
+        // prompt-only.
         private static JObject BuildBody(string model, AudioGenRequest req)
         {
             var body = new JObject { ["prompt"] = req.Prompt ?? string.Empty };
-            if (req.Duration > 0f)
+
+            ModelEntry entry = AssetGenModelCatalog.Find(model);
+            if (entry != null && !string.IsNullOrEmpty(entry.DurationField))
             {
-                if (model.IndexOf("stable-audio-25", StringComparison.OrdinalIgnoreCase) >= 0)
-                    body["seconds_total"] = (int)Math.Min(req.Duration, 190f);
-                else if (model.IndexOf("sound-effects", StringComparison.OrdinalIgnoreCase) >= 0)
-                    body["duration"] = (int)Math.Min(req.Duration, 30f);
+                float dur = req.Duration > 0f ? req.Duration : entry.DefaultDurationSeconds;
+                float floor = Math.Max(1f, entry.MinDurationSeconds);
+                dur = Math.Min(Math.Max(dur, floor), entry.MaxDurationSeconds);
+                int seconds = (int)Math.Round(dur);
+                if (seconds < 1) seconds = 1;
+                body[entry.DurationField] = seconds;
             }
             return body;
         }
@@ -76,6 +88,9 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
         {
             if (string.IsNullOrEmpty(providerJobId)) throw new ArgumentNullException(nameof(providerJobId));
             string responseUrl = providerJobId;
+            // providerJobId is provider-supplied (the submit-time response_url). Re-validate before
+            // attaching the key so a poisoned URL can never exfiltrate it.
+            ProviderHttp.RequireHost(responseUrl, QueueHost, apiKey, "fal poll");
 
             var statusSpec = new HttpRequestSpec { Method = "GET", Url = responseUrl + "/status" };
             statusSpec.Headers["Authorization"] = "Key " + apiKey;
@@ -102,7 +117,10 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                     result.Error = SecretRedactor.Scrub(statusJson["error"]?.ToString() ?? "fal task failed.", apiKey);
                     return result;
                 default:
-                    result.State = ProviderPollState.Running;
+                    // An unmapped terminal status would otherwise poll until the 600s job timeout —
+                    // fail fast instead.
+                    result.State = ProviderPollState.Failed;
+                    result.Error = SecretRedactor.Scrub($"fal returned an unexpected status '{status}'.", apiKey);
                     return result;
             }
 

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs.meta
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/FalAudioAdapter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13bdc532957f463e94feb4c25df0329f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/IProviderAdapters.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/IProviderAdapters.cs
@@ -24,6 +24,18 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
         Task<ProviderPollResult> PollAsync(string providerJobId, string apiKey, IHttpTransport http, CancellationToken ct);
     }
 
+    /// <summary>
+    /// A generative audio provider (fal.ai for v1). All v1 audio models route through the single
+    /// fal adapter; the model is chosen inside <see cref="AudioGenRequest.Model"/>. The api key is
+    /// passed in at call time and never cached on the adapter.
+    /// </summary>
+    public interface IAudioProviderAdapter
+    {
+        string Id { get; }
+        Task<string> SubmitAsync(AudioGenRequest req, string apiKey, IHttpTransport http, CancellationToken ct);
+        Task<ProviderPollResult> PollAsync(string providerJobId, string apiKey, IHttpTransport http, CancellationToken ct);
+    }
+
     /// <summary>A 3D marketplace provider (Sketchfab, ...). Search/preview/resolve, not generative. Phase 6.</summary>
     public interface IMarketplaceProviderAdapter
     {

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/MeshyAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/MeshyAdapter.cs
@@ -21,6 +21,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     {
         private const string TextEndpoint = "https://api.meshy.ai/openapi/v2/text-to-3d";
         private const string ImageEndpoint = "https://api.meshy.ai/openapi/v1/image-to-3d";
+        // Default model; the catalog mirrors this and the drift-guard test pins the two together.
+        internal const string DefaultModel = "meshy-6";
 
         public string Id => "meshy";
 
@@ -28,6 +30,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
         private string _format = "glb";
         private bool _isImage;
         private bool _wantTexture = true;
+        private string _aiModel = DefaultModel; // stashed so the refine task reuses the submit model
         private string _refineTaskId;
         private bool _refineSubmitted;
 
@@ -38,6 +41,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
 
             _format = string.IsNullOrEmpty(req.Format) ? "glb" : req.Format.TrimStart('.').ToLowerInvariant();
             _wantTexture = req.Texture;
+            _aiModel = string.IsNullOrEmpty(req.Model) ? DefaultModel : req.Model;
             _isImage = string.Equals(req.Mode, "image", StringComparison.OrdinalIgnoreCase)
                        && (!string.IsNullOrEmpty(req.ImageUrl) || !string.IsNullOrEmpty(req.ImagePath));
 
@@ -52,7 +56,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 body = new JObject
                 {
                     ["image_url"] = imageRef,
-                    ["ai_model"] = "meshy-6",
+                    ["ai_model"] = _aiModel,
                     ["should_texture"] = _wantTexture
                 };
             }
@@ -64,7 +68,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 {
                     ["mode"] = "preview",
                     ["prompt"] = req.Prompt ?? string.Empty,
-                    ["ai_model"] = "meshy-6"
+                    ["ai_model"] = _aiModel
                 };
             }
 
@@ -107,7 +111,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                     {
                         ["mode"] = "refine",
                         ["preview_task_id"] = providerJobId,
-                        ["ai_model"] = "meshy-6"
+                        ["ai_model"] = _aiModel
                     };
                     _refineTaskId = await PostTask(TextEndpoint, refineBody, apiKey, http, ct, "refine");
                     _refineSubmitted = true;

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/OpenRouterAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/OpenRouterAdapter.cs
@@ -18,7 +18,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     public sealed class OpenRouterAdapter : IImageProviderAdapter
     {
         private const string Endpoint = "https://openrouter.ai/api/v1/chat/completions";
-        private const string DefaultModel = "google/gemini-2.5-flash-image";
+        // internal so the model catalog references it directly (single source of truth).
+        internal const string DefaultModel = "google/gemini-2.5-flash-image";
 
         public string Id => "openrouter";
 

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/ProviderHttp.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/ProviderHttp.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Text;
+using MCPForUnity.Editor.Security;
 using MCPForUnity.Editor.Services.AssetGen.Http;
 
 namespace MCPForUnity.Editor.Services.AssetGen.Providers
@@ -9,6 +11,24 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     /// </summary>
     internal static class ProviderHttp
     {
+        /// <summary>
+        /// Throw unless <paramref name="url"/> is an absolute https URL whose host is exactly
+        /// <paramref name="allowedHost"/>. Adapters route every auth-bearing request URL through
+        /// this so a malicious/MITM'd provider response (e.g. a rogue response_url) can't redirect
+        /// the API key to an attacker host. The error is scrubbed of the key.
+        /// </summary>
+        public static void RequireHost(string url, string allowedHost, string apiKey, string context)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri u)
+                || u.Scheme != Uri.UriSchemeHttps
+                || !string.Equals(u.Host, allowedHost, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception(SecretRedactor.Scrub(
+                    $"{context}: refusing to send credentials to an unexpected host in URL '{url}' (expected https://{allowedHost}).",
+                    apiKey));
+            }
+        }
+
         /// <summary>Response text, falling back to a UTF-8 decode of the raw body when Text is empty.</summary>
         public static string BodyText(HttpResult res)
         {

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/ProviderModels.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/ProviderModels.cs
@@ -40,6 +40,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
         public float TargetSize = 1f;
         public bool Texture = true;
         public string Tier;
+        public string Model; // provider model id/version; null => adapter DefaultModel
         public string Name;
         public string OutputFolder;
     }
@@ -62,13 +63,28 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     }
 
     /// <summary>
+    /// Request to generate an audio clip (fal.ai for v1). <see cref="Model"/> selects the fal
+    /// endpoint (stable-audio-25 / cassetteai/* / lyria2). <see cref="Duration"/> is a per-gen
+    /// input; 0 => provider default. Never carries a key; never persisted (transient request only).
+    /// </summary>
+    public sealed class AudioGenRequest
+    {
+        public string Provider; // "fal" for v1
+        public string Model; // fal model id, e.g. fal-ai/stable-audio-25/text-to-audio
+        public string Prompt;
+        public float Duration; // seconds; 0 => per-model default. Soft-clamped per model in the adapter.
+        public string Name;
+        public string OutputFolder;
+    }
+
+    /// <summary>
     /// Public, key-free description of a provider for <c>list_providers</c>. Never carries a key
     /// value — <see cref="Configured"/> reports existence only.
     /// </summary>
     public sealed class ProviderInfo
     {
         public string Id;
-        public string Kind; // model | image | marketplace
+        public string Kind; // model | image | audio | marketplace
         public bool Configured;
         public string[] Capabilities;
     }

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/TripoAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/TripoAdapter.cs
@@ -19,7 +19,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
     {
         private const string TaskEndpoint = "https://api.tripo3d.ai/v2/openapi/task";
         // Current recommended Tripo model (v3.1). Premium alternative: P1-20260311.
-        private const string ModelVersion = "v3.1-20260211";
+        // internal so the model catalog references it directly (single source of truth, drift-guarded).
+        internal const string ModelVersion = "v3.1-20260211";
 
         public string Id => "tripo";
 
@@ -54,7 +55,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 {
                     ["type"] = "text_to_model",
                     ["prompt"] = req.Prompt ?? string.Empty,
-                    ["model_version"] = ModelVersion
+                    ["model_version"] = string.IsNullOrEmpty(req.Model) ? ModelVersion : req.Model
                 };
             }
 

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/TripoAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/TripoAdapter.cs
@@ -42,6 +42,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 body = new JObject
                 {
                     ["type"] = "image_to_model",
+                    ["model_version"] = string.IsNullOrEmpty(req.Model) ? ModelVersion : req.Model,
                     ["file"] = new JObject
                     {
                         ["type"] = "url",

--- a/MCPForUnity/Editor/Tools/AssetGen/AssetGenToolHelpers.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/AssetGenToolHelpers.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Services.AssetGen;
+using MCPForUnity.Editor.Services.AssetGen.Providers;
+
+namespace MCPForUnity.Editor.Tools.AssetGen
+{
+    /// <summary>
+    /// Shared action handlers for the generate_* asset tools (audio / image / model). The three tools
+    /// differ only in their generate step and a kind label; <c>status</c>, <c>cancel</c>, and
+    /// <c>list_providers</c> are identical modulo that label, so they live here once.
+    /// </summary>
+    internal static class AssetGenToolHelpers
+    {
+        /// <summary>
+        /// Poll a job by id and map its state to a client response. <paramref name="kindLabel"/>
+        /// prefixes the human-readable message (e.g. "Audio", "Image", "3D model").
+        /// </summary>
+        public static object Status(ToolParams p, string kindLabel, double pollIntervalSeconds)
+        {
+            string jobId = p.Get("job_id");
+            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for status.");
+            AssetGenJob job = AssetGenJobManager.GetJob(jobId);
+            if (job == null) return new ErrorResponse($"No job found with ID '{jobId}'.");
+
+            switch (job.State)
+            {
+                case AssetGenJobState.Done:
+                    return new SuccessResponse(
+                        $"{kindLabel} generated: {job.AssetPath}",
+                        new { state = "done", asset_path = job.AssetPath, asset_guid = job.AssetGuid, progress = 1f });
+                case AssetGenJobState.Failed:
+                    return new ErrorResponse(job.Error ?? "Generation failed.", new { state = "failed" });
+                case AssetGenJobState.Canceled:
+                    return new SuccessResponse("Generation canceled.", new { state = "canceled" });
+                default:
+                    return new PendingResponse(
+                        $"{kindLabel} {job.State.ToString().ToLowerInvariant()} ({job.Progress:P0}).",
+                        pollIntervalSeconds: pollIntervalSeconds,
+                        data: new { job_id = job.JobId, state = job.State.ToString().ToLowerInvariant(), progress = job.Progress });
+            }
+        }
+
+        /// <summary>Request cancellation of a job by id.</summary>
+        public static object Cancel(ToolParams p)
+        {
+            string jobId = p.Get("job_id");
+            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for cancel.");
+            return AssetGenJobManager.Cancel(jobId)
+                ? new SuccessResponse($"Cancel requested for job '{jobId}'.")
+                : new ErrorResponse($"No cancelable job found with ID '{jobId}'.");
+        }
+
+        /// <summary>List the configured providers for a given kind (audio / image / model).</summary>
+        public static object ListProviders(string kind)
+        {
+            var list = new List<object>();
+            foreach (ProviderInfo info in AssetGenProviders.List())
+            {
+                if (info.Kind != kind) continue;
+                list.Add(new { id = info.Id, kind = info.Kind, configured = info.Configured, capabilities = info.Capabilities });
+            }
+            return new SuccessResponse($"{list.Count} {kind} provider(s).", new { providers = list });
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/AssetGen/AssetGenToolHelpers.cs.meta
+++ b/MCPForUnity/Editor/Tools/AssetGen/AssetGenToolHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8320589d7a679498c8ad56b59f662878
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs
@@ -9,12 +9,13 @@ using Newtonsoft.Json.Linq;
 namespace MCPForUnity.Editor.Tools.AssetGen
 {
     /// <summary>
-    /// 2D image generation via an aggregator (fal.ai / OpenRouter). Triggered here (never from the
-    /// GUI); the C# side reads the provider key from the secure store and runs the job. Returns a
-    /// job_id immediately; the client polls the `status` action.
+    /// Audio generation (SFX / music) via fal.ai. Triggered here (never from the GUI); the C# side
+    /// reads the fal key from the secure store and runs the job. Returns a job_id immediately; the
+    /// client polls the `status` action. When `model` is omitted it falls back to the model selected
+    /// in the Asset Generation tab, then the catalog default.
     /// </summary>
-    [McpForUnityTool("generate_image", AutoRegister = false, Group = "asset_gen", RequiresPolling = true, PollAction = "status", MaxPollSeconds = 300)]
-    public static class GenerateImage
+    [McpForUnityTool("generate_audio", AutoRegister = false, Group = "asset_gen", RequiresPolling = true, PollAction = "status", MaxPollSeconds = 600)]
+    public static class GenerateAudio
     {
         public static object HandleCommand(JObject @params)
         {
@@ -26,14 +27,12 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 switch (action)
                 {
                     case "generate": return Generate(p);
-                    case "remove_background":
-                        return new ErrorResponse("remove_background is not implemented in this version.");
                     case "status": return Status(p);
                     case "cancel": return Cancel(p);
                     case "list_providers": return ListProviders();
                     case "": return new ErrorResponse("'action' parameter is required.");
                     default:
-                        return new ErrorResponse($"Unknown action: '{action}'. Supported: generate, remove_background, status, cancel, list_providers.");
+                        return new ErrorResponse($"Unknown action: '{action}'. Supported: generate, status, cancel, list_providers.");
                 }
             }
             catch (NotSupportedException nse)
@@ -49,53 +48,41 @@ namespace MCPForUnity.Editor.Tools.AssetGen
         private static object Generate(ToolParams p)
         {
             string provider = (p.Get("provider", "fal") ?? "fal").ToLowerInvariant();
-            AssetGenProviders.Image(provider); // throws NotSupportedException for unknown providers
+            AssetGenProviders.Audio(provider); // throws NotSupportedException for unknown providers
 
             if (!SecureKeyStore.Current.Has(provider))
                 return new ErrorResponse(AssetGenProviders.MissingKeyMessage(provider));
 
-            // Empty -> GUI-selected model -> catalog default. Null still reaches the adapter's own
-            // default (no regression when nothing is selected anywhere).
-            string model = p.Get("model");
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenPrefs.GetSelectedModel("image", provider);
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenModelCatalog.DefaultModelId(provider, "image");
+            string prompt = p.Get("prompt");
+            if (string.IsNullOrWhiteSpace(prompt))
+                return new ErrorResponse("'prompt' is required for audio generation.");
 
-            var req = new ImageGenRequest
+            // Empty -> GUI-selected model -> catalog default. A null model reaches the adapter's own
+            // default; a resolved id is passed through verbatim (the catalog default equals the
+            // adapter constant, so an omitted model is a no-op either way).
+            string model = p.Get("model");
+            if (string.IsNullOrWhiteSpace(model)) model = AssetGenPrefs.GetSelectedModel("audio", provider);
+            if (string.IsNullOrWhiteSpace(model)) model = AssetGenModelCatalog.DefaultModelId(provider, "audio");
+
+            var req = new AudioGenRequest
             {
                 Provider = provider,
-                Mode = (p.Get("mode", "text") ?? "text").ToLowerInvariant(),
-                Prompt = p.Get("prompt"),
-                ImagePath = p.Get("imagePath"),
-                ImageUrl = p.Get("imageUrl"),
                 Model = string.IsNullOrWhiteSpace(model) ? null : model,
-                Transparent = p.GetBool("transparent", false),
-                AsSprite = p.GetBool("asSprite", true),
-                Width = p.GetInt("width", 0) ?? 0,
-                Height = p.GetInt("height", 0) ?? 0,
+                Prompt = prompt,
+                Duration = p.GetFloat("duration", 0f) ?? 0f,
                 Name = p.Get("name"),
                 OutputFolder = p.Get("outputFolder"),
             };
             if (!NormalizeOutputFolder(req.OutputFolder, out req.OutputFolder, out string outputErr))
                 return new ErrorResponse(outputErr);
 
-            if (req.Mode == "text" && string.IsNullOrWhiteSpace(req.Prompt))
-                return new ErrorResponse("'prompt' is required for text mode.");
-            if (req.Mode == "image" && string.IsNullOrWhiteSpace(req.ImageUrl))
-            {
-                if (string.IsNullOrWhiteSpace(req.ImagePath))
-                    return new ErrorResponse("image mode requires 'image_url' or 'image_path'.");
-                if (!LocalImage.ResolveExisting(req.ImagePath, out string absImg, out string imgErr))
-                    return new ErrorResponse(imgErr);
-                req.ImagePath = absImg;
-            }
-
-            AssetGenJob job = AssetGenJobManager.StartImageGeneration(req);
+            AssetGenJob job = AssetGenJobManager.StartAudioGeneration(req);
             if (job.State == AssetGenJobState.Failed)
                 return new ErrorResponse(job.Error ?? "Failed to start generation.");
 
             return new PendingResponse(
-                $"Image generation started with '{provider}'. Poll the status action with this job_id.",
-                pollIntervalSeconds: 2.0,
+                $"Audio generation started with '{provider}'. Poll the status action with this job_id.",
+                pollIntervalSeconds: 3.0,
                 data: new { job_id = job.JobId, provider, status = "pending" });
         }
 
@@ -120,7 +107,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
             {
                 case AssetGenJobState.Done:
                     return new SuccessResponse(
-                        $"Image generated: {job.AssetPath}",
+                        $"Audio generated: {job.AssetPath}",
                         new { state = "done", asset_path = job.AssetPath, asset_guid = job.AssetGuid, progress = 1f });
                 case AssetGenJobState.Failed:
                     return new ErrorResponse(job.Error ?? "Generation failed.", new { state = "failed" });
@@ -128,8 +115,8 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                     return new SuccessResponse("Generation canceled.", new { state = "canceled" });
                 default:
                     return new PendingResponse(
-                        $"Image {job.State.ToString().ToLowerInvariant()} ({job.Progress:P0}).",
-                        pollIntervalSeconds: 2.0,
+                        $"Audio {job.State.ToString().ToLowerInvariant()} ({job.Progress:P0}).",
+                        pollIntervalSeconds: 3.0,
                         data: new { job_id = job.JobId, state = job.State.ToString().ToLowerInvariant(), progress = job.Progress });
             }
         }
@@ -148,10 +135,10 @@ namespace MCPForUnity.Editor.Tools.AssetGen
             var list = new List<object>();
             foreach (ProviderInfo info in AssetGenProviders.List())
             {
-                if (info.Kind != "image") continue;
+                if (info.Kind != "audio") continue;
                 list.Add(new { id = info.Id, kind = info.Kind, configured = info.Configured, capabilities = info.Capabilities });
             }
-            return new SuccessResponse($"{list.Count} image provider(s).", new { providers = list });
+            return new SuccessResponse($"{list.Count} audio provider(s).", new { providers = list });
         }
     }
 }

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
 using MCPForUnity.Editor.Services.AssetGen;
@@ -12,7 +11,8 @@ namespace MCPForUnity.Editor.Tools.AssetGen
     /// Audio generation (SFX / music) via fal.ai. Triggered here (never from the GUI); the C# side
     /// reads the fal key from the secure store and runs the job. Returns a job_id immediately; the
     /// client polls the `status` action. When `model` is omitted it falls back to the model selected
-    /// in the Asset Generation tab, then the catalog default.
+    /// in the Asset Generation tab, then the catalog default. Status / cancel / list_providers are
+    /// shared across the generate_* tools via <see cref="AssetGenToolHelpers"/>.
     /// </summary>
     [McpForUnityTool("generate_audio", AutoRegister = false, Group = "asset_gen", RequiresPolling = true, PollAction = "status", MaxPollSeconds = 600)]
     public static class GenerateAudio
@@ -27,9 +27,9 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 switch (action)
                 {
                     case "generate": return Generate(p);
-                    case "status": return Status(p);
-                    case "cancel": return Cancel(p);
-                    case "list_providers": return ListProviders();
+                    case "status": return AssetGenToolHelpers.Status(p, "Audio", 3.0);
+                    case "cancel": return AssetGenToolHelpers.Cancel(p);
+                    case "list_providers": return AssetGenToolHelpers.ListProviders("audio");
                     case "": return new ErrorResponse("'action' parameter is required.");
                     default:
                         return new ErrorResponse($"Unknown action: '{action}'. Supported: generate, status, cancel, list_providers.");
@@ -71,7 +71,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 Name = p.Get("name"),
                 OutputFolder = p.Get("outputFolder"),
             };
-            if (!NormalizeOutputFolder(req.OutputFolder, out req.OutputFolder, out string outputErr))
+            if (!AssetGenPaths.NormalizeOutputFolder(req.OutputFolder, out req.OutputFolder, out string outputErr))
                 return new ErrorResponse(outputErr);
 
             AssetGenJob job = AssetGenJobManager.StartAudioGeneration(req);
@@ -82,61 +82,6 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 $"Audio generation started with '{provider}'. Poll the status action with this job_id.",
                 pollIntervalSeconds: 3.0,
                 data: new { job_id = job.JobId, provider, status = "pending" });
-        }
-
-        private static bool NormalizeOutputFolder(string outputFolder, out string normalized, out string error)
-        {
-            normalized = outputFolder;
-            error = null;
-            if (string.IsNullOrWhiteSpace(outputFolder)) return true;
-            if (AssetGenPaths.TryGetAssetsFolder(outputFolder, out normalized)) return true;
-            error = "'output_folder' must resolve under the project's Assets folder.";
-            return false;
-        }
-
-        private static object Status(ToolParams p)
-        {
-            string jobId = p.Get("job_id");
-            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for status.");
-            AssetGenJob job = AssetGenJobManager.GetJob(jobId);
-            if (job == null) return new ErrorResponse($"No job found with ID '{jobId}'.");
-
-            switch (job.State)
-            {
-                case AssetGenJobState.Done:
-                    return new SuccessResponse(
-                        $"Audio generated: {job.AssetPath}",
-                        new { state = "done", asset_path = job.AssetPath, asset_guid = job.AssetGuid, progress = 1f });
-                case AssetGenJobState.Failed:
-                    return new ErrorResponse(job.Error ?? "Generation failed.", new { state = "failed" });
-                case AssetGenJobState.Canceled:
-                    return new SuccessResponse("Generation canceled.", new { state = "canceled" });
-                default:
-                    return new PendingResponse(
-                        $"Audio {job.State.ToString().ToLowerInvariant()} ({job.Progress:P0}).",
-                        pollIntervalSeconds: 3.0,
-                        data: new { job_id = job.JobId, state = job.State.ToString().ToLowerInvariant(), progress = job.Progress });
-            }
-        }
-
-        private static object Cancel(ToolParams p)
-        {
-            string jobId = p.Get("job_id");
-            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for cancel.");
-            return AssetGenJobManager.Cancel(jobId)
-                ? new SuccessResponse($"Cancel requested for job '{jobId}'.")
-                : new ErrorResponse($"No cancelable job found with ID '{jobId}'.");
-        }
-
-        private static object ListProviders()
-        {
-            var list = new List<object>();
-            foreach (ProviderInfo info in AssetGenProviders.List())
-            {
-                if (info.Kind != "audio") continue;
-                list.Add(new { id = info.Id, kind = info.Kind, configured = info.Configured, capabilities = info.Capabilities });
-            }
-            return new SuccessResponse($"{list.Count} audio provider(s).", new { providers = list });
         }
     }
 }

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs
@@ -60,14 +60,12 @@ namespace MCPForUnity.Editor.Tools.AssetGen
             // Empty -> GUI-selected model -> catalog default. A null model reaches the adapter's own
             // default; a resolved id is passed through verbatim (the catalog default equals the
             // adapter constant, so an omitted model is a no-op either way).
-            string model = p.Get("model");
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenPrefs.GetSelectedModel("audio", provider);
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenModelCatalog.DefaultModelId(provider, "audio");
+            string model = AssetGenModelCatalog.ResolveModel("audio", provider, p.Get("model"));
 
             var req = new AudioGenRequest
             {
                 Provider = provider,
-                Model = string.IsNullOrWhiteSpace(model) ? null : model,
+                Model = model,
                 Prompt = prompt,
                 Duration = p.GetFloat("duration", 0f) ?? 0f,
                 Name = p.Get("name"),

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs.meta
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateAudio.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ed859d728fc4de4b9d54b2dc23f3746
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateImage.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateImage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
 using MCPForUnity.Editor.Services.AssetGen;
@@ -11,7 +10,8 @@ namespace MCPForUnity.Editor.Tools.AssetGen
     /// <summary>
     /// 2D image generation via an aggregator (fal.ai / OpenRouter). Triggered here (never from the
     /// GUI); the C# side reads the provider key from the secure store and runs the job. Returns a
-    /// job_id immediately; the client polls the `status` action.
+    /// job_id immediately; the client polls the `status` action. Status / cancel / list_providers are
+    /// shared across the generate_* tools via <see cref="AssetGenToolHelpers"/>.
     /// </summary>
     [McpForUnityTool("generate_image", AutoRegister = false, Group = "asset_gen", RequiresPolling = true, PollAction = "status", MaxPollSeconds = 300)]
     public static class GenerateImage
@@ -28,9 +28,9 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                     case "generate": return Generate(p);
                     case "remove_background":
                         return new ErrorResponse("remove_background is not implemented in this version.");
-                    case "status": return Status(p);
-                    case "cancel": return Cancel(p);
-                    case "list_providers": return ListProviders();
+                    case "status": return AssetGenToolHelpers.Status(p, "Image", 2.0);
+                    case "cancel": return AssetGenToolHelpers.Cancel(p);
+                    case "list_providers": return AssetGenToolHelpers.ListProviders("image");
                     case "": return new ErrorResponse("'action' parameter is required.");
                     default:
                         return new ErrorResponse($"Unknown action: '{action}'. Supported: generate, remove_background, status, cancel, list_providers.");
@@ -73,7 +73,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 Name = p.Get("name"),
                 OutputFolder = p.Get("outputFolder"),
             };
-            if (!NormalizeOutputFolder(req.OutputFolder, out req.OutputFolder, out string outputErr))
+            if (!AssetGenPaths.NormalizeOutputFolder(req.OutputFolder, out req.OutputFolder, out string outputErr))
                 return new ErrorResponse(outputErr);
 
             if (req.Mode == "text" && string.IsNullOrWhiteSpace(req.Prompt))
@@ -95,61 +95,6 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 $"Image generation started with '{provider}'. Poll the status action with this job_id.",
                 pollIntervalSeconds: 2.0,
                 data: new { job_id = job.JobId, provider, status = "pending" });
-        }
-
-        private static bool NormalizeOutputFolder(string outputFolder, out string normalized, out string error)
-        {
-            normalized = outputFolder;
-            error = null;
-            if (string.IsNullOrWhiteSpace(outputFolder)) return true;
-            if (AssetGenPaths.TryGetAssetsFolder(outputFolder, out normalized)) return true;
-            error = "'output_folder' must resolve under the project's Assets folder.";
-            return false;
-        }
-
-        private static object Status(ToolParams p)
-        {
-            string jobId = p.Get("job_id");
-            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for status.");
-            AssetGenJob job = AssetGenJobManager.GetJob(jobId);
-            if (job == null) return new ErrorResponse($"No job found with ID '{jobId}'.");
-
-            switch (job.State)
-            {
-                case AssetGenJobState.Done:
-                    return new SuccessResponse(
-                        $"Image generated: {job.AssetPath}",
-                        new { state = "done", asset_path = job.AssetPath, asset_guid = job.AssetGuid, progress = 1f });
-                case AssetGenJobState.Failed:
-                    return new ErrorResponse(job.Error ?? "Generation failed.", new { state = "failed" });
-                case AssetGenJobState.Canceled:
-                    return new SuccessResponse("Generation canceled.", new { state = "canceled" });
-                default:
-                    return new PendingResponse(
-                        $"Image {job.State.ToString().ToLowerInvariant()} ({job.Progress:P0}).",
-                        pollIntervalSeconds: 2.0,
-                        data: new { job_id = job.JobId, state = job.State.ToString().ToLowerInvariant(), progress = job.Progress });
-            }
-        }
-
-        private static object Cancel(ToolParams p)
-        {
-            string jobId = p.Get("job_id");
-            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for cancel.");
-            return AssetGenJobManager.Cancel(jobId)
-                ? new SuccessResponse($"Cancel requested for job '{jobId}'.")
-                : new ErrorResponse($"No cancelable job found with ID '{jobId}'.");
-        }
-
-        private static object ListProviders()
-        {
-            var list = new List<object>();
-            foreach (ProviderInfo info in AssetGenProviders.List())
-            {
-                if (info.Kind != "image") continue;
-                list.Add(new { id = info.Id, kind = info.Kind, configured = info.Configured, capabilities = info.Capabilities });
-            }
-            return new SuccessResponse($"{list.Count} image provider(s).", new { providers = list });
         }
     }
 }

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateImage.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateImage.cs
@@ -56,9 +56,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
 
             // Empty -> GUI-selected model -> catalog default. Null still reaches the adapter's own
             // default (no regression when nothing is selected anywhere).
-            string model = p.Get("model");
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenPrefs.GetSelectedModel("image", provider);
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenModelCatalog.DefaultModelId(provider, "image");
+            string model = AssetGenModelCatalog.ResolveModel("image", provider, p.Get("model"));
 
             var req = new ImageGenRequest
             {
@@ -67,7 +65,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 Prompt = p.Get("prompt"),
                 ImagePath = p.Get("imagePath"),
                 ImageUrl = p.Get("imageUrl"),
-                Model = string.IsNullOrWhiteSpace(model) ? null : model,
+                Model = model,
                 Transparent = p.GetBool("transparent", false),
                 AsSprite = p.GetBool("asSprite", true),
                 Width = p.GetInt("width", 0) ?? 0,

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateModel.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
 using MCPForUnity.Editor.Services.AssetGen;
@@ -12,6 +11,8 @@ namespace MCPForUnity.Editor.Tools.AssetGen
     /// 3D model generation (Tripo/Meshy). Generation is triggered here (never from
     /// the GUI); the C# side reads the provider key from the secure store and runs the job.
     /// Long-running: returns a job_id immediately and the client polls the `status` action.
+    /// Status / cancel / list_providers are shared across the generate_* tools via
+    /// <see cref="AssetGenToolHelpers"/>.
     /// </summary>
     [McpForUnityTool("generate_model", AutoRegister = false, Group = "asset_gen", RequiresPolling = true, PollAction = "status", MaxPollSeconds = 300)]
     public static class GenerateModel
@@ -26,9 +27,9 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 switch (action)
                 {
                     case "generate": return Generate(p);
-                    case "status": return Status(p);
-                    case "cancel": return Cancel(p);
-                    case "list_providers": return ListProviders();
+                    case "status": return AssetGenToolHelpers.Status(p, "3D model", 3.0);
+                    case "cancel": return AssetGenToolHelpers.Cancel(p);
+                    case "list_providers": return AssetGenToolHelpers.ListProviders("model");
                     case "": return new ErrorResponse("'action' parameter is required.");
                     default:
                         return new ErrorResponse($"Unknown action: '{action}'. Supported: generate, status, cancel, list_providers.");
@@ -71,7 +72,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 Name = p.Get("name"),
                 OutputFolder = p.Get("outputFolder"),
             };
-            if (!NormalizeOutputFolder(req.OutputFolder, out req.OutputFolder, out string outputErr))
+            if (!AssetGenPaths.NormalizeOutputFolder(req.OutputFolder, out req.OutputFolder, out string outputErr))
                 return new ErrorResponse(outputErr);
 
             if (req.Mode == "text" && string.IsNullOrWhiteSpace(req.Prompt))
@@ -95,61 +96,6 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 $"3D generation started with '{provider}'. Poll the status action with this job_id.",
                 pollIntervalSeconds: 3.0,
                 data: new { job_id = job.JobId, provider, status = "pending" });
-        }
-
-        private static bool NormalizeOutputFolder(string outputFolder, out string normalized, out string error)
-        {
-            normalized = outputFolder;
-            error = null;
-            if (string.IsNullOrWhiteSpace(outputFolder)) return true;
-            if (AssetGenPaths.TryGetAssetsFolder(outputFolder, out normalized)) return true;
-            error = "'output_folder' must resolve under the project's Assets folder.";
-            return false;
-        }
-
-        private static object Status(ToolParams p)
-        {
-            string jobId = p.Get("job_id");
-            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for status.");
-            AssetGenJob job = AssetGenJobManager.GetJob(jobId);
-            if (job == null) return new ErrorResponse($"No job found with ID '{jobId}'.");
-
-            switch (job.State)
-            {
-                case AssetGenJobState.Done:
-                    return new SuccessResponse(
-                        $"Generation complete: {job.AssetPath}",
-                        new { state = "done", asset_path = job.AssetPath, asset_guid = job.AssetGuid, progress = 1f });
-                case AssetGenJobState.Failed:
-                    return new ErrorResponse(job.Error ?? "Generation failed.", new { state = "failed" });
-                case AssetGenJobState.Canceled:
-                    return new SuccessResponse("Generation canceled.", new { state = "canceled" });
-                default:
-                    return new PendingResponse(
-                        $"Generation {job.State.ToString().ToLowerInvariant()} ({job.Progress:P0}).",
-                        pollIntervalSeconds: 3.0,
-                        data: new { job_id = job.JobId, state = job.State.ToString().ToLowerInvariant(), progress = job.Progress });
-            }
-        }
-
-        private static object Cancel(ToolParams p)
-        {
-            string jobId = p.Get("job_id");
-            if (string.IsNullOrEmpty(jobId)) return new ErrorResponse("'job_id' is required for cancel.");
-            return AssetGenJobManager.Cancel(jobId)
-                ? new SuccessResponse($"Cancel requested for job '{jobId}'.")
-                : new ErrorResponse($"No cancelable job found with ID '{jobId}'.");
-        }
-
-        private static object ListProviders()
-        {
-            var list = new List<object>();
-            foreach (ProviderInfo info in AssetGenProviders.List())
-            {
-                if (info.Kind != "model") continue; // keep image/audio rows out of the 3D provider list
-                list.Add(new { id = info.Id, kind = info.Kind, configured = info.Configured, capabilities = info.Capabilities });
-            }
-            return new SuccessResponse($"{list.Count} model provider(s).", new { providers = list });
         }
     }
 }

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateModel.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateModel.cs
@@ -54,9 +54,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
 
             // Empty -> GUI-selected model -> catalog default. Null still reaches the adapter's own
             // default (Tripo ModelVersion / Meshy meshy-6).
-            string model = p.Get("model");
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenPrefs.GetSelectedModel("model", provider);
-            if (string.IsNullOrWhiteSpace(model)) model = AssetGenModelCatalog.DefaultModelId(provider, "model");
+            string model = AssetGenModelCatalog.ResolveModel("model", provider, p.Get("model"));
 
             var req = new ModelGenRequest
             {
@@ -69,7 +67,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 TargetSize = p.GetFloat("targetSize", 1f) ?? 1f,
                 Texture = p.GetBool("texture", true),
                 Tier = p.Get("tier"),
-                Model = string.IsNullOrWhiteSpace(model) ? null : model,
+                Model = model,
                 Name = p.Get("name"),
                 OutputFolder = p.Get("outputFolder"),
             };

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateModel.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateModel.cs
@@ -52,6 +52,12 @@ namespace MCPForUnity.Editor.Tools.AssetGen
             if (!SecureKeyStore.Current.Has(provider))
                 return new ErrorResponse(AssetGenProviders.MissingKeyMessage(provider));
 
+            // Empty -> GUI-selected model -> catalog default. Null still reaches the adapter's own
+            // default (Tripo ModelVersion / Meshy meshy-6).
+            string model = p.Get("model");
+            if (string.IsNullOrWhiteSpace(model)) model = AssetGenPrefs.GetSelectedModel("model", provider);
+            if (string.IsNullOrWhiteSpace(model)) model = AssetGenModelCatalog.DefaultModelId(provider, "model");
+
             var req = new ModelGenRequest
             {
                 Provider = provider,
@@ -63,6 +69,7 @@ namespace MCPForUnity.Editor.Tools.AssetGen
                 TargetSize = p.GetFloat("targetSize", 1f) ?? 1f,
                 Texture = p.GetBool("texture", true),
                 Tier = p.Get("tier"),
+                Model = string.IsNullOrWhiteSpace(model) ? null : model,
                 Name = p.Get("name"),
                 OutputFolder = p.Get("outputFolder"),
             };
@@ -140,8 +147,11 @@ namespace MCPForUnity.Editor.Tools.AssetGen
         {
             var list = new List<object>();
             foreach (ProviderInfo info in AssetGenProviders.List())
+            {
+                if (info.Kind != "model") continue; // keep image/audio rows out of the 3D provider list
                 list.Add(new { id = info.Id, kind = info.Kind, configured = info.Configured, capabilities = info.Capabilities });
-            return new SuccessResponse($"{list.Count} provider(s).", new { providers = list });
+            }
+            return new SuccessResponse($"{list.Count} model provider(s).", new { providers = list });
         }
     }
 }

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
@@ -168,23 +168,50 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             providersContainer.Clear();
             modelEnableToggles.Clear();
 
-            AddGroupLabel("3D Model Providers");
+            var modelPanel = AddCategoryPanel("3D Models");
             foreach (var provider in ModelProviders)
             {
-                var toggle = AddProviderRow(provider.Id, provider.Label, "model");
+                var toggle = AddProviderRow(modelPanel, provider.Id, provider.Label, "model");
                 modelEnableToggles.Add((provider.Id, toggle));
             }
 
-            AddGroupLabel("Image Providers");
+            var imagePanel = AddCategoryPanel("2D Images");
             foreach (var provider in ImageProviders)
             {
-                AddProviderRow(provider.Id, provider.Label, "image");
+                AddProviderRow(imagePanel, provider.Id, provider.Label, "image");
             }
 
-            AddGroupLabel("Audio (fal.ai)");
-            AddAudioRow();
+            var audioPanel = AddCategoryPanel("Sound (fal.ai)");
+            AddAudioRow(audioPanel);
 
             AddBlenderHandoffRow();
+        }
+
+        /// <summary>
+        /// Creates a darker rounded panel with a title (added to the providers container). Each of the
+        /// three categories (3D / 2D / sound) gets its own panel so they read as distinct blocks.
+        /// </summary>
+        private VisualElement AddCategoryPanel(string title)
+        {
+            var panel = new VisualElement();
+            panel.style.backgroundColor = new Color(0f, 0f, 0f, 0.20f);
+            panel.style.paddingTop = 8;
+            panel.style.paddingBottom = 8;
+            panel.style.paddingLeft = 8;
+            panel.style.paddingRight = 8;
+            panel.style.marginBottom = 10;
+            panel.style.borderTopLeftRadius = 4;
+            panel.style.borderTopRightRadius = 4;
+            panel.style.borderBottomLeftRadius = 4;
+            panel.style.borderBottomRightRadius = 4;
+
+            var label = new Label(title);
+            label.AddToClassList("config-label");
+            label.style.marginTop = 0;
+            panel.Add(label);
+
+            providersContainer.Add(panel);
+            return panel;
         }
 
         private void AddGroupLabel(string text)
@@ -223,7 +250,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             providersContainer.Add(row);
         }
 
-        private Toggle AddProviderRow(string id, string displayName, string kind)
+        private Toggle AddProviderRow(VisualElement parent, string id, string displayName, string kind)
         {
             var row = new VisualElement();
             row.style.marginBottom = 8;
@@ -231,7 +258,10 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             row.style.borderBottomWidth = 1;
             row.style.borderBottomColor = new Color(0.3f, 0.3f, 0.3f, 0.3f);
 
-            // Header: bold provider name + enable toggle.
+            var statusLabel = new Label();
+            statusLabel.AddToClassList("help-text");
+
+            // Header: bold provider name, key status inline to its right, enable toggle far right.
             var header = new VisualElement();
             header.style.flexDirection = FlexDirection.Row;
             header.style.alignItems = Align.Center;
@@ -239,8 +269,12 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
 
             var nameLabel = new Label(displayName);
             nameLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
-            nameLabel.style.flexGrow = 1;
+            nameLabel.style.flexShrink = 0;
             header.Add(nameLabel);
+
+            statusLabel.style.flexGrow = 1;
+            statusLabel.style.marginLeft = 8;
+            header.Add(statusLabel);
 
             var enableToggle = new Toggle("Enabled");
             enableToggle.SetValueWithoutNotify(AssetGenPrefs.IsProviderEnabled(id));
@@ -248,9 +282,6 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             header.Add(enableToggle);
 
             row.Add(header);
-
-            var statusLabel = new Label();
-            statusLabel.AddToClassList("help-text");
 
             // Masked key field + Save / Clear / Test buttons.
             var fieldRow = new VisualElement();
@@ -281,7 +312,6 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             fieldRow.Add(testButton);
 
             row.Add(fieldRow);
-            row.Add(statusLabel);
 
             // Persist the typed key, then clear the field so the secret is never displayed.
             void SaveKeyFromField()
@@ -345,7 +375,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             // models, e.g. the Sketchfab marketplace).
             AddModelDropdown(row, kind, id);
 
-            providersContainer.Add(row);
+            parent.Add(row);
             return enableToggle;
         }
 
@@ -411,7 +441,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         /// Audio row: no enable toggle and no key field — audio reuses the single fal key owned by
         /// the Image "fal" row. Surfaces that key's presence and a fal-audio model dropdown.
         /// </summary>
-        private void AddAudioRow()
+        private void AddAudioRow(VisualElement parent)
         {
             var row = new VisualElement();
             row.style.marginBottom = 8;
@@ -419,21 +449,31 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             row.style.borderBottomWidth = 1;
             row.style.borderBottomColor = new Color(0.3f, 0.3f, 0.3f, 0.3f);
 
+            // Header: name + shared-key status inline to its right. No key field — audio reuses the
+            // fal key owned by the 2D fal row.
+            var header = new VisualElement();
+            header.style.flexDirection = FlexDirection.Row;
+            header.style.alignItems = Align.Center;
+            header.style.marginBottom = 2;
+
             var nameLabel = new Label("fal (audio)");
             nameLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
-            row.Add(nameLabel);
+            nameLabel.style.flexShrink = 0;
+            header.Add(nameLabel);
 
             bool hasFal = HasKey("fal");
-            var status = new Label(hasFal
-                ? "fal key present ✓ (shared with the Image fal provider)"
-                : "no fal key set — add it in the Image Providers section above");
+            var status = new Label(hasFal ? "key present ✓ (shared with 2D fal)" : "no fal key — set it in 2D Images");
             status.AddToClassList("help-text");
             status.style.color = hasFal ? new Color(0.4f, 0.8f, 0.4f) : new Color(0.7f, 0.7f, 0.7f);
-            row.Add(status);
+            status.style.flexGrow = 1;
+            status.style.marginLeft = 8;
+            header.Add(status);
+
+            row.Add(header);
 
             AddModelDropdown(row, "audio", "fal");
 
-            providersContainer.Add(row);
+            parent.Add(row);
         }
 
         private static ModelEntry FindByLabel(IReadOnlyList<ModelEntry> models, string label)

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
+using MCPForUnity.Editor.Services.AssetGen;
 using MCPForUnity.Editor.Services.AssetGen.Import;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -41,6 +42,8 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         private DropdownField formatDropdown;
         private TextField outputRootField;
         private Toggle autoNormalizeToggle;
+        private Button refreshButton;
+        private Label refreshStatusLabel;
 
         // Per-provider enable toggles for the GLB-capable (model) providers, used to
         // recompute the glTFast notice when a toggle changes.
@@ -63,6 +66,8 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             formatDropdown = Root.Q<DropdownField>("assetgen-format-dropdown");
             outputRootField = Root.Q<TextField>("assetgen-output-root");
             autoNormalizeToggle = Root.Q<Toggle>("assetgen-auto-normalize");
+            refreshButton = Root.Q<Button>("assetgen-refresh");
+            refreshStatusLabel = Root.Q<Label>("assetgen-refresh-status");
         }
 
         private void InitializeUI()
@@ -115,6 +120,26 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
                     AssetGenPrefs.AutoNormalize = evt.newValue;
                 });
             }
+
+            if (refreshButton != null)
+            {
+                refreshButton.tooltip =
+                    "Re-check API-key presence and rebuild the provider/model rows. Picks up keys or " +
+                    "prefs set elsewhere (CLI, env override). The model list is curated in-package.";
+                refreshButton.clicked += OnRefreshClicked;
+            }
+        }
+
+        /// <summary>
+        /// Re-reads secure-store key presence and the curated catalog and rebuilds the rows — useful
+        /// to pick up keys/prefs set elsewhere (CLI, env override). fal has no public list-models API,
+        /// so the curated catalog is the source of truth; this never hits the network or blocks the tab.
+        /// </summary>
+        private void OnRefreshClicked()
+        {
+            SyncFromPrefs();
+            if (refreshStatusLabel != null)
+                SetStatus(refreshStatusLabel, "refreshed — using the built-in model catalog", true);
         }
 
         /// <summary>
@@ -146,15 +171,18 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             AddGroupLabel("3D Model Providers");
             foreach (var provider in ModelProviders)
             {
-                var toggle = AddProviderRow(provider.Id, provider.Label);
+                var toggle = AddProviderRow(provider.Id, provider.Label, "model");
                 modelEnableToggles.Add((provider.Id, toggle));
             }
 
             AddGroupLabel("Image Providers");
             foreach (var provider in ImageProviders)
             {
-                AddProviderRow(provider.Id, provider.Label);
+                AddProviderRow(provider.Id, provider.Label, "image");
             }
+
+            AddGroupLabel("Audio (fal.ai)");
+            AddAudioRow();
 
             AddBlenderHandoffRow();
         }
@@ -195,7 +223,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             providersContainer.Add(row);
         }
 
-        private Toggle AddProviderRow(string id, string displayName)
+        private Toggle AddProviderRow(string id, string displayName, string kind)
         {
             var row = new VisualElement();
             row.style.marginBottom = 8;
@@ -313,8 +341,113 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             bool has = HasKey(id);
             SetStatus(statusLabel, has ? "saved ✓" : "not set", has);
 
+            // "Which model" selector for this provider (skipped for providers with no catalog
+            // models, e.g. the Sketchfab marketplace).
+            AddModelDropdown(row, kind, id);
+
             providersContainer.Add(row);
             return enableToggle;
+        }
+
+        /// <summary>
+        /// Adds a "Model" dropdown + metadata line for a (kind, provider) pair, if the catalog has
+        /// any models for it. The dropdown shows friendly labels; the pref stores the model id.
+        /// Selecting a model becomes the default that generate_* uses when no explicit model is passed.
+        /// </summary>
+        private void AddModelDropdown(VisualElement parent, string kind, string providerId)
+        {
+            IReadOnlyList<ModelEntry> models = AssetGenModelCatalog.ForProvider(providerId, kind);
+            if (models.Count == 0) return;
+
+            var choices = new List<string>();
+            foreach (ModelEntry m in models) choices.Add(m.Label);
+
+            string selectedId = AssetGenPrefs.GetSelectedModel(kind, providerId);
+            if (string.IsNullOrEmpty(selectedId)) selectedId = AssetGenModelCatalog.DefaultModelId(providerId, kind);
+            ModelEntry selected = AssetGenModelCatalog.Find(selectedId) ?? models[0];
+
+            var dropdown = new DropdownField("Model", choices, 0);
+            dropdown.AddToClassList("setting-dropdown-inline");
+            dropdown.tooltip = "The model generate_* uses for this provider when no explicit model is passed.";
+            dropdown.SetValueWithoutNotify(selected.Label);
+            parent.Add(dropdown);
+
+            var meta = new Label();
+            meta.AddToClassList("help-text");
+            meta.style.whiteSpace = WhiteSpace.Normal;
+            parent.Add(meta);
+
+            var caveat = new Label();
+            caveat.AddToClassList("validation-description");
+            caveat.style.whiteSpace = WhiteSpace.Normal;
+            parent.Add(caveat);
+
+            UpdateModelMeta(meta, selected);
+            UpdateModelCaveat(caveat, selected);
+
+            dropdown.RegisterValueChangedCallback(evt =>
+            {
+                ModelEntry picked = FindByLabel(models, evt.newValue);
+                if (picked == null) return;
+                AssetGenPrefs.SetSelectedModel(kind, providerId, picked.Id);
+                UpdateModelMeta(meta, picked);
+                UpdateModelCaveat(caveat, picked);
+            });
+        }
+
+        /// <summary>
+        /// Audio row: no enable toggle and no key field — audio reuses the single fal key owned by
+        /// the Image "fal" row. Surfaces that key's presence and a fal-audio model dropdown.
+        /// </summary>
+        private void AddAudioRow()
+        {
+            var row = new VisualElement();
+            row.style.marginBottom = 8;
+            row.style.paddingBottom = 8;
+            row.style.borderBottomWidth = 1;
+            row.style.borderBottomColor = new Color(0.3f, 0.3f, 0.3f, 0.3f);
+
+            var nameLabel = new Label("fal (audio)");
+            nameLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+            row.Add(nameLabel);
+
+            bool hasFal = HasKey("fal");
+            var status = new Label(hasFal
+                ? "fal key present ✓ (shared with the Image fal provider)"
+                : "no fal key set — add it in the Image Providers section above");
+            status.AddToClassList("help-text");
+            status.style.color = hasFal ? new Color(0.4f, 0.8f, 0.4f) : new Color(0.7f, 0.7f, 0.7f);
+            row.Add(status);
+
+            AddModelDropdown(row, "audio", "fal");
+
+            providersContainer.Add(row);
+        }
+
+        private static ModelEntry FindByLabel(IReadOnlyList<ModelEntry> models, string label)
+        {
+            foreach (ModelEntry m in models)
+                if (m.Label == label) return m;
+            return null;
+        }
+
+        private static void UpdateModelMeta(Label label, ModelEntry m)
+        {
+            if (label == null || m == null) return;
+            var parts = new List<string>();
+            if (!string.IsNullOrEmpty(m.UseCase)) parts.Add(m.UseCase);
+            if (!string.IsNullOrEmpty(m.PriceLabel)) parts.Add(m.PriceLabel);
+            if (m.MaxDurationSeconds > 0f) parts.Add($"≤{m.MaxDurationSeconds:0}s");
+            if (m.Loopable) parts.Add("loopable");
+            label.text = string.Join(" · ", parts);
+        }
+
+        private static void UpdateModelCaveat(Label label, ModelEntry m)
+        {
+            if (label == null) return;
+            bool show = m != null && !string.IsNullOrEmpty(m.CommercialNote);
+            label.text = show ? m.CommercialNote : string.Empty;
+            label.style.display = show ? DisplayStyle.Flex : DisplayStyle.None;
         }
 
         private static void SetStatus(Label label, string text, bool ok)

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
@@ -327,6 +327,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
                     SecureKeyStore.Current.Set(id, text);
                     keyField.SetValueWithoutNotify(string.Empty);
                     SetStatus(statusLabel, "saved ✓", true);
+                    RebuildIfSharedKey(id);
                 }
                 catch (Exception ex)
                 {
@@ -351,6 +352,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
 
                 keyField.SetValueWithoutNotify(string.Empty);
                 SetStatus(statusLabel, "not set", false);
+                RebuildIfSharedKey(id);
             };
 
             // v1 surfaces presence only. Live endpoint validation (an actual auth ping to the
@@ -394,7 +396,16 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
 
             string selectedId = AssetGenPrefs.GetSelectedModel(kind, providerId);
             if (string.IsNullOrEmpty(selectedId)) selectedId = AssetGenModelCatalog.DefaultModelId(providerId, kind);
-            ModelEntry selected = AssetGenModelCatalog.Find(selectedId) ?? models[0];
+            ModelEntry selected = AssetGenModelCatalog.Find(selectedId);
+            if (selected == null)
+            {
+                // The stored pref points at a model that's no longer in the catalog (stale/invalid).
+                // The dropdown falls back to the first model — clear the pref so generate_* resolves to
+                // the same shown model instead of sending the stale id.
+                selected = models[0];
+                if (!string.IsNullOrEmpty(AssetGenPrefs.GetSelectedModel(kind, providerId)))
+                    AssetGenPrefs.SetSelectedModel(kind, providerId, string.Empty);
+            }
 
             // Lay the dropdown out like the Format row: a horizontal .setting-row (align-items:center,
             // min-height:24px) with a .setting-label + a label-less DropdownField. Adding the dropdown
@@ -476,6 +487,18 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             parent.Add(row);
         }
 
+        /// <summary>
+        /// The fal key is shared with the audio row, whose "key present" status is snapshotted at
+        /// build time. When the 2D fal key is saved/cleared, schedule a full rebuild so the audio row
+        /// reflects it without a manual Refresh. Deferred so we don't destroy the element whose
+        /// callback is still running.
+        /// </summary>
+        private void RebuildIfSharedKey(string id)
+        {
+            if (!string.Equals(id, "fal", StringComparison.OrdinalIgnoreCase)) return;
+            Root?.schedule.Execute(SyncFromPrefs);
+        }
+
         private static ModelEntry FindByLabel(IReadOnlyList<ModelEntry> models, string label)
         {
             foreach (ModelEntry m in models)
@@ -489,7 +512,9 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             var parts = new List<string>();
             if (!string.IsNullOrEmpty(m.UseCase)) parts.Add(m.UseCase);
             if (!string.IsNullOrEmpty(m.PriceLabel)) parts.Add(m.PriceLabel);
-            if (m.MaxDurationSeconds > 0f) parts.Add($"≤{m.MaxDurationSeconds:0}s");
+            // Only surface the "≤Ns" hint for models with an actual duration control (DurationField);
+            // Lyria advertises a max but takes no duration input, so showing a hint would mislead.
+            if (m.MaxDurationSeconds > 0f && !string.IsNullOrEmpty(m.DurationField)) parts.Add($"≤{m.MaxDurationSeconds:0}s");
             if (m.Loopable) parts.Add("loopable");
             label.text = string.Join(" · ", parts);
         }

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
@@ -366,11 +366,23 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             if (string.IsNullOrEmpty(selectedId)) selectedId = AssetGenModelCatalog.DefaultModelId(providerId, kind);
             ModelEntry selected = AssetGenModelCatalog.Find(selectedId) ?? models[0];
 
-            var dropdown = new DropdownField("Model", choices, 0);
+            // Lay the dropdown out like the Format row: a horizontal .setting-row (align-items:center,
+            // min-height:24px) with a .setting-label + a label-less DropdownField. Adding the dropdown
+            // straight into the column row instead makes flex-grow expand it vertically into a huge box.
+            var dropdownRow = new VisualElement();
+            dropdownRow.AddToClassList("setting-row");
+
+            var modelLabel = new Label("Model");
+            modelLabel.AddToClassList("setting-label");
+            dropdownRow.Add(modelLabel);
+
+            var dropdown = new DropdownField(choices, 0);
             dropdown.AddToClassList("setting-dropdown-inline");
             dropdown.tooltip = "The model generate_* uses for this provider when no explicit model is passed.";
             dropdown.SetValueWithoutNotify(selected.Label);
-            parent.Add(dropdown);
+            dropdownRow.Add(dropdown);
+
+            parent.Add(dropdownRow);
 
             var meta = new Label();
             meta.AddToClassList("help-text");

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.uxml
@@ -7,6 +7,10 @@
             <ui:VisualElement name="gltfast-notice" class="warning-banner">
                 <ui:Label class="warning-banner-text" text="GLB import needs the glTFast package — install it from the Dependencies tab." />
             </ui:VisualElement>
+            <ui:VisualElement class="setting-row" style="margin-top: 4px;">
+                <ui:Button name="assetgen-refresh" text="Refresh" class="icon-button" />
+                <ui:Label name="assetgen-refresh-status" class="help-text" />
+            </ui:VisualElement>
             <ui:VisualElement name="assetgen-providers-container" style="margin-top: 8px;" />
             <ui:Label text="Preferences" class="config-label" />
             <ui:VisualElement class="setting-row">

--- a/MCPForUnity/Editor/Windows/Components/Tools/McpToolsSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/Tools/McpToolsSection.cs
@@ -46,6 +46,7 @@ namespace MCPForUnity.Editor.Windows.Components.Tools
             { "testing", "Testing" },
             { "probuilder", "ProBuilder — Experimental" },
             { "profiling", "Profiling & Frame Debugger" },
+            { "asset_gen", "Asset Gen" },
         };
 
         public VisualElement Root { get; }

--- a/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.uxml
+++ b/MCPForUnity/Editor/Windows/MCPForUnityEditorWindow.uxml
@@ -14,7 +14,7 @@
             <uie:ToolbarToggle name="clients-tab" text="Connect" value="true" />
             <uie:ToolbarToggle name="tools-tab" text="Tools" />
             <uie:ToolbarToggle name="resources-tab" text="Resources" />
-            <uie:ToolbarToggle name="assetgen-tab" text="Asset Gen" />
+            <uie:ToolbarToggle name="assetgen-tab" text="Generative" />
             <uie:ToolbarToggle name="deps-tab" text="Deps" />
             <uie:ToolbarToggle name="advanced-tab" text="Advanced" />
         </uie:Toolbar>

--- a/Server/src/cli/commands/asset_gen.py
+++ b/Server/src/cli/commands/asset_gen.py
@@ -38,6 +38,7 @@ def _emit(result, config, verb):
 @click.option("--target-size", default=None, type=float, help="Normalize largest dimension (meters).")
 @click.option("--texture/--no-texture", "texture", default=None, help="Generate textures.")
 @click.option("--tier", default=None, help="Provider quality/cost tier.")
+@click.option("--model", default=None, help="Provider model id/version (omit for the GUI-selected default).")
 @click.option("--name", default=None, help="Base name for the imported asset.")
 @click.option("--output-folder", default=None, help="Destination folder under Assets/.")
 @handle_unity_errors
@@ -51,6 +52,7 @@ def generate_model(
     target_size: Optional[float],
     texture: Optional[bool],
     tier: Optional[str],
+    model: Optional[str],
     name: Optional[str],
     output_folder: Optional[str],
 ):
@@ -74,6 +76,7 @@ def generate_model(
         "targetSize": target_size,
         "texture": texture,
         "tier": tier,
+        "model": model,
         "name": name,
         "outputFolder": output_folder,
     }
@@ -194,6 +197,46 @@ def generate_image(
     params.update({k: v for k, v in optional.items() if v is not None})
 
     result = run_command("generate_image", params, config)
+    _emit(result, config, "Generation")
+
+
+@asset_gen.command("generate-audio")
+@click.option("--provider", default=None, help="Provider id (fal).")
+@click.option("--prompt", default=None, help="Text prompt describing the sound or music.")
+@click.option("--model", default=None, help="fal model id (omit for the GUI-selected default).")
+@click.option("--duration", default=None, type=float, help="Requested length in seconds (soft-clamped per model).")
+@click.option("--name", default=None, help="Base name for the imported asset.")
+@click.option("--output-folder", default=None, help="Destination folder under Assets/.")
+@handle_unity_errors
+def generate_audio(
+    provider: Optional[str],
+    prompt: Optional[str],
+    model: Optional[str],
+    duration: Optional[float],
+    name: Optional[str],
+    output_folder: Optional[str],
+):
+    """Generate audio (SFX / music) with a fal.ai model.
+
+    \b
+    Examples:
+        unity-mcp asset-gen generate-audio --provider fal --prompt "8-bit coin pickup"
+        unity-mcp asset-gen generate-audio --prompt "calm ambient loop" --duration 30
+    """
+    config = get_config()
+
+    params: dict[str, Any] = {"action": "generate"}
+    optional = {
+        "provider": provider,
+        "prompt": prompt,
+        "model": model,
+        "duration": duration,
+        "name": name,
+        "outputFolder": output_folder,
+    }
+    params.update({k: v for k, v in optional.items() if v is not None})
+
+    result = run_command("generate_audio", params, config)
     _emit(result, config, "Generation")
 
 

--- a/Server/src/cli/commands/asset_gen.py
+++ b/Server/src/cli/commands/asset_gen.py
@@ -1,4 +1,4 @@
-"""AI asset generation CLI commands (3D model gen/import, 2D image gen).
+"""AI asset generation CLI commands (3D model gen/import, 2D image gen, audio gen).
 
 Thin pass-through to Unity over HTTP: these commands carry NO API keys and NO
 file bytes. The C# side reads provider keys from the OS secure store, performs

--- a/Server/src/services/registry/tool_registry.py
+++ b/Server/src/services/registry/tool_registry.py
@@ -25,7 +25,7 @@ TOOL_GROUPS: dict[str, str] = {
     "testing": "Test runner & async test jobs",
     "probuilder": "ProBuilder 3D modeling – requires com.unity.probuilder package",
     "profiling": "Unity Profiler session control, counters, memory snapshots & Frame Debugger",
-    "asset_gen": "AI asset generation – 3D model gen/import & 2D image gen (bring-your-own-key)",
+    "asset_gen": "AI asset generation – 3D model gen/import, 2D image gen & audio gen (bring-your-own-key)",
 }
 
 DEFAULT_ENABLED_GROUPS: set[str] = {"core"}

--- a/Server/src/services/tools/generate_audio.py
+++ b/Server/src/services/tools/generate_audio.py
@@ -1,0 +1,79 @@
+"""
+Defines the generate_audio tool for AI audio (SFX / music) generation in Unity.
+
+Thin pass-through: this tool carries NO API keys and NO file bytes. The C# side
+reads the user's fal.ai key from the OS secure store, performs the provider
+HTTPS call, downloads the result, and imports it as an AudioClip.
+"""
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+
+from services.registry import mcp_for_unity_tool
+from services.tools import get_unity_instance_from_context
+from transport.unity_transport import send_with_unity_instance
+from transport.legacy.unity_connection import async_send_command_with_retry
+
+
+@mcp_for_unity_tool(
+    group="asset_gen",
+    description=(
+        "Generate audio (sound effects and background music) with fal.ai models and import "
+        "them as AudioClips into the Unity project. Bring-your-own-key: the fal key lives in "
+        "the editor's secure store (shared with image generation) and never crosses the bridge.\n\n"
+        "MODELS (all via fal.ai): fal-ai/stable-audio-25/text-to-audio (music + SFX, <=190s), "
+        "cassetteai/sound-effects-generator (SFX, <=30s), cassetteai/music-generator (music), "
+        "fal-ai/lyria2 (music). Omit model to use the model selected in the "
+        "MCP for Unity -> Asset Generation tab.\n\n"
+        "ACTIONS:\n"
+        "- generate: Submit an audio job from a text prompt. Returns { job_id }; poll with the "
+        "status action. Params: provider (fal), prompt, model, duration (seconds), name, "
+        "output_folder.\n"
+        "- status: Poll an async job by job_id -> { state, progress, assetPath?, error? }.\n"
+        "- cancel: Cancel an in-flight job by job_id.\n"
+        "- list_providers: List configured audio providers and capabilities (no key values)."
+    ),
+    annotations=ToolAnnotations(
+        title="Generate Audio",
+        destructiveHint=False,
+    ),
+)
+async def generate_audio(
+    ctx: Context,
+    action: Annotated[Literal["generate", "status", "cancel", "list_providers"],
+                      "Action to perform."],
+
+    provider: Annotated[str, "Provider id (fal)."] | None = None,
+    prompt: Annotated[str, "Text prompt describing the sound or music."] | None = None,
+    model: Annotated[str, "fal model id (e.g. fal-ai/stable-audio-25/text-to-audio). "
+                     "Omit to use the GUI-selected default."] | None = None,
+    duration: Annotated[float, "Requested length in seconds (soft-clamped per model)."] | None = None,
+    name: Annotated[str, "Base name for the imported asset."] | None = None,
+    output_folder: Annotated[str, "Destination folder under Assets/ for the import."] | None = None,
+    job_id: Annotated[str, "Job id for status/cancel."] | None = None,
+) -> dict[str, Any]:
+    unity_instance = await get_unity_instance_from_context(ctx)
+
+    params_dict = {
+        "action": action.lower(),
+        "provider": provider,
+        "prompt": prompt,
+        "model": model,
+        "duration": duration,
+        "name": name,
+        "outputFolder": output_folder,
+        "jobId": job_id,
+    }
+
+    # Remove None values
+    params_dict = {k: v for k, v in params_dict.items() if v is not None}
+
+    result = await send_with_unity_instance(
+        async_send_command_with_retry,
+        unity_instance,
+        "generate_audio",
+        params_dict,
+    )
+
+    return result if isinstance(result, dict) else {"success": False, "message": str(result)}

--- a/Server/src/services/tools/generate_model.py
+++ b/Server/src/services/tools/generate_model.py
@@ -26,7 +26,7 @@ from transport.legacy.unity_connection import async_send_command_with_retry
         "- generate: Submit a generation job (text->3D or image->3D). Returns { job_id } "
         "immediately; poll with the status action. Params: provider, mode (text|image), "
         "prompt, image_path|image_url, format (glb|fbx|obj|usdz), target_size, texture, "
-        "tier, name, output_folder.\n"
+        "tier, model, name, output_folder.\n"
         "- status: Poll an async job by job_id -> { state, progress, assetPath?, error? }.\n"
         "- cancel: Cancel an in-flight job by job_id.\n"
         "- list_providers: List configured 3D providers and capabilities (no key values)."
@@ -50,6 +50,8 @@ async def generate_model(
     target_size: Annotated[float, "Normalize the largest dimension to this size (meters)."] | None = None,
     texture: Annotated[bool, "Whether to generate textures for the model."] | None = None,
     tier: Annotated[str, "Provider quality/cost tier."] | None = None,
+    model: Annotated[str, "Provider model id/version (e.g. Tripo v3.1, Meshy meshy-6). "
+                     "Omit for the GUI-selected default."] | None = None,
     name: Annotated[str, "Base name for the imported asset."] | None = None,
     output_folder: Annotated[str, "Destination folder under Assets/ for the import."] | None = None,
     job_id: Annotated[str, "Job id for status/cancel."] | None = None,
@@ -67,6 +69,7 @@ async def generate_model(
         "targetSize": target_size,
         "texture": texture,
         "tier": tier,
+        "model": model,
         "name": name,
         "outputFolder": output_folder,
         "jobId": job_id,

--- a/Server/tests/test_asset_gen_audio.py
+++ b/Server/tests/test_asset_gen_audio.py
@@ -1,0 +1,145 @@
+"""Tests for the generate_audio asset-gen tool and CLI command (fal.ai).
+
+Pass-through tool: NO API keys, NO file bytes. Unity transport fully mocked.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from click.testing import CliRunner
+
+from cli.commands.asset_gen import asset_gen
+from cli.utils.config import CLIConfig
+from services.registry import get_registered_tools
+
+from services.tools import generate_audio as generate_audio_module
+from services.tools.generate_audio import generate_audio
+
+
+COMMAND = "generate_audio"
+ALLOWED_KEYS = {
+    "action", "provider", "prompt", "model", "duration", "name", "outputFolder", "jobId",
+}
+
+
+def _call_tool(**kwargs):
+    ctx = MagicMock()
+    with patch.object(generate_audio_module, "get_unity_instance_from_context",
+                      new=AsyncMock(return_value="unity-1")):
+        with patch.object(generate_audio_module, "send_with_unity_instance",
+                          new=AsyncMock(return_value={"success": True, "data": {}})) as mock_send:
+            result = asyncio.run(generate_audio(ctx, **kwargs))
+    return result, mock_send.call_args.args
+
+
+def _sent_command(sent_args):
+    return sent_args[2]
+
+
+def _sent_params(sent_args):
+    return sent_args[3]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_config():
+    return CLIConfig(host="127.0.0.1", port=8080, timeout=30, format="text", unity_instance=None)
+
+
+@pytest.fixture
+def cli_runner(runner, mock_config):
+    def _invoke(args):
+        with patch("cli.commands.asset_gen.get_config", return_value=mock_config):
+            with patch("cli.commands.asset_gen.run_command",
+                       return_value={"success": True, "message": "OK", "data": {}}) as mock_run:
+                result = runner.invoke(asset_gen, args)
+                return result, mock_run
+    return _invoke
+
+
+class TestGenerateAudioRegistration:
+    def test_tool_registered_under_asset_gen_group(self):
+        tools = get_registered_tools()
+        tool = next((t for t in tools if t["name"] == "generate_audio"), None)
+        assert tool is not None
+        assert tool["group"] == "asset_gen"
+
+
+class TestGenerateAudioRouting:
+    def test_generate_routes_to_command(self):
+        _, sent = _call_tool(action="generate", provider="fal", prompt="8-bit coin pickup")
+        assert _sent_command(sent) == COMMAND
+        assert _sent_params(sent)["action"] == "generate"
+
+    def test_status_and_job_id_mapping(self):
+        _, sent = _call_tool(action="status", job_id="j5")
+        assert _sent_params(sent) == {"action": "status", "jobId": "j5"}
+
+    def test_param_camelcase_mapping(self):
+        _, sent = _call_tool(
+            action="generate", provider="fal", prompt="rain", duration=30.0,
+            output_folder="Assets/Generated/Audio",
+        )
+        params = _sent_params(sent)
+        assert params["outputFolder"] == "Assets/Generated/Audio"
+        assert params["duration"] == 30.0
+        for snake in ("output_folder", "job_id"):
+            assert snake not in params
+
+    def test_action_is_lowercased(self):
+        _, sent = _call_tool(action="GENERATE", prompt="p")
+        assert _sent_params(sent)["action"] == "generate"
+
+    def test_omitting_model_drops_it(self):
+        # Load-bearing precondition for the GUI-selected default: an omitted model must NOT be
+        # sent, so the C# side falls back to the panel selection / catalog default.
+        _, sent = _call_tool(action="generate", provider="fal", prompt="p")
+        params = _sent_params(sent)
+        assert "model" not in params
+        assert params == {"action": "generate", "provider": "fal", "prompt": "p"}
+
+    def test_explicit_model_passes_through(self):
+        _, sent = _call_tool(action="generate", provider="fal", prompt="p",
+                             model="cassetteai/sound-effects-generator")
+        assert _sent_params(sent)["model"] == "cassetteai/sound-effects-generator"
+
+    def test_no_secret_keys_in_payload(self):
+        _, sent = _call_tool(
+            action="generate", provider="fal", prompt="p",
+            model="fal-ai/stable-audio-25/text-to-audio", duration=12.5, name="Sfx",
+            output_folder="Assets/Generated/Audio", job_id="j",
+        )
+        params = _sent_params(sent)
+        assert set(params.keys()).issubset(ALLOWED_KEYS)
+        joined = " ".join(params.keys()).lower()
+        for forbidden in ("key", "secret", "token", "apikey", "password"):
+            assert forbidden not in joined
+
+    def test_non_dict_response_guarded(self):
+        ctx = MagicMock()
+        with patch.object(generate_audio_module, "get_unity_instance_from_context",
+                          new=AsyncMock(return_value="u")):
+            with patch.object(generate_audio_module, "send_with_unity_instance",
+                              new=AsyncMock(return_value=42)):
+                result = asyncio.run(generate_audio(ctx, action="status", job_id="j"))
+        assert result["success"] is False
+        assert "42" in result["message"]
+
+
+class TestGenerateAudioCLI:
+    def test_generate_audio_cli(self, cli_runner):
+        result, mock_run = cli_runner([
+            "generate-audio", "--provider", "fal", "--prompt", "ambient", "--duration", "30",
+        ])
+        assert result.exit_code == 0
+        command = mock_run.call_args.args[0]
+        params = mock_run.call_args.args[1]
+        assert command == COMMAND
+        assert params["action"] == "generate"
+        assert params["provider"] == "fal"
+        assert params["duration"] == 30.0
+        assert set(params.keys()).issubset(ALLOWED_KEYS)

--- a/Server/tests/test_asset_gen_model.py
+++ b/Server/tests/test_asset_gen_model.py
@@ -22,7 +22,7 @@ COMMAND = "generate_model"
 # Every camelCase key the tool is allowed to send. Crucially, no key/secret param.
 ALLOWED_KEYS = {
     "action", "provider", "mode", "prompt", "imagePath", "imageUrl",
-    "format", "targetSize", "texture", "tier", "name", "outputFolder", "jobId",
+    "format", "targetSize", "texture", "tier", "model", "name", "outputFolder", "jobId",
 }
 
 
@@ -129,6 +129,15 @@ class TestGenerateModelRouting:
         # snake_case keys must never reach Unity
         for snake in ("image_path", "image_url", "target_size", "output_folder", "job_id"):
             assert snake not in params
+
+    def test_model_param_passthrough(self):
+        _, sent = _call_tool(action="generate", provider="tripo", prompt="x", model="v3.1-20260211")
+        params = _sent_params(sent)
+        assert params["model"] == "v3.1-20260211"
+
+    def test_model_omitted_is_dropped(self):
+        _, sent = _call_tool(action="generate", provider="tripo", prompt="x")
+        assert "model" not in _sent_params(sent)
 
     def test_none_values_stripped(self):
         _, sent = _call_tool(action="generate", provider="tripo", prompt="x")

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenJobManagerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenJobManagerTests.cs
@@ -19,6 +19,9 @@ namespace MCPForUnityTests.Editor.AssetGen
     {
         private const string EnvVar = "MCPFORUNITY_TRIPO_API_KEY";
         private const string Secret = "tsk_e2e_secret_value";
+        private const string FalEnvVar = "MCPFORUNITY_FAL_API_KEY";
+        private const string FalSecret = "fal_e2e_secret_value";
+        private const string AudioResp = "https://queue.fal.run/fal-ai/stable-audio-25/text-to-audio/requests/r1";
         private const string TestFolder = "Assets/Generated/__assetgen_jobtest";
 
         private FakeHttpTransport _fake;
@@ -28,6 +31,7 @@ namespace MCPForUnityTests.Editor.AssetGen
         {
             AssetGenJobManager.ResetForTests();
             Environment.SetEnvironmentVariable(EnvVar, Secret);
+            Environment.SetEnvironmentVariable(FalEnvVar, FalSecret);
             _fake = new FakeHttpTransport();
             AssetGenJobManager.TransportOverrideForTests = _fake;
             AssetGenJobManager.PollIntervalSeconds = 0;
@@ -40,6 +44,7 @@ namespace MCPForUnityTests.Editor.AssetGen
         {
             AssetGenJobManager.ResetForTests();
             Environment.SetEnvironmentVariable(EnvVar, null);
+            Environment.SetEnvironmentVariable(FalEnvVar, null);
             try
             {
                 string abs = Path.Combine(ProjectRoot(), TestFolder);
@@ -65,6 +70,14 @@ namespace MCPForUnityTests.Editor.AssetGen
             Format = "glb",
             TargetSize = 1f,
             Name = "jobtest",
+            OutputFolder = TestFolder,
+        };
+
+        private static AudioGenRequest AudioReq() => new AudioGenRequest
+        {
+            Provider = "fal",
+            Prompt = "gentle rain",
+            Name = "audiotest",
             OutputFolder = TestFolder,
         };
 
@@ -94,6 +107,68 @@ namespace MCPForUnityTests.Editor.AssetGen
             Assert.IsNotNull(job.AssetPath);
             StringAssert.EndsWith("jobtest.glb", job.AssetPath);
             Assert.AreEqual(1f, job.Progress);
+        }
+
+        [Test]
+        public void Audio_EndToEnd_ReachesDone_WithWavAssetPath_AndLeaksNoKey()
+        {
+            _fake.Handler = spec =>
+            {
+                if (spec.Method == "POST") return Json("{\"response_url\":\"" + AudioResp + "\"}");
+                if (spec.Url.EndsWith("/status")) return Json("{\"status\":\"COMPLETED\"}");
+                if (spec.Url.Contains("cdn.example.com"))
+                    return new HttpResult { Status = 200, IsSuccess = true, Body = new byte[] { 1, 2, 3, 4 } };
+                return Json("{\"audio_file\":{\"url\":\"https://cdn.example.com/a.wav\"}}"); // result payload
+            };
+
+            AssetGenJob job = AssetGenJobManager.StartAudioGeneration(AudioReq());
+            Pump(job.JobId);
+
+            Assert.AreEqual(AssetGenJobState.Done, job.State);
+            Assert.IsNotNull(job.AssetPath);
+            StringAssert.EndsWith("audiotest.wav", job.AssetPath);
+            Assert.AreEqual(1f, job.Progress);
+
+            string serialized = JsonConvert.SerializeObject(job);
+            StringAssert.DoesNotContain(FalSecret, serialized);
+        }
+
+        [Test]
+        public void Audio_Mp3Result_DownloadsWithMp3Ext()
+        {
+            _fake.Handler = spec =>
+            {
+                if (spec.Method == "POST") return Json("{\"response_url\":\"" + AudioResp + "\"}");
+                if (spec.Url.EndsWith("/status")) return Json("{\"status\":\"COMPLETED\"}");
+                if (spec.Url.Contains("cdn.example.com"))
+                    return new HttpResult { Status = 200, IsSuccess = true, Body = new byte[] { 1, 2, 3, 4 } };
+                return Json("{\"audio_file\":{\"url\":\"https://cdn.example.com/track.mp3\"}}");
+            };
+
+            AssetGenJob job = AssetGenJobManager.StartAudioGeneration(AudioReq());
+            Pump(job.JobId);
+
+            Assert.AreEqual(AssetGenJobState.Done, job.State);
+            StringAssert.EndsWith("audiotest.mp3", job.AssetPath);
+        }
+
+        [Test]
+        public void Audio_NoKey_FailsImmediately()
+        {
+            Environment.SetEnvironmentVariable(FalEnvVar, null); // remove the env key
+            string dir = Path.Combine(Path.GetTempPath(), "mcp_jobmgr_audio_nokey_" + Guid.NewGuid().ToString("N"));
+            MCPForUnity.Editor.Security.SecureKeyStore.OverrideForTests(new MCPForUnity.Editor.Security.EncryptedFileKeyStore(dir));
+            try
+            {
+                AssetGenJob job = AssetGenJobManager.StartAudioGeneration(AudioReq());
+                Assert.AreEqual(AssetGenJobState.Failed, job.State);
+                StringAssert.Contains("No API key", job.Error);
+            }
+            finally
+            {
+                MCPForUnity.Editor.Security.SecureKeyStore.ResetForTests();
+                try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { }
+            }
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenJobManagerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenJobManagerTests.cs
@@ -211,6 +211,11 @@ namespace MCPForUnityTests.Editor.AssetGen
             // marketplace shares the model allowlist.
             Assert.IsTrue(AssetGenJobManager.IsAllowedResultExtension("marketplace", "zip"));
             Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("marketplace", "dll"));
+
+            // Fail closed: an unexpected/unknown kind allows nothing at the RCE boundary.
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("bogus_kind", "glb"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension(null, "png"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("", "wav"));
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenJobManagerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenJobManagerTests.cs
@@ -192,6 +192,57 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
+        public void IsAllowedResultExtension_AllowsSafeTypes_RejectsCodeTypes()
+        {
+            // H2/P8: a provider-controlled result extension must be gated per kind so a rogue provider
+            // can't land a .cs/.asmdef/.meta/.asset under Assets/ and get it compiled/imported.
+            Assert.IsTrue(AssetGenJobManager.IsAllowedResultExtension("audio", "wav"));
+            Assert.IsTrue(AssetGenJobManager.IsAllowedResultExtension("audio", ".mp3"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("audio", "cs"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("audio", "asmdef"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("audio", "meta"));
+
+            Assert.IsTrue(AssetGenJobManager.IsAllowedResultExtension("image", "png"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("image", "cs"));
+
+            Assert.IsTrue(AssetGenJobManager.IsAllowedResultExtension("model", "glb"));
+            Assert.IsTrue(AssetGenJobManager.IsAllowedResultExtension("model", "zip"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("model", "cs"));
+            // marketplace shares the model allowlist.
+            Assert.IsTrue(AssetGenJobManager.IsAllowedResultExtension("marketplace", "zip"));
+            Assert.IsFalse(AssetGenJobManager.IsAllowedResultExtension("marketplace", "dll"));
+        }
+
+        [Test]
+        public void Audio_DisallowedResultExt_FailsJob_WritesNoAsset()
+        {
+            // H2/P8: a poll returning a .cs result extension must fail the job before any file is
+            // written under Assets/ — never a compilable/importable payload.
+            _fake.Handler = spec =>
+            {
+                if (spec.Method == "POST") return Json("{\"response_url\":\"" + AudioResp + "\"}");
+                if (spec.Url.EndsWith("/status")) return Json("{\"status\":\"COMPLETED\"}");
+                if (spec.Url.Contains("cdn.example.com"))
+                    return new HttpResult { Status = 200, IsSuccess = true, Body = new byte[] { 1, 2, 3, 4 } };
+                // Provider hands back a payload whose URL implies a .cs extension.
+                return Json("{\"audio_file\":{\"url\":\"https://cdn.example.com/payload.cs\"}}");
+            };
+
+            AssetGenJob job = AssetGenJobManager.StartAudioGeneration(AudioReq());
+            Pump(job.JobId);
+
+            Assert.AreEqual(AssetGenJobState.Failed, job.State);
+            StringAssert.Contains("disallowed", job.Error.ToLowerInvariant());
+            Assert.IsTrue(string.IsNullOrEmpty(job.AssetPath), "no asset path should be recorded for a rejected type");
+
+            // Nothing named payload.cs may have been written under the test output folder.
+            string abs = Path.Combine(ProjectRoot(), TestFolder);
+            if (Directory.Exists(abs))
+                foreach (string f in Directory.GetFiles(abs))
+                    StringAssert.DoesNotEndWith(".cs", f);
+        }
+
+        [Test]
         public void FileSchemeDownloadUrl_Rejected_FailsJob()
         {
             _fake.Handler = spec =>

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs
@@ -38,6 +38,29 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
+        public void Audio_DurationFields_MatchEndpointSchemas()
+        {
+            IReadOnlyList<ModelEntry> audio = AssetGenModelCatalog.ForProvider("fal", "audio");
+
+            // stable-audio -> seconds_total; both cassette models -> duration; lyria -> no duration knob.
+            CollectionAssert.AreEqual(
+                new[] { "seconds_total", "duration", "duration", null },
+                audio.Select(e => e.DurationField).ToList());
+
+            // The two required-duration models carry a non-zero default so a Duration=0 call still
+            // sends a valid body (C2), and a floor >= 1 so fractional durations never send 0 (C3).
+            ModelEntry music = AssetGenModelCatalog.Find("cassetteai/music-generator");
+            Assert.Greater(music.DefaultDurationSeconds, 0f);
+            Assert.GreaterOrEqual(music.MinDurationSeconds, 1f);
+
+            ModelEntry sfx = AssetGenModelCatalog.Find("cassetteai/sound-effects-generator");
+            Assert.Greater(sfx.DefaultDurationSeconds, 0f);
+            Assert.GreaterOrEqual(sfx.MinDurationSeconds, 1f);
+
+            Assert.IsNull(AssetGenModelCatalog.Find("fal-ai/lyria2").DurationField, "Lyria has no duration control");
+        }
+
+        [Test]
         public void DefaultModelId_PerKindPerProvider()
         {
             Assert.AreEqual("fal-ai/flux-2", AssetGenModelCatalog.DefaultModelId("fal", "image"));

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using MCPForUnity.Editor.Services.AssetGen;
+using MCPForUnity.Editor.Services.AssetGen.Providers;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.AssetGen
+{
+    /// <summary>
+    /// Covers the curated model catalog: the four audio models + metadata, per-kind/per-provider
+    /// defaults, the adapter-constant drift guard, and exact-id lookup.
+    /// </summary>
+    public class AssetGenModelCatalogTests
+    {
+        [Test]
+        public void Curated_HasAllFourAudioModels()
+        {
+            IReadOnlyList<ModelEntry> audio = AssetGenModelCatalog.ForProvider("fal", "audio");
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "fal-ai/stable-audio-25/text-to-audio",
+                    "cassetteai/sound-effects-generator",
+                    "cassetteai/music-generator",
+                    "fal-ai/lyria2",
+                },
+                audio.Select(e => e.Id).ToList());
+
+            CollectionAssert.AreEqual(
+                new[] { 190f, 30f, 180f, 30f },
+                audio.Select(e => e.MaxDurationSeconds).ToList());
+
+            Assert.IsNotNull(audio[0].CommercialNote, "Stable Audio should carry a license caveat");
+            Assert.IsNull(audio[1].CommercialNote);
+            Assert.IsNull(audio[2].CommercialNote);
+            Assert.IsNull(audio[3].CommercialNote);
+        }
+
+        [Test]
+        public void DefaultModelId_PerKindPerProvider()
+        {
+            Assert.AreEqual("fal-ai/flux-2", AssetGenModelCatalog.DefaultModelId("fal", "image"));
+            Assert.AreEqual("fal-ai/stable-audio-25/text-to-audio", AssetGenModelCatalog.DefaultModelId("fal", "audio"));
+            Assert.AreEqual("v3.1-20260211", AssetGenModelCatalog.DefaultModelId("tripo", "model"));
+            Assert.AreEqual("meshy-6", AssetGenModelCatalog.DefaultModelId("meshy", "model"));
+            Assert.IsNull(AssetGenModelCatalog.DefaultModelId("nope", "audio"), "unknown provider => null, not a throw");
+        }
+
+        [Test]
+        public void DefaultModelId_MatchesAdapterConstants()
+        {
+            // Drift guard: the panel's shown default must equal what an omitted `model` param
+            // resolves to in the adapter. The catalog references the adapter constant, so these are
+            // pinned together — this test fails loudly if anyone reorders or reliterals a default.
+            Assert.AreEqual(TripoAdapter.ModelVersion, AssetGenModelCatalog.DefaultModelId("tripo", "model"));
+            Assert.AreEqual(MeshyAdapter.DefaultModel, AssetGenModelCatalog.DefaultModelId("meshy", "model"));
+            Assert.AreEqual(FalAdapter.DefaultModel, AssetGenModelCatalog.DefaultModelId("fal", "image"));
+            Assert.AreEqual(FalAudioAdapter.DefaultModel, AssetGenModelCatalog.DefaultModelId("fal", "audio"));
+        }
+
+        [Test]
+        public void Find_ReturnsEntry_ByExactId()
+        {
+            ModelEntry e = AssetGenModelCatalog.Find("cassetteai/music-generator");
+            Assert.IsNotNull(e);
+            Assert.AreEqual("audio", e.Kind);
+            Assert.IsNull(AssetGenModelCatalog.Find("does/not/exist"));
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf9e75d8f0a84ffb8b6ac1eafb407ec7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenPrefsTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenPrefsTests.cs
@@ -16,6 +16,11 @@ namespace MCPForUnityTests.Editor.AssetGen
         {
             EditorPrefKeys.AssetGenSelectedModelProvider,
             EditorPrefKeys.AssetGenSelectedImageProvider,
+            EditorPrefKeys.AssetGenSelectedAudioProvider,
+            EditorPrefKeys.AssetGenSelectedModelPrefix + "image.fal",
+            EditorPrefKeys.AssetGenSelectedModelPrefix + "model.tripo",
+            EditorPrefKeys.AssetGenSelectedModelPrefix + "model.meshy",
+            EditorPrefKeys.AssetGenSelectedModelPrefix + "audio.fal",
             EditorPrefKeys.AssetGenDefaultFormat,
             EditorPrefKeys.AssetGenOutputRoot,
             EditorPrefKeys.AssetGenAutoNormalize,
@@ -55,6 +60,32 @@ namespace MCPForUnityTests.Editor.AssetGen
             Assert.AreEqual("Assets/Foo", AssetGenPrefs.OutputRoot);
             Assert.IsFalse(AssetGenPrefs.AutoNormalize);
             Assert.IsTrue(AssetGenPrefs.IsProviderEnabled("tripo"));
+        }
+
+        [Test]
+        public void Defaults_ModelSelectionsEmpty_WhenUnset()
+        {
+            Assert.AreEqual(string.Empty, AssetGenPrefs.GetSelectedModel("image", "fal"));
+            Assert.AreEqual(string.Empty, AssetGenPrefs.GetSelectedModel("model", "tripo"));
+            Assert.AreEqual(string.Empty, AssetGenPrefs.GetSelectedModel("audio", "fal"));
+            Assert.AreEqual("fal", AssetGenPrefs.AudioProvider);
+        }
+
+        [Test]
+        public void SelectedModels_RoundTrip_PerProvider_AndClearOnEmpty()
+        {
+            AssetGenPrefs.SetSelectedModel("model", "tripo", "P1-20260311");
+            AssetGenPrefs.SetSelectedModel("model", "meshy", "meshy-6");
+            AssetGenPrefs.SetSelectedModel("audio", "fal", "cassetteai/sound-effects-generator");
+
+            // Per-provider: Tripo and Meshy selections are independent, no clobbering.
+            Assert.AreEqual("P1-20260311", AssetGenPrefs.GetSelectedModel("model", "tripo"));
+            Assert.AreEqual("meshy-6", AssetGenPrefs.GetSelectedModel("model", "meshy"));
+            Assert.AreEqual("cassetteai/sound-effects-generator", AssetGenPrefs.GetSelectedModel("audio", "fal"));
+
+            // Setting empty deletes the key (SetOrDelete) -> back to the empty default.
+            AssetGenPrefs.SetSelectedModel("audio", "fal", "");
+            Assert.AreEqual(string.Empty, AssetGenPrefs.GetSelectedModel("audio", "fal"));
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenProvidersTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenProvidersTests.cs
@@ -28,6 +28,42 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
+        public void Audio_Fal_ReturnsAdapter()
+        {
+            IAudioProviderAdapter adapter = AssetGenProviders.Audio("fal");
+            Assert.IsNotNull(adapter);
+            Assert.AreEqual("fal", adapter.Id);
+        }
+
+        [Test]
+        public void Audio_Unimplemented_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() => AssetGenProviders.Audio("elevenlabs"));
+        }
+
+        [Test]
+        public void List_IncludesFalAudioRow()
+        {
+            ProviderInfo row = FindByIdKind("fal", "audio");
+            Assert.IsNotNull(row, "List() should advertise a fal audio row");
+            Assert.AreEqual("audio", row.Kind);
+        }
+
+        [Test]
+        public void List_HasExactlyOneFalImage_AndOneFalAudio()
+        {
+            int image = 0, audio = 0;
+            foreach (ProviderInfo p in AssetGenProviders.List())
+            {
+                if (p.Id != "fal") continue;
+                if (p.Kind == "image") image++;
+                else if (p.Kind == "audio") audio++;
+            }
+            Assert.AreEqual(1, image, "exactly one fal image row");
+            Assert.AreEqual(1, audio, "exactly one fal audio row");
+        }
+
+        [Test]
         public void List_IncludesTripo_ConfiguredIsBool()
         {
             const string envName = "MCPFORUNITY_TRIPO_API_KEY";
@@ -62,6 +98,15 @@ namespace MCPForUnityTests.Editor.AssetGen
             foreach (ProviderInfo p in AssetGenProviders.List())
             {
                 if (p.Id == "tripo") return p;
+            }
+            return null;
+        }
+
+        private static ProviderInfo FindByIdKind(string id, string kind)
+        {
+            foreach (ProviderInfo p in AssetGenProviders.List())
+            {
+                if (p.Id == id && p.Kind == kind) return p;
             }
             return null;
         }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AudioImportPipelineTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AudioImportPipelineTests.cs
@@ -1,0 +1,38 @@
+using MCPForUnity.Editor.Services.AssetGen;
+using MCPForUnity.Editor.Services.AssetGen.Import;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.AssetGen
+{
+    /// <summary>
+    /// Validates the audio import pipeline's guard paths without fabricating audio bytes. Real
+    /// AudioClip import + AudioImporter settings are left to the licensed editor (manual checklist /
+    /// live smoke test), matching ModelImportPipelineTests' guard-only philosophy.
+    /// </summary>
+    public class AudioImportPipelineTests
+    {
+        private static AssetGenJob Job() => new AssetGenJob
+        {
+            JobId = "test",
+            Kind = "audio",
+            Provider = "fal",
+            State = AssetGenJobState.Importing,
+            Format = "wav",
+        };
+
+        [Test]
+        public void ImportInto_NullPath_Fails()
+        {
+            AssetGenJob result = AudioImportPipeline.ImportInto(Job(), null);
+            Assert.AreEqual(AssetGenJobState.Failed, result.State);
+        }
+
+        [Test]
+        public void ImportInto_PathOutsideAssets_Fails()
+        {
+            AssetGenJob result = AudioImportPipeline.ImportInto(Job(), "/tmp/somewhere/sound.wav");
+            Assert.AreEqual(AssetGenJobState.Failed, result.State);
+            StringAssert.Contains("Assets", result.Error);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AudioImportPipelineTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AudioImportPipelineTests.cs
@@ -34,5 +34,15 @@ namespace MCPForUnityTests.Editor.AssetGen
             Assert.AreEqual(AssetGenJobState.Failed, result.State);
             StringAssert.Contains("Assets", result.Error);
         }
+
+        [Test]
+        public void ImportInto_NonAudioExtension_UnderAssets_Rejected()
+        {
+            // Defense-in-depth: even a path under Assets is refused if it isn't an audio type, so a
+            // .cs payload can never be handed to AssetDatabase.ImportAsset.
+            AssetGenJob result = AudioImportPipeline.ImportInto(Job(), "Assets/Generated/payload.cs");
+            Assert.AreEqual(AssetGenJobState.Failed, result.State);
+            StringAssert.Contains("non-audio", result.Error.ToLowerInvariant());
+        }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AudioImportPipelineTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AudioImportPipelineTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a74b37c946289499eb717c4e37dbd3a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAdapterTests.cs
@@ -121,5 +121,42 @@ namespace MCPForUnityTests.Editor.AssetGen
 
             Assert.AreEqual(ProviderPollState.Running, pr.State);
         }
+
+        [Test]
+        public void Poll_UnknownStatus_FailsFast_NotRunning()
+        {
+            // C4: an unmapped terminal status must fail immediately, not poll until the job timeout.
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"status\":\"WEIRD_UNKNOWN\"}") };
+            var adapter = new FalAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Failed, pr.State);
+            StringAssert.Contains("WEIRD_UNKNOWN", pr.Error);
+        }
+
+        [Test]
+        public void Poll_ForeignHost_Throws_AndSendsNothing()
+        {
+            // H3: the key must never be attached to a provider-controlled host.
+            var fake = new FakeHttpTransport();
+            var adapter = new FalAdapter();
+
+            Assert.Throws<System.Exception>(() =>
+                adapter.PollAsync("https://attacker.example/harvest", "falkey123", fake, CancellationToken.None)
+                       .GetAwaiter().GetResult());
+            Assert.IsEmpty(fake.RecordedRequests, "no request (and no key) may be sent to a foreign host");
+        }
+
+        [Test]
+        public void Submit_ForeignResponseUrl_Throws()
+        {
+            // H3: a poisoned response_url from the provider must be rejected before it's used to poll.
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"https://evil.example/x\"}") };
+            var adapter = new FalAdapter();
+
+            Assert.Throws<System.Exception>(() =>
+                adapter.SubmitAsync(Req(), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult());
+        }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs
@@ -131,6 +131,21 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
+        public void Submit_CassetteMusic_FractionalDuration_Floors_NotRounds()
+        {
+            // Duration must be floored (not rounded) so it never exceeds the requested value:
+            // 10.9 -> 10, not 11.
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req("cassetteai/music-generator", 10.9f), "falkey123", fake, CancellationToken.None)
+                   .GetAwaiter().GetResult();
+
+            JObject body = JObject.Parse(SubmittedBody(fake));
+            Assert.AreEqual(10, (int)body["duration"]);
+        }
+
+        [Test]
         public void Submit_Lyria_PromptOnly()
         {
             var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs
@@ -88,20 +88,60 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
-        public void Submit_Lyria_And_CassetteMusic_PromptOnly()
+        public void Submit_CassetteMusic_WithDuration_IncludesDuration_ClampsTo180()
         {
-            foreach (string model in new[] { "fal-ai/lyria2", "cassetteai/music-generator" })
-            {
-                var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
-                var adapter = new FalAudioAdapter();
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
 
-                adapter.SubmitAsync(Req(model, 30f), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+            adapter.SubmitAsync(Req("cassetteai/music-generator", 300f), "falkey123", fake, CancellationToken.None)
+                   .GetAwaiter().GetResult();
 
-                string body = SubmittedBody(fake);
-                StringAssert.DoesNotContain("seconds_total", body);
-                StringAssert.DoesNotContain("duration", body);
-                StringAssert.Contains("prompt", body);
-            }
+            JObject body = JObject.Parse(SubmittedBody(fake));
+            Assert.AreEqual(180, (int)body["duration"]);
+        }
+
+        [Test]
+        public void Submit_CassetteMusic_DefaultDuration_IncludesDuration_NotPromptOnly()
+        {
+            // C2: CassetteAI Music REQUIRES duration; a default (Duration=0) call must still send a
+            // valid duration >= 1, not a prompt-only body (which fal rejects with 422).
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req("cassetteai/music-generator"), "falkey123", fake, CancellationToken.None)
+                   .GetAwaiter().GetResult();
+
+            JObject body = JObject.Parse(SubmittedBody(fake));
+            Assert.IsNotNull(body["duration"], "duration must be present for a required-duration model");
+            Assert.GreaterOrEqual((int)body["duration"], 1);
+        }
+
+        [Test]
+        public void Submit_CassetteMusic_FractionalDuration_FloorsToAtLeastOne()
+        {
+            // C3: Duration=0.5 must not (int)-truncate to 0 (which fal rejects); it clamps to >= 1.
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req("cassetteai/music-generator", 0.5f), "falkey123", fake, CancellationToken.None)
+                   .GetAwaiter().GetResult();
+
+            JObject body = JObject.Parse(SubmittedBody(fake));
+            Assert.GreaterOrEqual((int)body["duration"], 1);
+        }
+
+        [Test]
+        public void Submit_Lyria_PromptOnly()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req("fal-ai/lyria2", 30f), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = SubmittedBody(fake);
+            StringAssert.DoesNotContain("seconds_total", body);
+            StringAssert.DoesNotContain("duration", body);
+            StringAssert.Contains("prompt", body);
         }
 
         [Test]
@@ -241,6 +281,43 @@ namespace MCPForUnityTests.Editor.AssetGen
 
             Assert.AreEqual(ProviderPollState.Failed, pr.State);
             StringAssert.DoesNotContain("falkey123", pr.Error);
+        }
+
+        [Test]
+        public void Poll_UnknownStatus_FailsFast_NotRunning()
+        {
+            // C4: an unmapped terminal status must fail immediately, not poll until the job timeout.
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"status\":\"WEIRD_UNKNOWN\"}") };
+            var adapter = new FalAudioAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Failed, pr.State);
+            StringAssert.Contains("WEIRD_UNKNOWN", pr.Error);
+        }
+
+        [Test]
+        public void Poll_ForeignHost_Throws_AndSendsNothing()
+        {
+            // H3: the key must never be attached to a provider-controlled host.
+            var fake = new FakeHttpTransport();
+            var adapter = new FalAudioAdapter();
+
+            Assert.Throws<System.Exception>(() =>
+                adapter.PollAsync("https://attacker.example/harvest", "falkey123", fake, CancellationToken.None)
+                       .GetAwaiter().GetResult());
+            Assert.IsEmpty(fake.RecordedRequests, "no request (and no key) may be sent to a foreign host");
+        }
+
+        [Test]
+        public void Submit_ForeignResponseUrl_Throws()
+        {
+            // H3: a poisoned response_url from the provider must be rejected before it's used to poll.
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"https://evil.example/x\"}") };
+            var adapter = new FalAudioAdapter();
+
+            Assert.Throws<System.Exception>(() =>
+                adapter.SubmitAsync(Req(), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult());
         }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs
@@ -1,0 +1,246 @@
+using System.Text;
+using System.Threading;
+using MCPForUnity.Editor.Services.AssetGen.Http;
+using MCPForUnity.Editor.Services.AssetGen.Providers;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.AssetGen
+{
+    public class FalAudioAdapterTests
+    {
+        private const string StableAudio = "fal-ai/stable-audio-25/text-to-audio";
+        private const string Resp = "https://queue.fal.run/fal-ai/stable-audio-25/text-to-audio/requests/r1";
+
+        private static HttpResult Json(string body) => new HttpResult { Status = 200, IsSuccess = true, Text = body };
+
+        private static AudioGenRequest Req(string model = null, float duration = 0f) =>
+            new AudioGenRequest { Provider = "fal", Model = model, Prompt = "gentle rain", Duration = duration };
+
+        private static string SubmittedBody(FakeHttpTransport fake) =>
+            Encoding.UTF8.GetString(fake.RecordedRequests[0].Body);
+
+        [Test]
+        public void Submit_PostsModelEndpoint_WithKeyHeader_ReturnsResponseUrl()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = _ => Json("{\"request_id\":\"r1\",\"response_url\":\"" + Resp + "\"}")
+            };
+            var adapter = new FalAudioAdapter();
+
+            string pid = adapter.SubmitAsync(Req(), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(Resp, pid);
+            HttpRequestSpec sent = fake.RecordedRequests[0];
+            Assert.AreEqual("POST", sent.Method);
+            StringAssert.Contains(StableAudio, sent.Url);
+            Assert.IsTrue(sent.Headers.ContainsKey("Authorization"));
+            StringAssert.StartsWith("Key ", sent.Headers["Authorization"]);
+        }
+
+        [Test]
+        public void Submit_ModelOverride_UsesModelEndpoint()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req("cassetteai/sound-effects-generator"), "falkey123", fake, CancellationToken.None)
+                   .GetAwaiter().GetResult();
+
+            StringAssert.Contains("cassetteai/sound-effects-generator", fake.RecordedRequests[0].Url);
+        }
+
+        [Test]
+        public void Submit_StableAudio_WithDuration_IncludesSecondsTotal()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req(StableAudio, 30f), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            StringAssert.Contains("seconds_total", SubmittedBody(fake));
+        }
+
+        [Test]
+        public void Submit_StableAudio_OverMax_ClampsTo190()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req(StableAudio, 250f), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            JObject body = JObject.Parse(SubmittedBody(fake));
+            Assert.AreEqual(190, (int)body["seconds_total"]);
+        }
+
+        [Test]
+        public void Submit_CassetteSfx_WithDuration_IncludesDuration_ClampsTo30()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+            var adapter = new FalAudioAdapter();
+
+            adapter.SubmitAsync(Req("cassetteai/sound-effects-generator", 45f), "falkey123", fake, CancellationToken.None)
+                   .GetAwaiter().GetResult();
+
+            JObject body = JObject.Parse(SubmittedBody(fake));
+            Assert.AreEqual(30, (int)body["duration"]);
+        }
+
+        [Test]
+        public void Submit_Lyria_And_CassetteMusic_PromptOnly()
+        {
+            foreach (string model in new[] { "fal-ai/lyria2", "cassetteai/music-generator" })
+            {
+                var fake = new FakeHttpTransport { Handler = _ => Json("{\"response_url\":\"" + Resp + "\"}") };
+                var adapter = new FalAudioAdapter();
+
+                adapter.SubmitAsync(Req(model, 30f), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+                string body = SubmittedBody(fake);
+                StringAssert.DoesNotContain("seconds_total", body);
+                StringAssert.DoesNotContain("duration", body);
+                StringAssert.Contains("prompt", body);
+            }
+        }
+
+        [Test]
+        public void Submit_FallbackResponseUrl_UsesModelRequestsPath()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"request_id\":\"r1\"}") }; // no response_url
+            var adapter = new FalAudioAdapter();
+
+            string pid = adapter.SubmitAsync(Req(), "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            StringAssert.Contains(StableAudio + "/requests/r1", pid);
+        }
+
+        [Test]
+        public void Poll_Status_KeyHeaderPresent()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => spec.Url.EndsWith("/status")
+                    ? Json("{\"status\":\"COMPLETED\"}")
+                    : Json("{\"audio_file\":{\"url\":\"https://cdn.example.com/a.wav\"}}")
+            };
+            var adapter = new FalAudioAdapter();
+
+            adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            foreach (HttpRequestSpec sent in fake.RecordedRequests)
+            {
+                Assert.IsTrue(sent.Headers.ContainsKey("Authorization"));
+                StringAssert.StartsWith("Key ", sent.Headers["Authorization"]);
+            }
+        }
+
+        [Test]
+        public void Poll_Completed_WavResult_ReturnsWavExt()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => spec.Url.EndsWith("/status")
+                    ? Json("{\"status\":\"COMPLETED\"}")
+                    : Json("{\"audio_file\":{\"url\":\"https://cdn.example.com/a.wav\"}}")
+            };
+            var adapter = new FalAudioAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Succeeded, pr.State);
+            Assert.AreEqual("https://cdn.example.com/a.wav", pr.DownloadUrl);
+            Assert.AreEqual("wav", pr.ResultExt);
+        }
+
+        [Test]
+        public void Poll_Completed_Mp3Result_ReturnsMp3Ext()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => spec.Url.EndsWith("/status")
+                    ? Json("{\"status\":\"COMPLETED\"}")
+                    : Json("{\"audio_file\":{\"url\":\"https://cdn.example.com/track.mp3\"}}")
+            };
+            var adapter = new FalAudioAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual("mp3", pr.ResultExt);
+        }
+
+        [Test]
+        public void Poll_AudioShape_And_BareUrl_Extracted()
+        {
+            foreach (string result in new[]
+            {
+                "{\"audio\":{\"url\":\"https://cdn.example.com/a.wav\"}}",
+                "{\"audio_url\":\"https://cdn.example.com/a.wav\"}"
+            })
+            {
+                var fake = new FakeHttpTransport
+                {
+                    Handler = spec => spec.Url.EndsWith("/status") ? Json("{\"status\":\"COMPLETED\"}") : Json(result)
+                };
+                var adapter = new FalAudioAdapter();
+
+                ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+                Assert.AreEqual(ProviderPollState.Succeeded, pr.State);
+                Assert.AreEqual("https://cdn.example.com/a.wav", pr.DownloadUrl);
+            }
+        }
+
+        [Test]
+        public void Poll_Completed_NoUrl_Fails()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => spec.Url.EndsWith("/status") ? Json("{\"status\":\"COMPLETED\"}") : Json("{}")
+            };
+            var adapter = new FalAudioAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Failed, pr.State);
+            StringAssert.Contains("audio", pr.Error);
+        }
+
+        [Test]
+        public void Poll_InProgress_Running()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"status\":\"IN_PROGRESS\"}") };
+            var adapter = new FalAudioAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Running, pr.State);
+        }
+
+        [Test]
+        public void Poll_InQueue_Queued()
+        {
+            var fake = new FakeHttpTransport { Handler = _ => Json("{\"status\":\"IN_QUEUE\"}") };
+            var adapter = new FalAudioAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Queued, pr.State);
+        }
+
+        [Test]
+        public void Poll_Failed_RedactsError()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = _ => Json("{\"status\":\"ERROR\",\"error\":\"boom falkey123 leaked\"}")
+            };
+            var adapter = new FalAudioAdapter();
+
+            ProviderPollResult pr = adapter.PollAsync(Resp, "falkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Failed, pr.State);
+            StringAssert.DoesNotContain("falkey123", pr.Error);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/FalAudioAdapterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc7e0ad00c6945a88a078ae0e52c54a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateAudioTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateAudioTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using MCPForUnity.Editor.Security;
+using MCPForUnity.Editor.Services.AssetGen;
+using MCPForUnity.Editor.Services.AssetGen.Http;
+using MCPForUnity.Editor.Tools.AssetGen;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.AssetGen
+{
+    public class GenerateAudioTests
+    {
+        private string _dir;
+        private EncryptedFileKeyStore _store;
+
+        [SetUp]
+        public void SetUp()
+        {
+            AssetGenJobManager.ResetForTests();
+            Environment.SetEnvironmentVariable("MCPFORUNITY_FAL_API_KEY", null);
+            _dir = Path.Combine(Path.GetTempPath(), "mcp_audiohandler_" + Guid.NewGuid().ToString("N"));
+            _store = new EncryptedFileKeyStore(_dir);
+            SecureKeyStore.OverrideForTests(_store);
+            AssetGenJobManager.TransportOverrideForTests = new FakeHttpTransport();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AssetGenJobManager.ResetForTests();
+            SecureKeyStore.ResetForTests();
+            try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
+        }
+
+        private static JObject Call(JObject p)
+            => JObject.Parse(JsonConvert.SerializeObject(GenerateAudio.HandleCommand(p)));
+
+        [Test]
+        public void Generate_WithKey_ReturnsPendingJobId()
+        {
+            _store.Set("fal", "falkey");
+            JObject gen = Call(new JObject { ["action"] = "generate", ["provider"] = "fal", ["prompt"] = "gentle rain" });
+            Assert.AreEqual("pending", (string)gen["_mcp_status"]);
+            Assert.IsFalse(string.IsNullOrEmpty((string)gen["data"]["job_id"]));
+        }
+
+        [Test]
+        public void Generate_MissingKey_ReturnsError()
+        {
+            JObject resp = Call(new JObject { ["action"] = "generate", ["provider"] = "fal", ["prompt"] = "gentle rain" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("No API key", (string)resp["error"]);
+        }
+
+        [Test]
+        public void Generate_EmptyPrompt_ReturnsError()
+        {
+            _store.Set("fal", "falkey");
+            JObject resp = Call(new JObject { ["action"] = "generate", ["provider"] = "fal" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("prompt", ((string)resp["error"]).ToLowerInvariant());
+        }
+
+        [Test]
+        public void Generate_UnknownProvider_ReturnsError()
+        {
+            JObject resp = Call(new JObject { ["action"] = "generate", ["provider"] = "elevenlabs", ["prompt"] = "gentle rain" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+        }
+
+        [Test]
+        public void ListProviders_FiltersAudioKind()
+        {
+            JObject resp = Call(new JObject { ["action"] = "list_providers" });
+            Assert.AreEqual(true, (bool)resp["success"]);
+            string s = resp.ToString();
+            StringAssert.Contains("fal", s);
+            StringAssert.Contains("audio", s);
+            StringAssert.DoesNotContain("tripo", s);      // model providers excluded
+            StringAssert.DoesNotContain("openrouter", s); // image providers excluded
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateAudioTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateAudioTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3a53bbf67324d27b68a813da5c82637
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateImageTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateImageTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
 using MCPForUnity.Editor.Services.AssetGen;
 using MCPForUnity.Editor.Services.AssetGen.Http;
@@ -144,6 +145,54 @@ namespace MCPForUnityTests.Editor.AssetGen
             _store.Set("bogus", "k");
             JObject resp = Call(new JObject { ["action"] = "generate", ["provider"] = "bogus", ["mode"] = "text", ["prompt"] = "a cat" });
             Assert.AreEqual(false, (bool)resp["success"]);
+        }
+
+        private static HttpResult FalStatus(HttpRequestSpec spec) =>
+            spec.Url.EndsWith("/status")
+                ? new HttpResult { Status = 200, IsSuccess = true, Text = "{\"status\":\"IN_PROGRESS\"}" }
+                : new HttpResult { Status = 200, IsSuccess = true, Text = "{\"response_url\":\"https://queue.fal.run/x/requests/r1\"}" };
+
+        [Test]
+        public void Generate_NoModelParam_UsesSelectedImageModelPref()
+        {
+            _store.Set("fal", "falkey");
+            AssetGenPrefs.SetSelectedModel("image", "fal", "fal-ai/flux-2-pro");
+            var fake = new FakeHttpTransport { Handler = FalStatus };
+            AssetGenJobManager.TransportOverrideForTests = fake;
+            AssetGenJobManager.PollIntervalSeconds = 0;
+            try
+            {
+                JObject gen = Call(new JObject { ["action"] = "generate", ["provider"] = "fal", ["mode"] = "text", ["prompt"] = "a cat" });
+                string jobId = (string)gen["data"]["job_id"];
+                for (int i = 0; i < 6; i++) AssetGenJobManager.TryAdvanceForTests(jobId);
+
+                HttpRequestSpec post = fake.RecordedRequests.Find(r => r.Method == "POST");
+                Assert.IsNotNull(post, "expected a submit POST");
+                StringAssert.Contains("flux-2-pro", post.Url); // pref drove the model when none was passed
+            }
+            finally { AssetGenPrefs.SetSelectedModel("image", "fal", ""); }
+        }
+
+        [Test]
+        public void Generate_ExplicitModel_OverridesPref()
+        {
+            _store.Set("fal", "falkey");
+            AssetGenPrefs.SetSelectedModel("image", "fal", "fal-ai/flux-2-pro");
+            var fake = new FakeHttpTransport { Handler = FalStatus };
+            AssetGenJobManager.TransportOverrideForTests = fake;
+            AssetGenJobManager.PollIntervalSeconds = 0;
+            try
+            {
+                JObject gen = Call(new JObject { ["action"] = "generate", ["provider"] = "fal", ["mode"] = "text", ["prompt"] = "a cat", ["model"] = "fal-ai/flux-2/flash" });
+                string jobId = (string)gen["data"]["job_id"];
+                for (int i = 0; i < 6; i++) AssetGenJobManager.TryAdvanceForTests(jobId);
+
+                HttpRequestSpec post = fake.RecordedRequests.Find(r => r.Method == "POST");
+                Assert.IsNotNull(post);
+                StringAssert.Contains("flux-2/flash", post.Url);
+                StringAssert.DoesNotContain("flux-2-pro", post.Url);
+            }
+            finally { AssetGenPrefs.SetSelectedModel("image", "fal", ""); }
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/MeshyAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/MeshyAdapterTests.cs
@@ -62,6 +62,32 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
+        public void Submit_UsesRequestModel_WhenProvided()
+        {
+            var http = new FakeHttpTransport { Handler = _ => Json("{\"result\":\"t\"}") };
+            var adapter = new MeshyAdapter();
+            var req = new ModelGenRequest { Provider = "meshy", Mode = "text", Prompt = "x", Model = "meshy-5" };
+
+            adapter.SubmitAsync(req, "k", http, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = Encoding.UTF8.GetString(http.RecordedRequests[0].Body);
+            StringAssert.Contains("\"ai_model\":\"meshy-5\"", body);
+        }
+
+        [Test]
+        public void Submit_FallsBackToDefault_WhenModelEmpty()
+        {
+            var http = new FakeHttpTransport { Handler = _ => Json("{\"result\":\"t\"}") };
+            var adapter = new MeshyAdapter();
+            var req = new ModelGenRequest { Provider = "meshy", Mode = "text", Prompt = "x" }; // Model null
+
+            adapter.SubmitAsync(req, "k", http, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = Encoding.UTF8.GetString(http.RecordedRequests[0].Body);
+            StringAssert.Contains("\"ai_model\":\"" + MeshyAdapter.DefaultModel + "\"", body);
+        }
+
+        [Test]
         public void Poll_Succeeded_ReturnsGlbUrl()
         {
             var http = new FakeHttpTransport

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/TripoAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/TripoAdapterTests.cs
@@ -148,6 +148,44 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
+        public void Submit_ImageMode_HonorsModelVersion_WhenProvided()
+        {
+            var http = new FakeHttpTransport { Handler = _ => Json("{\"code\":0,\"data\":{\"task_id\":\"img1\"}}") };
+            var adapter = new TripoAdapter();
+            var req = new ModelGenRequest
+            {
+                Provider = "tripo",
+                Mode = "image",
+                ImageUrl = "https://example.com/in.png",
+                Model = "P1-20260311",
+            };
+
+            adapter.SubmitAsync(req, "k", http, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = Encoding.UTF8.GetString(http.RecordedRequests[0].Body);
+            StringAssert.Contains("image_to_model", body);
+            StringAssert.Contains("\"model_version\":\"P1-20260311\"", body);
+        }
+
+        [Test]
+        public void Submit_ImageMode_FallsBackToDefaultModelVersion_WhenModelEmpty()
+        {
+            var http = new FakeHttpTransport { Handler = _ => Json("{\"code\":0,\"data\":{\"task_id\":\"img1\"}}") };
+            var adapter = new TripoAdapter();
+            var req = new ModelGenRequest
+            {
+                Provider = "tripo",
+                Mode = "image",
+                ImageUrl = "https://example.com/in.png", // Model null
+            };
+
+            adapter.SubmitAsync(req, "k", http, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = Encoding.UTF8.GetString(http.RecordedRequests[0].Body);
+            StringAssert.Contains("\"model_version\":\"" + TripoAdapter.ModelVersion + "\"", body);
+        }
+
+        [Test]
         public void Submit_ImageMode_LocalPathOnly_Throws()
         {
             // Tripo can't take a local image inline (no data-URI support, upload not wired) — it must

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/TripoAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/TripoAdapterTests.cs
@@ -100,6 +100,32 @@ namespace MCPForUnityTests.Editor.AssetGen
         }
 
         [Test]
+        public void Submit_UsesRequestModel_WhenProvided()
+        {
+            var http = new FakeHttpTransport { Handler = _ => Json("{\"code\":0,\"data\":{\"task_id\":\"t\"}}") };
+            var adapter = new TripoAdapter();
+            var req = new ModelGenRequest { Provider = "tripo", Mode = "text", Prompt = "x", Model = "P1-20260311" };
+
+            adapter.SubmitAsync(req, "k", http, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = Encoding.UTF8.GetString(http.RecordedRequests[0].Body);
+            StringAssert.Contains("\"model_version\":\"P1-20260311\"", body);
+        }
+
+        [Test]
+        public void Submit_FallsBackToDefault_WhenModelEmpty()
+        {
+            var http = new FakeHttpTransport { Handler = _ => Json("{\"code\":0,\"data\":{\"task_id\":\"t\"}}") };
+            var adapter = new TripoAdapter();
+            var req = new ModelGenRequest { Provider = "tripo", Mode = "text", Prompt = "x" }; // Model null
+
+            adapter.SubmitAsync(req, "k", http, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = Encoding.UTF8.GetString(http.RecordedRequests[0].Body);
+            StringAssert.Contains("\"model_version\":\"" + TripoAdapter.ModelVersion + "\"", body);
+        }
+
+        [Test]
         public void Submit_ImageMode_UsesImageToModel()
         {
             var http = new FakeHttpTransport

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/UnityWebRequestTransportTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/UnityWebRequestTransportTests.cs
@@ -1,0 +1,39 @@
+using MCPForUnity.Editor.Services.AssetGen.Http;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.AssetGen
+{
+    /// <summary>
+    /// H1: an auth-bearing request must not follow redirects (UnityWebRequest re-sends the
+    /// Authorization header to a 3xx target by default). We can't drive a real redirect headlessly,
+    /// so we test the decision helper that gates redirectLimit = 0.
+    /// </summary>
+    public class UnityWebRequestTransportTests
+    {
+        [Test]
+        public void CarriesAuth_TrueWhenAuthorizationHeaderPresent()
+        {
+            var spec = new HttpRequestSpec { Method = "GET", Url = "https://queue.fal.run/x" };
+            spec.Headers["Authorization"] = "Key secret123";
+
+            Assert.IsTrue(UnityWebRequestTransport.CarriesAuth(spec));
+        }
+
+        [Test]
+        public void CarriesAuth_CaseInsensitiveHeaderKey()
+        {
+            var spec = new HttpRequestSpec { Method = "GET", Url = "https://queue.fal.run/x" };
+            spec.Headers["authorization"] = "Bearer secret123";
+
+            Assert.IsTrue(UnityWebRequestTransport.CarriesAuth(spec));
+        }
+
+        [Test]
+        public void CarriesAuth_FalseWhenNoAuthorizationHeader()
+        {
+            var spec = new HttpRequestSpec { Method = "GET", Url = "https://cdn.example.com/a.wav" };
+
+            Assert.IsFalse(UnityWebRequestTransport.CarriesAuth(spec));
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/UnityWebRequestTransportTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/UnityWebRequestTransportTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f9a1eafd557475683b6426972bd8e71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/Characterization/Windows_Characterization.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/Characterization/Windows_Characterization.cs
@@ -714,10 +714,10 @@ namespace MCPForUnityTests.Editor.Windows.Characterization
             Assert.IsNotNull(type.GetMethod("AddAudioRow", BindingFlags.NonPublic | BindingFlags.Instance),
                 "expected a fal audio row builder");
 
-            // AddProviderRow now takes (id, displayName, kind) so each row knows its catalog kind.
+            // AddProviderRow takes (parent, id, displayName, kind) so each row knows its catalog kind.
             var addRow = type.GetMethod("AddProviderRow", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.IsNotNull(addRow);
-            Assert.AreEqual(3, addRow.GetParameters().Length, "AddProviderRow should take (id, displayName, kind)");
+            Assert.AreEqual(4, addRow.GetParameters().Length, "AddProviderRow should take (parent, id, displayName, kind)");
 
             foreach (string phase in new[] { "CacheUIElements", "InitializeUI", "RegisterCallbacks" })
                 Assert.IsNotNull(type.GetMethod(phase, BindingFlags.NonPublic | BindingFlags.Instance),

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/Characterization/Windows_Characterization.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/Characterization/Windows_Characterization.cs
@@ -696,5 +696,47 @@ namespace MCPForUnityTests.Editor.Windows.Characterization
         }
 
         #endregion
+
+        #region Section 9: McpAssetGenSection model-selection structure (reflection, no instantiation)
+
+        /// <summary>
+        /// The Asset Gen section builds per-provider model dropdowns and a fal audio row. We assert
+        /// the private builders exist and keep the three-phase lifecycle, without instantiating the
+        /// section (its ctor requires the real UXML tree) — matching this suite's reflection style.
+        /// </summary>
+        [Test]
+        public void McpAssetGenSection_HasModelDropdownAndAudioRowBuilders()
+        {
+            var type = typeof(MCPForUnity.Editor.Windows.Components.AssetGen.McpAssetGenSection);
+
+            Assert.IsNotNull(type.GetMethod("AddModelDropdown", BindingFlags.NonPublic | BindingFlags.Instance),
+                "expected a per-provider model dropdown builder");
+            Assert.IsNotNull(type.GetMethod("AddAudioRow", BindingFlags.NonPublic | BindingFlags.Instance),
+                "expected a fal audio row builder");
+
+            // AddProviderRow now takes (id, displayName, kind) so each row knows its catalog kind.
+            var addRow = type.GetMethod("AddProviderRow", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(addRow);
+            Assert.AreEqual(3, addRow.GetParameters().Length, "AddProviderRow should take (id, displayName, kind)");
+
+            foreach (string phase in new[] { "CacheUIElements", "InitializeUI", "RegisterCallbacks" })
+                Assert.IsNotNull(type.GetMethod(phase, BindingFlags.NonPublic | BindingFlags.Instance),
+                    $"three-phase lifecycle method {phase} should remain");
+        }
+
+        [Test]
+        public void McpAssetGenSection_HasRefreshHandler_AndCachedRefreshElements()
+        {
+            var type = typeof(MCPForUnity.Editor.Windows.Components.AssetGen.McpAssetGenSection);
+
+            Assert.IsNotNull(type.GetMethod("OnRefreshClicked", BindingFlags.NonPublic | BindingFlags.Instance),
+                "expected a Refresh click handler");
+            Assert.IsNotNull(type.GetField("refreshButton", BindingFlags.NonPublic | BindingFlags.Instance),
+                "expected the Refresh button to be cached (three-phase CacheUIElements)");
+            Assert.IsNotNull(type.GetField("refreshStatusLabel", BindingFlags.NonPublic | BindingFlags.Instance),
+                "expected the Refresh status label to be cached");
+        }
+
+        #endregion
     }
 }

--- a/website/docs/reference/tools/asset_gen/generate_audio.md
+++ b/website/docs/reference/tools/asset_gen/generate_audio.md
@@ -1,0 +1,47 @@
+---
+title: generate_audio
+sidebar_label: generate_audio
+description: "Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project."
+---
+
+# `generate_audio`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `asset_gen` &nbsp;·&nbsp; **Module:** `services.tools.generate_audio`
+
+## Description
+
+Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project. Bring-your-own-key: the fal key lives in the editor's secure store (shared with image generation) and never crosses the bridge.
+
+MODELS (all via fal.ai): fal-ai/stable-audio-25/text-to-audio (music + SFX, <=190s), cassetteai/sound-effects-generator (SFX, <=30s), cassetteai/music-generator (music), fal-ai/lyria2 (music). Omit model to use the model selected in the MCP for Unity -> Asset Generation tab.
+
+ACTIONS:
+- generate: Submit an audio job from a text prompt. Returns { job_id }; poll with the status action. Params: provider (fal), prompt, model, duration (seconds), name, output_folder.
+- status: Poll an async job by job_id -> { state, progress, assetPath?, error? }.
+- cancel: Cancel an in-flight job by job_id.
+- list_providers: List configured audio providers and capabilities (no key values).
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['generate', 'status', 'cancel', 'list_providers']` | yes | Action to perform. |
+| `provider` | `str \| None` | — | Provider id (fal). |
+| `prompt` | `str \| None` | — | Text prompt describing the sound or music. |
+| `model` | `str \| None` | — | fal model id (e.g. fal-ai/stable-audio-25/text-to-audio). Omit to use the GUI-selected default. |
+| `duration` | `float \| None` | — | Requested length in seconds (soft-clamped per model). |
+| `name` | `str \| None` | — | Base name for the imported asset. |
+| `output_folder` | `str \| None` | — | Destination folder under Assets/ for the import. |
+| `job_id` | `str \| None` | — | Job id for status/cancel. |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/asset_gen/generate_model.md
+++ b/website/docs/reference/tools/asset_gen/generate_model.md
@@ -15,7 +15,7 @@ description: "Generate 3D models with AI providers (Tripo, Meshy) and import the
 Generate 3D models with AI providers (Tripo, Meshy) and import them into the Unity project. Bring-your-own-key: provider keys live in the editor's secure store and never cross the bridge.
 
 ACTIONS:
-- generate: Submit a generation job (text->3D or image->3D). Returns { job_id } immediately; poll with the status action. Params: provider, mode (text|image), prompt, image_path|image_url, format (glb|fbx|obj|usdz), target_size, texture, tier, name, output_folder.
+- generate: Submit a generation job (text->3D or image->3D). Returns { job_id } immediately; poll with the status action. Params: provider, mode (text|image), prompt, image_path|image_url, format (glb|fbx|obj|usdz), target_size, texture, tier, model, name, output_folder.
 - status: Poll an async job by job_id -> { state, progress, assetPath?, error? }.
 - cancel: Cancel an in-flight job by job_id.
 - list_providers: List configured 3D providers and capabilities (no key values).
@@ -34,6 +34,7 @@ ACTIONS:
 | `target_size` | `float \| None` | — | Normalize the largest dimension to this size (meters). |
 | `texture` | `bool \| None` | — | Whether to generate textures for the model. |
 | `tier` | `str \| None` | — | Provider quality/cost tier. |
+| `model` | `str \| None` | — | Provider model id/version (e.g. Tripo v3.1, Meshy meshy-6). Omit for the GUI-selected default. |
 | `name` | `str \| None` | — | Base name for the imported asset. |
 | `output_folder` | `str \| None` | — | Destination folder under Assets/ for the import. |
 | `job_id` | `str \| None` | — | Job id for status/cancel. |

--- a/website/docs/reference/tools/asset_gen/index.md
+++ b/website/docs/reference/tools/asset_gen/index.md
@@ -6,8 +6,9 @@ description: "MCP for Unity tools in the asset_gen group."
 
 # `asset_gen` tools
 
-AI asset generation – 3D model gen/import & 2D image gen (bring-your-own-key)
+AI asset generation – 3D model gen/import, 2D image gen & audio gen (bring-your-own-key)
 
+- **[`generate_audio`](./generate_audio.md)** — Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project.
 - **[`generate_image`](./generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project.
 - **[`generate_model`](./generate_model.md)** — Generate 3D models with AI providers (Tripo, Meshy) and import them into the Unity project.
 - **[`import_model`](./import_model.md)** — Import 3D models from the Sketchfab marketplace into the Unity project.

--- a/website/docs/reference/tools/index.md
+++ b/website/docs/reference/tools/index.md
@@ -16,8 +16,9 @@ Every tool MCP for Unity exposes, generated directly from the Python `@mcp_for_u
 Animator control & AnimationClip creation
 - **[`manage_animation`](./animation/manage_animation.md)** — Manage Unity animation: Animator control and AnimationClip creation.
 
-## `asset_gen` &nbsp; (4 tools)
-AI asset generation – 3D model gen/import & 2D image gen (bring-your-own-key)
+## `asset_gen` &nbsp; (5 tools)
+AI asset generation – 3D model gen/import, 2D image gen & audio gen (bring-your-own-key)
+- **[`generate_audio`](./asset_gen/generate_audio.md)** — Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project.
 - **[`generate_image`](./asset_gen/generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project.
 - **[`generate_model`](./asset_gen/generate_model.md)** — Generate 3D models with AI providers (Tripo, Meshy) and import them into the Unity project.
 - **[`import_model`](./asset_gen/import_model.md)** — Import 3D models from the Sketchfab marketplace into the Unity project.


### PR DESCRIPTION
## Summary

Adds **AI audio generation** to the Asset Generation feature and a **shared model control panel** across image / 3D / audio, then hardens the whole subsystem after a security audit + code review.

- **`generate_audio`** MCP tool + CLI — fal.ai audio (Stable Audio 2.5 default, CassetteAI SFX/Music, Google Lyria 2), reusing the single `fal` key. Backend: `FalAudioAdapter`, `AudioImportPipeline` (load type branches on clip length), `AssetGenJobManager.StartAudioGeneration`.
- **Model control panel** — a curated `AssetGenModelCatalog` (per-model use-case / price / duration / license metadata) drives per-provider **Model** dropdowns on the image/3D/audio rows, a fal-audio row (no key field — shares the fal key), and a Refresh button. Model prefs are per-(kind, provider).

## Security hardening (from a dynamic security audit)

- **Provider API-key exfiltration via redirect** — `UnityWebRequestTransport` now sets `redirectLimit=0` on any request carrying an `Authorization` header, so a provider 3xx can't re-send the key to a redirect host.
- **Provider-controlled file extension → Editor RCE** — a per-kind result-extension **allowlist** at the write/import boundary (`AssetGenJobManager.WriteFile` + defense-in-depth in the audio/image import pipelines). A hostile provider response can no longer land a `.cs`/`.asmdef`/`.meta`/`.asset` under `Assets/` and get it compiled on refresh.
- **`response_url` / model host-pinning** — `ProviderHttp.RequireHost` validates the submit URL and the provider-supplied `response_url` are `https://queue.fal.run` before the fal key is ever attached (both fal image + audio adapters).

## Correctness fixes (from code review)

- Tripo image→3D now honors the selected `model_version`.
- `FalAudioAdapter.BuildBody` is catalog-driven: duration-required models (CassetteAI SFX/Music, Stable Audio) send a sensible **default duration** when the caller passes none (fixes a default-input fal 422), fractional durations floor to ≥1, Lyria stays prompt-only and its GUI no longer advertises a duration it ignores, and per-model clamp ceilings come from the catalog (no duplicated constants).
- Unknown fal poll status fails fast instead of polling to the 600s timeout.
- Stale/invalid selected-model pref is cleared on dropdown fallback; the audio fal-key status refreshes when the shared 2D fal key changes.

## Cleanup

- `AssetGenModelCatalog.ResolveModel(...)` dedupes the model-resolution chain across the three generate tools.
- Tool-group label fix: `asset_gen` → **"Asset Gen"** (was falling back to `"Asset_gen"`).
- Reference docs regenerated from the Python registry (adds `generate_audio.md`, refreshes the Asset Gen landscape).

## Testing

- **EditMode: 1166 tests, 0 failures** (+19 new regression tests covering every fix above), verified on the 2021.3 floor.
- **Python: 34 asset-gen tests pass.** Docs `--check` green. Compile matrix (pre-push hook) green.
- Live fal smoke tests run in-editor: SFX (3s), CassetteAI Music (20s), Stable Audio (30s) — all import with the expected specs; the label fix verified live (`asset_gen → "Asset Gen"`).

## Notes for reviewers

- Draft: the 6 **LOW** security findings (download-host SSRF guard, `image_url` validation, download size cap, request timeout/abort, concurrency cap, job-record accumulation) are **not** in this PR — several are pre-existing shared-infra gaps; happy to split them into a follow-up.
- Release notes / `Recent Updates` are auto-generated from the published GitHub Release, so this PR description doubles as the v10.1 change summary.

🤖 Prepared with Claude Code.

https://claude.ai/code/session_015KYy51gwBuhDuLZXXoqc98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio generation support end-to-end (generate/status/cancel/list providers) with provider + model selection and automatic Unity AudioClip import.
  * Introduced curated model selection with per-provider saved preferences and updated Asset Generation UI (audio rows, model dropdowns, refresh).
  * Added `generate_audio` CLI/MCP tool support and refreshed tool documentation.
* **Bug Fixes**
  * Strengthened validation for imported result file types and improved safety when authenticated (prevents redirect behavior) and when provider URLs are untrusted.
* **Documentation**
  * Updated and added audio tool reference pages.
* **Tests**
  * Added/expanded unit and integration tests covering audio flows, model catalog selection, validation/allowlists, and security edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->