### PR TITLE
fix: match macOS Unity projectPath argument case-insensitively

### DIFF
--- a/Server/src/utils/focus_nudge.py
+++ b/Server/src/utils/focus_nudge.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import os
 import platform
+import re
 import shutil
 import subprocess
 import time
@@ -199,29 +200,29 @@ def _find_unity_pid_by_project_path(project_path: str) -> int | None:
         # Determine if project_path is a full path or just a name
         is_full_path = "/" in project_path or "\\" in project_path
 
-        # Look for Unity.app processes with matching -projectpath
+        # Unity Hub emits -projectPath while manually launched editors may use
+        # -projectpath. Treat the option name case-insensitively.
         for line in result.stdout.splitlines():
             if "Unity.app/Contents/MacOS/Unity" not in line:
                 continue
 
-            # Check for -projectpath argument
-            if "-projectpath" not in line:
+            project_arg = re.search(r"-projectpath\s+(\S+)", line, re.IGNORECASE)
+            if project_arg is None:
                 continue
+            candidate_path = project_arg.group(1)
 
             if is_full_path:
                 # Exact match for full path
-                if f"-projectpath {project_path}" not in line:
+                if candidate_path != project_path:
                     continue
             else:
                 # Match if path ends with project name (e.g., ".../UnityMCPTests")
-                if "-projectpath" in line:
-                    # Extract the path after -projectpath
-                    try:
-                        parts = line.split("-projectpath", 1)[1].split()[0]
-                        if not parts.endswith(f"/{project_path}") and not parts.endswith(f"\\{project_path}") and parts != project_path:
-                            continue
-                    except (IndexError, ValueError):
-                        continue
+                if (
+                    not candidate_path.endswith(f"/{project_path}")
+                    and not candidate_path.endswith(f"\\{project_path}")
+                    and candidate_path != project_path
+                ):
+                    continue
 
             # Extract PID (second column in ps aux output)
             parts = line.split()

--- a/Server/tests/test_focus_nudge.py
+++ b/Server/tests/test_focus_nudge.py
@@ -10,7 +10,39 @@ from utils.focus_nudge import (
     reset_nudge_backoff,
     nudge_unity_focus,
     _is_available,
+    _find_unity_pid_by_project_path,
 )
+
+
+class TestFindUnityPidByProjectPath:
+    """Tests for matching Unity's macOS command-line project argument."""
+
+    @pytest.mark.parametrize("option", ["-projectPath", "-projectpath"])
+    def test_accepts_project_path_option_case(self, option):
+        process_list = (
+            "user 44915 0.0 0.0 0 0 ?? S 0:00.00 "
+            "/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity "
+            f"{option} /Users/user/Projects/MyGame"
+        )
+        with patch("utils.focus_nudge.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = process_list
+
+            assert _find_unity_pid_by_project_path(
+                "/Users/user/Projects/MyGame"
+            ) == 44915
+
+    def test_matches_project_name_with_unity_hub_option(self):
+        process_list = (
+            "user 7331 0.0 0.0 0 0 ?? S 0:00.00 "
+            "/Applications/Unity/Unity.app/Contents/MacOS/Unity "
+            "-projectPath /Users/user/Projects/MyGame"
+        )
+        with patch("utils.focus_nudge.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = process_list
+
+            assert _find_unity_pid_by_project_path("MyGame") == 7331
 
 
 class TestShouldNudge:


### PR DESCRIPTION
## Summary
- match Unity's `-projectPath` option case-insensitively in macOS focus recovery
- preserve exact project-path matching after parsing the option
- cover both Unity Hub casing and lowercase manual-launch casing

## Reproduction
Unity Hub 6000.5 launches the editor with `-projectPath`. The focus helper searched for lowercase `-projectpath`, failed to find the running editor, and added repeated 3/5/8/12-second waits during background test runs.

## Verification
- `uv run --extra dev pytest tests/test_focus_nudge.py -q`
- 17 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unity Editor detection when project path flags use different capitalization.
  * Improved matching for both full project paths and project-name inputs.
  * Increased reliability when Unity is launched with project path arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->