### PR TITLE
fix: guard TransformHandle against reflection serialization (destroyed-object NRE)

### DIFF
--- a/MCPForUnity/Editor/Helpers/GameObjectSerializer.cs
+++ b/MCPForUnity/Editor/Helpers/GameObjectSerializer.cs
@@ -714,6 +714,7 @@ namespace MCPForUnity.Editor.Helpers
                 new RectConverter(),
                 new BoundsConverter(),
                 new Matrix4x4Converter(), // Fix #478: Safe Matrix4x4 serialization for Cinemachine
+                new TransformHandleConverter(), // Unity 6 TransformHandle: enumerating a destroyed handle's children throws NRE
                 new UnityEngineObjectConverter() // Handles serialization of references
             },
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,

--- a/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
+++ b/MCPForUnity/Runtime/Serialization/UnityTypeConverters.cs
@@ -266,6 +266,31 @@ namespace MCPForUnity.Runtime.Serialization
         }
     }
 
+    /// <summary>
+    /// Safe pass-by converter for UnityEngine.TransformHandle (Unity 6+). Reflection-based
+    /// serialization of a handle enumerates its direct children, which throws
+    /// NullReferenceException the moment the underlying object is destroyed (a common race
+    /// when reading component data during play mode while scripts Destroy() objects), and on
+    /// live objects would walk entire child hierarchies of handles. A handle carries no
+    /// serializable identity of its own, so it is written as null. The type is matched by
+    /// name because it does not exist on all Unity versions this package supports.
+    /// Intentionally internal for the same converter-scanner reason as
+    /// UnityEngineObjectConverter below (see issue #1138).
+    /// </summary>
+    internal class TransformHandleConverter : JsonConverter
+    {
+        public override bool CanRead => false;
+
+        public override bool CanConvert(Type objectType)
+            => objectType?.FullName == "UnityEngine.TransformHandle";
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            => writer.WriteNull();
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            => throw new NotSupportedException("TransformHandleConverter is write-only.");
+    }
+
     // Converter for UnityEngine.Object references (GameObjects, Components, Materials, Textures, etc.)
     // Intentionally internal: this converter is meant for MCP-internal serialization only.
     // Leaving it public lets third-party Newtonsoft converter scanners (e.g. jillejr's

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/TransformHandleConverterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/TransformHandleConverterTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using MCPForUnity.Runtime.Serialization;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace MCPForUnityTests.Editor.Helpers
+{
+    /// <summary>
+    /// Tests for TransformHandleConverter, which writes UnityEngine.TransformHandle
+    /// (Unity 6+) as null instead of letting reflection-based serialization enumerate
+    /// the handle's children - that enumeration throws NullReferenceException once the
+    /// underlying object is destroyed (a live race when component data is read during
+    /// play mode while scripts Destroy() objects).
+    /// The type is resolved by reflection so this file compiles on every Unity version
+    /// the package supports; handle-specific tests self-ignore where the type is absent.
+    /// </summary>
+    public class TransformHandleConverterTests
+    {
+        private JsonSerializerSettings _settings;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settings = new JsonSerializerSettings
+            {
+                Converters = { new TransformHandleConverter() }
+            };
+        }
+
+        private static Type TransformHandleType =>
+            typeof(Transform).Assembly.GetType("UnityEngine.TransformHandle");
+
+        // Finds a public instance property on Transform that returns a TransformHandle,
+        // which is how the GameObjectSerializer's reflection walk encounters one.
+        private static object GetHandleFor(Transform transform)
+        {
+            Type handleType = TransformHandleType;
+            if (handleType == null) return null;
+
+            PropertyInfo handleProperty = typeof(Transform)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(p => p.PropertyType == handleType);
+            return handleProperty?.GetValue(transform);
+        }
+
+        [Test]
+        public void CanConvert_RejectsUnrelatedTypes()
+        {
+            var converter = new TransformHandleConverter();
+
+            Assert.That(converter.CanConvert(typeof(Vector3)), Is.False);
+            Assert.That(converter.CanConvert(typeof(Transform)), Is.False);
+            Assert.That(converter.CanConvert(typeof(Matrix4x4)), Is.False);
+        }
+
+        [Test]
+        public void CanConvert_MatchesTransformHandleByName()
+        {
+            Type handleType = TransformHandleType;
+            if (handleType == null)
+                Assert.Ignore("UnityEngine.TransformHandle does not exist on this Unity version.");
+
+            Assert.That(new TransformHandleConverter().CanConvert(handleType), Is.True);
+        }
+
+        [Test]
+        public void Serialize_LiveHandle_WritesNull()
+        {
+            var go = new GameObject("TransformHandleConverterTests_Live");
+            try
+            {
+                object handle = GetHandleFor(go.transform);
+                if (handle == null)
+                    Assert.Ignore("No TransformHandle-returning property on this Unity version.");
+
+                string json = JsonConvert.SerializeObject(handle, _settings);
+                Assert.That(json, Is.EqualTo("null"));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void Serialize_HandleOfDestroyedObject_DoesNotThrow()
+        {
+            // The regression: a handle obtained before its object is destroyed. Without
+            // the converter, serializing it enumerates its children and throws
+            // NullReferenceException from TransformHandle.AssertHandleIsValid.
+            var go = new GameObject("TransformHandleConverterTests_Destroyed");
+            object handle = GetHandleFor(go.transform);
+            UnityEngine.Object.DestroyImmediate(go);
+
+            if (handle == null)
+                Assert.Ignore("No TransformHandle-returning property on this Unity version.");
+
+            string json = null;
+            Assert.DoesNotThrow(() => json = JsonConvert.SerializeObject(handle, _settings));
+            Assert.That(json, Is.EqualTo("null"));
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/TransformHandleConverterTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/TransformHandleConverterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be5e4cb07a0b45b5a39740c520e258b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Why

`GameObjectSerializer` reflects over component properties and hands the values to Json.NET. On Unity 6, a component property returning `UnityEngine.TransformHandle` makes the serializer enumerate the handle's direct children (`TransformHandle.DirectChildrenEnumerator`). Two problems fall out of that:

- **A play-mode race:** the enumeration throws `NullReferenceException` from `TransformHandle.AssertHandleIsValid` the moment the underlying object is destroyed. Reading the `gameobject/{id}/components` resource while a game script `Destroy()`s objects (a spawner destroying and respawning pickups makes it reliable) logs the `[GameObjectSerializer] Unexpected error serializing value of type UnityEngine.TransformHandle` warning on every read that races a destroy.
- **Even on live objects,** serializing a handle walks child hierarchies of further handles rather than producing a meaningful value.

## What

A write-only `TransformHandleConverter` that emits `null` for the type. It matches by full type name (`UnityEngine.TransformHandle`) so the package still compiles on every supported Unity version (floor 2021.3, where the type does not exist) without version defines, per the `Unity*Compat` guidance in CONTRIBUTING. It is `internal` for the same third-party converter-scanner reason as `UnityEngineObjectConverter` (#1138), and registered in `GameObjectSerializer`'s output settings.

EditMode tests resolve the type by reflection and self-ignore on Unity versions without it; the key regression test obtains a handle, destroys its object, and asserts serialization no longer throws.

Observed in the field on Unity 6000.4.10f1 while polling component resources during play mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unity 6 compatibility when serializing `TransformHandle` values.
  * Prevented serialization errors for handles linked to destroyed objects.
  * Transform handles are safely represented as `null` in serialized output.

* **Tests**
  * Added coverage for supported, unsupported, live, and destroyed `TransformHandle` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->