### PR TITLE
Add per-call Unity instance targeting

### DIFF
--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -1,7 +1,9 @@
 from starlette.requests import Request
 from transport.unity_instance_middleware import (
+    InstanceTargetError,
     UnityInstanceMiddleware,
-    get_unity_instance_middleware
+    get_unity_instance_middleware,
+    resolve_instance_identifier,
 )
 from services.api_key_service import ApiKeyService
 from transport.legacy.unity_connection import get_unity_connection_pool, UnityConnectionPool
@@ -10,6 +12,7 @@ from core.telemetry import record_milestone, record_telemetry, MilestoneType, Re
 from services.resources import register_all_resources
 from transport.plugin_registry import PluginRegistry
 from transport.plugin_hub import PluginHub
+from transport.models import SessionDetails
 from services.custom_tool_service import (
     CustomToolService,
     resolve_project_id_for_unity_instance,
@@ -31,7 +34,8 @@ from contextlib import asynccontextmanager
 import os
 import threading
 import time
-from typing import AsyncIterator, Any
+from types import SimpleNamespace
+from typing import AsyncIterator, Any, Mapping
 from urllib.parse import urlparse
 
 # Workaround for environments where tool signature evaluation runs with a globals
@@ -363,13 +367,41 @@ Payload sizing & paging (important):
 """
 
 
-def _normalize_instance_token(instance_token: str | None) -> tuple[str | None, str | None]:
-    if not instance_token:
-        return None, None
-    if "@" in instance_token:
-        name_part, _, hash_part = instance_token.partition("@")
-        return (name_part or None), (hash_part or None)
-    return None, instance_token
+def _resolve_http_instance_target(
+    unity_instance: str,
+    sessions: Mapping[str, SessionDetails],
+) -> tuple[str, str, SessionDetails]:
+    """Resolve an explicit HTTP target to ``(session_id, Name@hash, details)``."""
+    candidates: list[SimpleNamespace] = []
+    for session_id, details in sessions.items():
+        project = details.project or "Unknown"
+        hash_value = details.hash
+        if not hash_value:
+            continue
+        candidates.append(SimpleNamespace(
+            id=f"{project}@{hash_value}",
+            name=project,
+            hash=hash_value,
+            session_id=session_id,
+        ))
+
+    canonical_id = resolve_instance_identifier(
+        unity_instance,
+        candidates,
+        transport_mode="http",
+    )
+    target = next(
+        (candidate for candidate in candidates if candidate.id == canonical_id),
+        None,
+    )
+    if target is None:
+        # The resolver only returns ids from candidates; keep the failure explicit
+        # if a future candidate type violates that invariant.
+        raise InstanceTargetError(
+            f"Unity instance '{unity_instance}' not found.",
+            status_code=404,
+        )
+    return target.session_id, target.id, sessions[target.session_id]
 
 
 def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
@@ -434,15 +466,18 @@ def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
                 # Find target session
                 session_id = None
                 session_details = None
-                instance_name, instance_hash = _normalize_instance_token(
-                    unity_instance)
-                if unity_instance:
-                    # Try to match by hash or project name
-                    for sid, details in sessions.sessions.items():
-                        if details.hash == instance_hash or details.project in (instance_name, unity_instance):
-                            session_id = sid
-                            session_details = details
-                            break
+                resolved_instance = None
+                if unity_instance is not None and unity_instance != "":
+                    try:
+                        session_id, resolved_instance, session_details = _resolve_http_instance_target(
+                            unity_instance,
+                            sessions.sessions,
+                        )
+                    except InstanceTargetError as exc:
+                        return JSONResponse(
+                            {"success": False, "error": str(exc)},
+                            status_code=exc.status_code,
+                        )
 
                 # If a specific unity_instance was requested but not found, return an error
                 # (Check done here so execute_custom_tool can also validate the instance)
@@ -503,9 +538,9 @@ def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
                         )
 
                     # Prefer a concrete hash for project-scoped tools.
-                    unity_instance_hint = unity_instance
+                    unity_instance_hint = resolved_instance
                     if session_details and session_details.hash:
-                        unity_instance_hint = session_details.hash
+                        unity_instance_hint = resolved_instance or session_details.hash
 
                     project_id = resolve_project_id_for_unity_instance(
                         unity_instance_hint)
@@ -553,8 +588,6 @@ def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
             """REST endpoint to list custom tools for the active Unity project."""
             try:
                 unity_instance = request.query_params.get("instance")
-                instance_name, instance_hash = _normalize_instance_token(
-                    unity_instance)
 
                 sessions = await PluginHub.get_sessions()
                 if not sessions.sessions:
@@ -564,27 +597,25 @@ def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
                     }, status_code=503)
 
                 session_details = None
+                resolved_instance = None
                 if unity_instance:
-                    # Try to match by hash or project name
-                    for _, details in sessions.sessions.items():
-                        if details.hash == instance_hash or details.project in (instance_name, unity_instance):
-                            session_details = details
-                            break
-                    if not session_details:
+                    try:
+                        _, resolved_instance, session_details = _resolve_http_instance_target(
+                            unity_instance,
+                            sessions.sessions,
+                        )
+                    except InstanceTargetError as exc:
                         return JSONResponse(
-                            {
-                                "success": False,
-                                "error": f"Unity instance '{unity_instance}' not found",
-                            },
-                            status_code=404,
+                            {"success": False, "error": str(exc)},
+                            status_code=exc.status_code,
                         )
                 else:
                     # No specific unity_instance requested: use first available session
                     session_details = next(iter(sessions.sessions.values()))
 
-                unity_instance_hint = unity_instance
+                unity_instance_hint = resolved_instance
                 if session_details and session_details.hash:
-                    unity_instance_hint = session_details.hash
+                    unity_instance_hint = resolved_instance or session_details.hash
 
                 project_id = resolve_project_id_for_unity_instance(
                     unity_instance_hint)

--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -321,7 +321,8 @@ Resources vs Tools:
 
 Reading resources (read this before using ANY resource named below):
 - Resources are addressed by URI, never by name. A resource's name and URI are NOT interchangeable: names use underscores (e.g. editor_state) while URIs use slashes (e.g. mcpforunity://editor/state). Do NOT build a URI by swapping separators in the name — you will 404.
-- Always read the exact URI from your MCP client's resource listing (resources/list). Where these instructions mention a resource by name, look up its URI in that listing rather than guessing it.
+- Always read the exact URI from your MCP client's resource listing (resources/list for concrete resources, resources/templates/list for parameterized resources). Where these instructions mention a resource by name, look up its URI in those listings rather than guessing it.
+- The MCP resources/read request accepts only a URI, not tool-style arguments. To route one resource read to a specific Unity instance, append the `unity_instance` query parameter to the URI (URL-encode `@` as `%40` when needed), for example: mcpforunity://editor/state?unity_instance=MyGame%40abc123. The active/session routing remains the default when this query parameter is omitted.
 - Resource payloads are wrapped: the content lives under a top-level `data` object, so field paths are `data.<section>.<field>` (e.g. `data.advice.ready_for_tools`), not bare top-level fields.
 
 Script Management:

--- a/Server/src/services/custom_tool_service.py
+++ b/Server/src/services/custom_tool_service.py
@@ -21,7 +21,7 @@ from transport.legacy.unity_connection import (
 )
 from transport.plugin_hub import PluginHub
 from services.tools import get_unity_instance_from_context
-from services.registry import get_registered_tools
+from services.registry import get_registered_tools, UNITY_TARGETABLE_TAG
 
 logger = logging.getLogger("mcp-for-unity-server")
 
@@ -361,6 +361,7 @@ class CustomToolService:
             wrapped = self._mcp.tool(
                 name=definition.name,
                 description=definition.description,
+                tags={UNITY_TARGETABLE_TAG},
             )(wrapped)
         except Exception as exc:  # pragma: no cover - defensive against tool conflicts
             logger.warning(

--- a/Server/src/services/registry/__init__.py
+++ b/Server/src/services/registry/__init__.py
@@ -8,6 +8,7 @@ from .tool_registry import (
     clear_tool_registry,
     TOOL_GROUPS,
     DEFAULT_ENABLED_GROUPS,
+    UNITY_TARGETABLE_TAG,
 )
 from .resource_registry import (
     mcp_for_unity_resource,
@@ -22,6 +23,7 @@ __all__ = [
     'clear_tool_registry',
     'TOOL_GROUPS',
     'DEFAULT_ENABLED_GROUPS',
+    'UNITY_TARGETABLE_TAG',
     'mcp_for_unity_resource',
     'get_registered_resources',
     'clear_resource_registry'

--- a/Server/src/services/registry/resource_registry.py
+++ b/Server/src/services/registry/resource_registry.py
@@ -11,6 +11,7 @@ def mcp_for_unity_resource(
     uri: str,
     name: str | None = None,
     description: str | None = None,
+    unity_targetable: bool = True,
     **kwargs
 ) -> Callable:
     """
@@ -21,6 +22,8 @@ def mcp_for_unity_resource(
     Args:
         name: Resource name (defaults to function name)
         description: Resource description
+        unity_targetable: Whether to expose the optional ``unity_instance``
+            URI query parameter for per-call routing.
         **kwargs: Additional arguments passed to @mcp.resource()
 
     Example:
@@ -35,6 +38,7 @@ def mcp_for_unity_resource(
             'uri': uri,
             'name': resource_name,
             'description': description,
+            'unity_targetable': unity_targetable,
             'kwargs': kwargs
         })
 

--- a/Server/src/services/registry/tool_registry.py
+++ b/Server/src/services/registry/tool_registry.py
@@ -38,8 +38,8 @@ def mcp_for_unity_tool(
     name: str | None = None,
     description: str | None = None,
     unity_target: str | None = "self",
-    unity_targetable: bool | None = None,
     group: str | None = "core",
+    unity_targetable: bool | None = None,
     **kwargs
 ) -> Callable:
     """

--- a/Server/src/services/registry/tool_registry.py
+++ b/Server/src/services/registry/tool_registry.py
@@ -30,11 +30,15 @@ TOOL_GROUPS: dict[str, str] = {
 
 DEFAULT_ENABLED_GROUPS: set[str] = {"core"}
 
+# FastMCP tag used to identify tools whose calls can target a Unity instance.
+UNITY_TARGETABLE_TAG = "mcpforunity:unity-targetable"
+
 
 def mcp_for_unity_tool(
     name: str | None = None,
     description: str | None = None,
     unity_target: str | None = "self",
+    unity_targetable: bool | None = None,
     group: str | None = "core",
     **kwargs
 ) -> Callable:
@@ -50,6 +54,9 @@ def mcp_for_unity_tool(
             - "self" (default): tool follows its own enabled state.
             - None: server-only tool, always visible in tool listing.
             - "<tool_name>": alias tool that follows another Unity tool state.
+        unity_targetable: Whether calls to this tool accept the optional
+            ``unity_instance`` routing envelope. Defaults to True for Unity
+            tools and False for server-only tools.
         group: Tool group for dynamic visibility.
             - A group name string (e.g. "core", "vfx") assigns the tool to
               that group and adds a ``tags={"group:<name>"}`` entry.
@@ -67,6 +74,8 @@ def mcp_for_unity_tool(
         tool_kwargs = dict(kwargs)  # Create a copy to avoid side effects
         if "unity_target" in tool_kwargs:
             del tool_kwargs["unity_target"]
+        if "unity_targetable" in tool_kwargs:
+            del tool_kwargs["unity_targetable"]
         if "group" in tool_kwargs:
             del tool_kwargs["group"]
 
@@ -96,11 +105,27 @@ def mcp_for_unity_tool(
                 "Expected None or a non-empty string."
             )
 
+        if unity_targetable is None:
+            resolved_unity_targetable = normalized_unity_target is not None
+        elif isinstance(unity_targetable, bool):
+            resolved_unity_targetable = unity_targetable
+        else:
+            raise ValueError(
+                f"Invalid unity_targetable for tool '{tool_name}': "
+                f"{unity_targetable!r}. Expected a bool or None."
+            )
+
+        if resolved_unity_targetable:
+            existing_tags = set(tool_kwargs.get("tags") or set())
+            existing_tags.add(UNITY_TARGETABLE_TAG)
+            tool_kwargs["tags"] = existing_tags
+
         _tool_registry.append({
             'func': func,
             'name': tool_name,
             'description': description,
             'unity_target': normalized_unity_target,
+            'unity_targetable': resolved_unity_targetable,
             'group': resolved_group,
             'kwargs': tool_kwargs,
         })

--- a/Server/src/services/resources/__init__.py
+++ b/Server/src/services/resources/__init__.py
@@ -40,6 +40,7 @@ def _serialize_pydantic(
     """Wrap a resource function and serialize Pydantic results as JSON."""
     @functools.wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        """Call the resource and serialize its structured result."""
         if consume_unity_instance:
             kwargs.pop(_UNITY_INSTANCE_PARAMETER, None)
         result = await func(*args, **kwargs)

--- a/Server/src/services/resources/__init__.py
+++ b/Server/src/services/resources/__init__.py
@@ -4,7 +4,9 @@ MCP Resources package - Auto-discovers and registers all resources in this direc
 import functools
 import inspect
 import logging
+import re
 from pathlib import Path
+from typing import Any, Callable
 
 from fastmcp import FastMCP
 from pydantic import BaseModel
@@ -19,16 +21,27 @@ logger = logging.getLogger("mcp-for-unity-server")
 # Export decorator for easy imports within tools
 __all__ = ['register_all_resources']
 
+_QUERY_EXPRESSION_RE = re.compile(r"\{\?([^}]*)\}")
+_PATH_PARAMETER_RE = re.compile(r"\{(\w+)(?:\*)?\}")
+_UNITY_INSTANCE_PARAMETER = "unity_instance"
+_TARGETING_DESCRIPTION = (
+    "\n\nAdvanced per-call routing: optionally set the `unity_instance` URI query "
+    "parameter to target this read to one Unity Editor instance. Usually omit "
+    "it to use the session's active instance. This override does not change "
+    "the active instance or affect later calls."
+)
 
-def _serialize_pydantic(func):
-    """Wrap a resource function so Pydantic models are serialized to JSON strings.
 
-    FastMCP 3.x expects resource functions to return str, bytes, or ResourceResult.
-    Our resource functions return MCPResponse (a Pydantic BaseModel). This wrapper
-    converts them to JSON strings automatically.
-    """
+def _serialize_pydantic(
+    func: Callable[..., Any],
+    *,
+    consume_unity_instance: bool = False,
+) -> Callable[..., Any]:
+    """Wrap a resource function and serialize Pydantic results as JSON."""
     @functools.wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if consume_unity_instance:
+            kwargs.pop(_UNITY_INSTANCE_PARAMETER, None)
         result = await func(*args, **kwargs)
         if isinstance(result, BaseModel):
             return result.model_dump_json()
@@ -36,21 +49,129 @@ def _serialize_pydantic(func):
             import json
             return json.dumps(result)
         return result
+
+    if consume_unity_instance:
+        signature = inspect.signature(func)
+        if _UNITY_INSTANCE_PARAMETER not in signature.parameters:
+            parameters = list(signature.parameters.values())
+            unity_instance_parameter = inspect.Parameter(
+                _UNITY_INSTANCE_PARAMETER,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=None,
+                annotation=str | None,
+            )
+            var_keyword_index = next(
+                (
+                    index
+                    for index, parameter in enumerate(parameters)
+                    if parameter.kind is inspect.Parameter.VAR_KEYWORD
+                ),
+                len(parameters),
+            )
+            parameters.insert(var_keyword_index, unity_instance_parameter)
+            wrapper.__signature__ = signature.replace(  # type: ignore[attr-defined]
+                parameters=parameters
+            )
+            wrapper.__annotations__ = {
+                **getattr(func, "__annotations__", {}),
+                _UNITY_INSTANCE_PARAMETER: str | None,
+            }
     return wrapper
 
 
-def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True):
+def _split_query_expression(uri: str) -> tuple[str, list[str]]:
+    """Return a URI without its RFC 6570 query expression and its parameters."""
+    matches = list(_QUERY_EXPRESSION_RE.finditer(uri))
+    if len(matches) > 1:
+        raise ValueError(f"Resource URI may contain only one query expression: {uri}")
+    if not matches:
+        return uri, []
+
+    match = matches[0]
+    if match.end() != len(uri):
+        raise ValueError(f"Resource URI query expression must be last: {uri}")
+    query_parameters = [
+        name.strip() for name in match.group(1).split(",") if name.strip()
+    ]
+    return uri[:match.start()], query_parameters
+
+
+def _targeted_uri(uri: str, func: Callable[..., Any]) -> tuple[str, bool]:
+    """Build the FastMCP template URI for a targetable resource.
+
+    Optional business parameters that are not already represented in the path
+    remain available as URI query parameters. The routing parameter is appended
+    to the same RFC 6570 expression because FastMCP 3.0.2 parses only one such
+    expression per template.
+    """
+    base_uri, existing_query_parameters = _split_query_expression(uri)
+    path_parameters = set(_PATH_PARAMETER_RE.findall(base_uri))
+    user_signature = inspect.signature(func)
+
+    business_query_parameters: list[str] = []
+    for name, parameter in user_signature.parameters.items():
+        if name in path_parameters or name in existing_query_parameters:
+            continue
+        if name == _UNITY_INSTANCE_PARAMETER:
+            continue
+        if parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        if parameter.default is not inspect.Parameter.empty:
+            business_query_parameters.append(name)
+
+    query_parameters: list[str] = list(dict.fromkeys(
+        existing_query_parameters
+        + business_query_parameters
+        + [_UNITY_INSTANCE_PARAMETER]
+    ))
+    query_expression = "{?" + ",".join(query_parameters) + "}"
+    return base_uri + query_expression, bool(path_parameters)
+
+
+def _register_resource(
+    mcp: FastMCP,
+    *,
+    func: Callable[..., Any],
+    uri: str,
+    name: str,
+    description: str | None,
+    kwargs: dict[str, Any],
+    consume_unity_instance: bool,
+) -> None:
+    """Apply the server's resource wrappers and register one URI contract."""
+    serialized = _serialize_pydantic(
+        func,
+        consume_unity_instance=consume_unity_instance,
+    )
+    wrapped = log_execution(name, "Resource")(serialized)
+    wrapped = telemetry_resource(name)(wrapped)
+    if consume_unity_instance:
+        # Re-attach the synthetic public contract after the logging and telemetry
+        # decorators so FastMCP sees the optional query parameter.
+        wrapped.__signature__ = inspect.signature(serialized)  # type: ignore[attr-defined]
+        wrapped.__annotations__ = dict(serialized.__annotations__)
+    mcp.resource(
+        uri=uri,
+        name=name,
+        description=description,
+        **kwargs,
+    )(wrapped)
+
+
+def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True) -> None:
     """
     Auto-discover and register all resources in the resources/ directory.
 
-    Any .py file in this directory or subdirectories with @mcp_for_unity_resource decorated
-    functions will be automatically registered.
+    Targetable resources keep their original concrete URI for compatibility and
+    additionally expose a query template that accepts ``unity_instance``.
+    Path resources use the template only, with existing optional business query
+    parameters preserved alongside the routing parameter.
     """
     logger.info("Auto-discovering MCP for Unity Server resources...")
-    # Dynamic import of all modules in this directory
     resources_dir = Path(__file__).parent
-
-    # Discover and import all modules
     list(discover_modules(resources_dir, __package__))
 
     resources = get_registered_resources()
@@ -65,6 +186,7 @@ def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True):
         uri = resource_info['uri']
         resource_name = resource_info['name']
         description = resource_info['description']
+        unity_targetable = resource_info.get('unity_targetable', True)
         kwargs = resource_info['kwargs']
 
         if not project_scoped_tools and resource_name == "custom_tools":
@@ -72,38 +194,50 @@ def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True):
                 "Skipping custom_tools resource registration (project-scoped tools disabled)")
             continue
 
-        # Check if URI contains query parameters (e.g., {?unity_instance})
-        has_query_params = '{?' in uri
+        if not unity_targetable:
+            _register_resource(
+                mcp,
+                func=func,
+                uri=uri,
+                name=resource_name,
+                description=description,
+                kwargs=kwargs,
+                consume_unity_instance=False,
+            )
+            registered_count += 1
+            logger.debug("Registered server-only resource: %s - %s", resource_name, uri)
+            continue
 
-        if has_query_params:
-            wrapped_template = _serialize_pydantic(func)
-            wrapped_template = log_execution(resource_name, "Resource")(wrapped_template)
-            wrapped_template = telemetry_resource(
-                resource_name)(wrapped_template)
-            wrapped_template = mcp.resource(
+        targeted_uri, has_path_parameters = _targeted_uri(uri, func)
+        if not has_path_parameters:
+            # Preserve concrete resources in resources/list for existing clients.
+            _register_resource(
+                mcp,
+                func=func,
                 uri=uri,
                 name=resource_name,
                 description=description,
-                **kwargs,
-            )(wrapped_template)
-            logger.debug(
-                f"Registered resource template: {resource_name} - {uri}")
+                kwargs=kwargs,
+                consume_unity_instance=False,
+            )
             registered_count += 1
-            resource_info['func'] = wrapped_template
-        else:
-            wrapped = _serialize_pydantic(func)
-            wrapped = log_execution(resource_name, "Resource")(wrapped)
-            wrapped = telemetry_resource(resource_name)(wrapped)
-            wrapped = mcp.resource(
-                uri=uri,
-                name=resource_name,
-                description=description,
-                **kwargs,
-            )(wrapped)
-            resource_info['func'] = wrapped
-            logger.debug(
-                f"Registered resource: {resource_name} - {description}")
-            registered_count += 1
+
+        _register_resource(
+            mcp,
+            func=func,
+            uri=targeted_uri,
+            name=resource_name,
+            description=(description or "") + _TARGETING_DESCRIPTION,
+            kwargs=kwargs,
+            consume_unity_instance=True,
+        )
+        registered_count += 1
+        logger.debug(
+            "Registered targetable resource%s: %s - %s",
+            " template" if has_path_parameters else " companion template",
+            resource_name,
+            targeted_uri,
+        )
 
     logger.info(
         f"Registered {registered_count} MCP resources ({len(resources)} unique)")

--- a/Server/src/services/resources/__init__.py
+++ b/Server/src/services/resources/__init__.py
@@ -210,14 +210,17 @@ def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True) -
             continue
 
         targeted_uri, has_path_parameters = _targeted_uri(uri, func)
+        targeted_description = (description or "") + _TARGETING_DESCRIPTION
         if not has_path_parameters:
             # Preserve concrete resources in resources/list for existing clients.
+            # Include the routing hint here as well as on the companion template;
+            # some clients do not query resources/templates/list.
             _register_resource(
                 mcp,
                 func=func,
                 uri=uri,
                 name=resource_name,
-                description=description,
+                description=targeted_description,
                 kwargs=kwargs,
                 consume_unity_instance=False,
             )
@@ -228,7 +231,7 @@ def register_all_resources(mcp: FastMCP, *, project_scoped_tools: bool = True) -
             func=func,
             uri=targeted_uri,
             name=resource_name,
-            description=(description or "") + _TARGETING_DESCRIPTION,
+            description=targeted_description,
             kwargs=kwargs,
             consume_unity_instance=True,
         )

--- a/Server/src/services/resources/gameobject.py
+++ b/Server/src/services/resources/gameobject.py
@@ -42,6 +42,7 @@ def _validate_instance_id(instance_id: str) -> tuple[int | None, MCPResponse | N
 @mcp_for_unity_resource(
     uri="mcpforunity://scene/gameobject-api",
     name="gameobject_api",
+    unity_targetable=False,
     description="Documentation for GameObject resources. Use find_gameobjects tool to get instance IDs, then access resources below.\n\nURI: mcpforunity://scene/gameobject-api"
 )
 async def get_gameobject_api_docs(_ctx: Context) -> MCPResponse:

--- a/Server/src/services/resources/prefab.py
+++ b/Server/src/services/resources/prefab.py
@@ -43,6 +43,7 @@ def _decode_prefab_path(encoded_path: str) -> str:
 @mcp_for_unity_resource(
     uri="mcpforunity://prefab-api",
     name="prefab_api",
+    unity_targetable=False,
     description="Documentation for Prefab resources. Use manage_asset action=search filterType=Prefab to find prefabs, then access resources below.\n\nURI: mcpforunity://prefab-api"
 )
 async def get_prefab_api_docs(_ctx: Context) -> MCPResponse:

--- a/Server/src/services/resources/tool_groups.py
+++ b/Server/src/services/resources/tool_groups.py
@@ -18,6 +18,7 @@ from services.registry import (
 @mcp_for_unity_resource(
     uri="mcpforunity://tool-groups",
     name="tool_groups",
+    unity_targetable=False,
     description=(
         "Available tool groups and their tools. "
         "Use manage_tools to activate/deactivate groups per session.\n\n"

--- a/Server/src/services/resources/unity_instances.py
+++ b/Server/src/services/resources/unity_instances.py
@@ -13,6 +13,7 @@ from core.config import config
 @mcp_for_unity_resource(
     uri="mcpforunity://instances",
     name="unity_instances",
+    unity_targetable=False,
     description="Lists all running Unity Editor instances with their details.\n\nURI: mcpforunity://instances"
 )
 async def unity_instances(ctx: Context) -> dict[str, Any]:

--- a/Server/src/services/tools/execute_custom_tool.py
+++ b/Server/src/services/tools/execute_custom_tool.py
@@ -16,6 +16,7 @@ from services.tools import get_unity_instance_from_context
 @mcp_for_unity_tool(
     name="execute_custom_tool",
     unity_target=None,
+    unity_targetable=True,
     group=None,
     description="Execute a project-scoped custom tool registered by Unity.",
     annotations=ToolAnnotations(

--- a/Server/src/services/tools/execute_custom_tool.py
+++ b/Server/src/services/tools/execute_custom_tool.py
@@ -17,7 +17,7 @@ from services.tools import get_unity_instance_from_context
     name="execute_custom_tool",
     unity_target=None,
     unity_targetable=True,
-    group=None,
+    group="core",
     description="Execute a project-scoped custom tool registered by Unity.",
     annotations=ToolAnnotations(
         title="Execute Custom Tool",

--- a/Server/src/services/tools/execute_custom_tool.py
+++ b/Server/src/services/tools/execute_custom_tool.py
@@ -25,6 +25,7 @@ from services.tools import get_unity_instance_from_context
     ),
 )
 async def execute_custom_tool(ctx: Context, tool_name: str, parameters: dict[str, Any] | None = None) -> MCPResponse:
+    """Execute a Unity-registered custom tool for the current project."""
     unity_instance = await get_unity_instance_from_context(ctx)
     if not unity_instance:
         return MCPResponse(

--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -273,7 +273,15 @@ class UnityConnection:
             return timeout
         return max(floor, min(timeout, deadline - time.monotonic()))
 
-    def send_command(self, command_type: str, params: dict[str, Any] | None = None, max_attempts: int | None = None, deadline: float | None = None) -> dict[str, Any]:
+    def send_command(
+        self,
+        command_type: str,
+        params: dict[str, Any] | None = None,
+        max_attempts: int | None = None,
+        deadline: float | None = None,
+        *,
+        allow_default_fallback: bool = True,
+    ) -> dict[str, Any]:
         """Send a command with retry/backoff and port rediscovery. Pings only when requested.
 
         Args:
@@ -335,6 +343,8 @@ class UnityConnection:
             if maybe_hash:
                 target_hash = maybe_hash
 
+        target_unavailable_error: ConnectionError | None = None
+
         # Preflight: if Unity reports reloading, return a structured hint so clients can retry politely
         try:
             status = read_status_file(target_hash)
@@ -359,10 +369,29 @@ class UnityConnection:
                 raise TimeoutError(
                     f"Command '{command_type}' exceeded total deadline of "
                     f"{total_timeout:.1f}s (connection wedged or Unity unresponsive)")
+            target_refresh_failed = False
             try:
                 # Discard stale sockets left over from a previous domain reload
                 # so we reconnect instead of writing to a dead connection.
                 self._ensure_live_connection()
+                # An explicit target that disappeared on the previous attempt
+                # has no safe port to connect to. Rediscover it before the next
+                # connect so a recovered target does not consume another retry.
+                if not self.sock and not allow_default_fallback and self.port is None:
+                    target_refresh_failed = True
+                    refreshed_instance = stdio_port_registry.get_instance(
+                        self.instance_id)
+                    if refreshed_instance and isinstance(refreshed_instance.port, int):
+                        target_refresh_failed = False
+                        self.port = refreshed_instance.port
+                        target_unavailable_error = None
+                        logger.debug(
+                            f"Rediscovered instance {self.instance_id} on port {self.port}")
+                    else:
+                        target_unavailable_error = ConnectionError(
+                            f"Unity instance '{self.instance_id}' is no longer available"
+                        )
+                        raise target_unavailable_error
                 # Ensure connected (handshake occurs within connect())
                 t_conn_start = time.time()
                 if not self.sock and not self.connect(self._cap_to_deadline(config.connection_timeout, deadline)):
@@ -440,7 +469,7 @@ class UnityConnection:
                 # Re-discover the port for this specific instance
                 try:
                     new_port: int | None = None
-                    if self.instance_id:
+                    if self.instance_id and not target_refresh_failed:
                         # Try to rediscover the specific instance via shared registry
                         refreshed_instance = stdio_port_registry.get_instance(
                             self.instance_id)
@@ -450,22 +479,38 @@ class UnityConnection:
                                 f"Rediscovered instance {self.instance_id} on port {new_port}")
                         else:
                             logger.warning(
-                                f"Instance {self.instance_id} not found during reconnection; falling back to port scan",
+                                f"Instance {self.instance_id} not found during reconnection",
                             )
 
-                    # Fallback to registry default if instance-specific discovery failed
+                    # An explicit per-call target must never be replaced by the
+                    # registry default after that target disappears. Calls that
+                    # entered the pool without an identifier retain the legacy
+                    # fallback behavior.
                     if new_port is None:
-                        new_port = stdio_port_registry.get_port(
-                            self.instance_id)
-                        logger.info(
-                            f"Using Unity port from stdio_port_registry: {new_port}")
+                        if not allow_default_fallback:
+                            target_unavailable_error = ConnectionError(
+                                f"Unity instance '{self.instance_id}' is no longer available"
+                            )
+                            self.port = None
+                        else:
+                            new_port = stdio_port_registry.get_port(
+                                self.instance_id)
+                            logger.info(
+                                f"Using Unity port from stdio_port_registry: {new_port}")
 
-                    if new_port != self.port:
+                    if new_port is not None and new_port != self.port:
                         logger.info(
                             f"Unity port changed {self.port} -> {new_port}")
-                    self.port = new_port
+                    if new_port is not None:
+                        self.port = new_port
+                        target_unavailable_error = None
                 except Exception as de:
                     logger.debug(f"Port discovery failed: {de}")
+                    if not allow_default_fallback:
+                        target_unavailable_error = ConnectionError(
+                            f"Unity instance '{self.instance_id}' is no longer available"
+                        )
+                        self.port = None
 
                 if attempt < attempts:
                     # Heartbeat-aware, jittered backoff
@@ -499,6 +544,8 @@ class UnityConnection:
                     sleep_s = self._cap_to_deadline(sleep_s, deadline, floor=0.0)
                     time.sleep(sleep_s)
                     continue
+                if target_unavailable_error is not None:
+                    raise target_unavailable_error
                 raise
 
 
@@ -534,20 +581,20 @@ class UnityConnectionPool:
         Returns:
             List of UnityInstanceInfo objects
         """
-        now = time.time()
-
-        # Return cached results if valid
-        if not force_refresh and (now - self._last_full_scan) < self._scan_interval:
-            logger.debug(
-                f"Returning cached Unity instances (age: {now - self._last_full_scan:.1f}s)")
-            return list(self._known_instances.values())
-
-        # Scan for instances
-        logger.debug("Scanning for Unity instances...")
-        instances = PortDiscovery.discover_all_unity_instances()
-
-        # Update cache
         with self._pool_lock:
+            now = time.time()
+
+            # Return cached results if valid
+            if not force_refresh and (now - self._last_full_scan) < self._scan_interval:
+                logger.debug(
+                    f"Returning cached Unity instances (age: {now - self._last_full_scan:.1f}s)")
+                return list(self._known_instances.values())
+
+            # Serialize forced scans so overlapping per-call targets cannot
+            # replace a complete snapshot with a transient partial one.
+            logger.debug("Scanning for instances...")
+            instances = PortDiscovery.discover_all_unity_instances()
+
             self._known_instances = {inst.id: inst for inst in instances}
             self._last_full_scan = now
 
@@ -875,7 +922,12 @@ def send_command_with_retry(
     send_max_attempts = None if retry_on_reload else 0
 
     response = conn.send_command(
-        command_type, params, max_attempts=send_max_attempts, deadline=deadline)
+        command_type,
+        params,
+        max_attempts=send_max_attempts,
+        deadline=deadline,
+        allow_default_fallback=instance_id is None,
+    )
     retries = 0
     wait_started = None
     reason = _extract_response_reason(response)
@@ -912,7 +964,12 @@ def send_command_with_retry(
         )
         time.sleep(max(0.0, sleep_ms / 1000.0))
         retries += 1
-        response = conn.send_command(command_type, params, deadline=deadline)
+        response = conn.send_command(
+            command_type,
+            params,
+            deadline=deadline,
+            allow_default_fallback=instance_id is None,
+        )
         reason = _extract_response_reason(response)
 
     if wait_started is not None:

--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -562,6 +562,7 @@ class UnityConnectionPool:
         self._last_full_scan: float = 0
         self._scan_interval: float = 5.0  # Cache for 5 seconds
         self._pool_lock = threading.Lock()
+        self._scan_lock = threading.Lock()
         self._default_instance_id: str | None = None
 
         # Check for default instance from environment
@@ -590,13 +591,20 @@ class UnityConnectionPool:
                     f"Returning cached Unity instances (age: {now - self._last_full_scan:.1f}s)")
                 return list(self._known_instances.values())
 
-            # Serialize forced scans so overlapping per-call targets cannot
-            # replace a complete snapshot with a transient partial one.
+        # Serialize scans without blocking readers that can use a valid cache.
+        with self._scan_lock:
+            # Re-check the cache after waiting for an overlapping scan.
+            with self._pool_lock:
+                now = time.time()
+                if not force_refresh and (now - self._last_full_scan) < self._scan_interval:
+                    return list(self._known_instances.values())
+
             logger.debug("Scanning for instances...")
             instances = PortDiscovery.discover_all_unity_instances()
 
-            self._known_instances = {inst.id: inst for inst in instances}
-            self._last_full_scan = now
+            with self._pool_lock:
+                self._known_instances = {inst.id: inst for inst in instances}
+                self._last_full_scan = time.time()
 
         logger.info(
             f"Found {len(instances)} Unity instances: {[inst.id for inst in instances]}")

--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -545,7 +545,7 @@ class UnityConnection:
                     time.sleep(sleep_s)
                     continue
                 if target_unavailable_error is not None:
-                    raise target_unavailable_error
+                    raise target_unavailable_error from e
                 raise
 
 

--- a/Server/src/transport/unity_instance_middleware.py
+++ b/Server/src/transport/unity_instance_middleware.py
@@ -41,17 +41,20 @@ class InstanceTargetError(ValueError):
     """A user-supplied Unity instance target could not be resolved."""
 
     def __init__(self, message: str, *, status_code: int = 404):
+        """Create an instance-target error with its HTTP status code."""
         super().__init__(message)
         self.status_code = status_code
 
 
 def _instance_attribute(instance: Any, name: str, default: Any = None) -> Any:
+    """Read an instance field from either a mapping or an object."""
     if isinstance(instance, Mapping):
         return instance.get(name, default)
     return getattr(instance, name, default)
 
 
 def _instance_id(instance: Any) -> str | None:
+    """Return an instance's canonical ``Name@hash`` identifier when available."""
     value = _instance_attribute(instance, "id")
     if isinstance(value, str) and value:
         return value
@@ -64,6 +67,7 @@ def _instance_id(instance: Any) -> str | None:
 
 
 def _instance_name(instance: Any) -> str | None:
+    """Return an instance's project name."""
     value = _instance_attribute(instance, "name") or _instance_attribute(instance, "project")
     if isinstance(value, str) and value:
         return value
@@ -74,6 +78,7 @@ def _instance_name(instance: Any) -> str | None:
 
 
 def _instance_hash(instance: Any) -> str | None:
+    """Return an instance's project hash."""
     value = _instance_attribute(instance, "hash")
     if isinstance(value, str) and value:
         return value
@@ -813,6 +818,7 @@ class UnityInstanceMiddleware(Middleware):
             self._last_tool_visibility_refresh = now
 
     def _is_tool_targetable(self, tool: Any) -> bool:
+        """Return whether a registered tool accepts per-call routing."""
         tool_name = getattr(tool, "name", None)
         tags = getattr(tool, "tags", None) or set()
         return (

--- a/Server/src/transport/unity_instance_middleware.py
+++ b/Server/src/transport/unity_instance_middleware.py
@@ -4,14 +4,17 @@ Middleware for managing Unity instance selection per session.
 This middleware intercepts all tool calls and injects the active Unity instance
 into the request-scoped state, allowing tools to access it via ctx.get_state("unity_instance").
 """
-from threading import RLock
+from copy import copy, deepcopy
 import logging
 import time
+from threading import RLock
+from typing import Any, Mapping, Sequence
+from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from core.config import config
-from services.registry import get_registered_tools
+from services.registry import UNITY_TARGETABLE_TAG, get_registered_tools
 from transport.plugin_hub import PluginHub
 
 logger = logging.getLogger("mcp-for-unity-server")
@@ -22,6 +25,207 @@ _diag = logging.getLogger("transport.unity_instance_middleware")
 # with it to set or clear the active unity instance.
 _unity_instance_middleware = None
 _middleware_lock = RLock()
+
+_UNITY_INSTANCE_PARAMETER_SCHEMA = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Advanced: route only this call to a Unity Editor identified by exact "
+        "Name@hash, a unique hash prefix, or a stdio port. Usually omit this "
+        "parameter and use the session's active instance."
+    ),
+}
+
+
+class InstanceTargetError(ValueError):
+    """A user-supplied Unity instance target could not be resolved."""
+
+    def __init__(self, message: str, *, status_code: int = 404):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _instance_attribute(instance: Any, name: str, default: Any = None) -> Any:
+    if isinstance(instance, Mapping):
+        return instance.get(name, default)
+    return getattr(instance, name, default)
+
+
+def _instance_id(instance: Any) -> str | None:
+    value = _instance_attribute(instance, "id")
+    if isinstance(value, str) and value:
+        return value
+
+    name = _instance_attribute(instance, "name") or _instance_attribute(instance, "project")
+    hash_value = _instance_attribute(instance, "hash")
+    if name and hash_value:
+        return f"{name}@{hash_value}"
+    return None
+
+
+def _instance_name(instance: Any) -> str | None:
+    value = _instance_attribute(instance, "name") or _instance_attribute(instance, "project")
+    if isinstance(value, str) and value:
+        return value
+    instance_id = _instance_id(instance)
+    if instance_id and "@" in instance_id:
+        return instance_id.rsplit("@", 1)[0]
+    return None
+
+
+def _instance_hash(instance: Any) -> str | None:
+    value = _instance_attribute(instance, "hash")
+    if isinstance(value, str) and value:
+        return value
+    instance_id = _instance_id(instance)
+    if instance_id and "@" in instance_id:
+        return instance_id.rsplit("@", 1)[1]
+    return None
+
+
+def resolve_instance_identifier(
+    value: str,
+    instances: Sequence[Any],
+    *,
+    transport_mode: str = "stdio",
+) -> str:
+    """Resolve an explicit instance token to its canonical ``Name@hash`` id.
+
+    This helper is intentionally limited to explicit-target resolution.  It does
+    not implement the no-target default/auto-select policy used by the transports.
+    """
+    if not isinstance(value, str):
+        raise InstanceTargetError(
+            "unity_instance must be a string.",
+            status_code=400,
+        )
+    value = value.strip()
+    if not value:
+        raise InstanceTargetError("unity_instance value must not be empty.", status_code=400)
+
+    transport = (transport_mode or "stdio").lower()
+    if value.isdigit():
+        if transport == "http":
+            exact_hash_matches = [
+                instance for instance in instances
+                if (_instance_hash(instance) or "") == value
+            ]
+            if len(exact_hash_matches) == 1:
+                resolved_id = _instance_id(exact_hash_matches[0])
+                if resolved_id:
+                    return resolved_id
+            if len(exact_hash_matches) > 1:
+                ambiguous = ", ".join(
+                    _instance_id(instance) or "?"
+                    for instance in exact_hash_matches
+                )
+                raise InstanceTargetError(
+                    f"Hash '{value}' is ambiguous ({ambiguous}). "
+                    "Provide the full Name@hash.",
+                    status_code=400,
+                )
+            hash_prefix_matches = [
+                instance for instance in instances
+                if (_instance_hash(instance) or "").startswith(value)
+            ]
+            if len(hash_prefix_matches) == 1:
+                resolved_id = _instance_id(hash_prefix_matches[0])
+                if resolved_id:
+                    return resolved_id
+            if len(hash_prefix_matches) > 1:
+                ambiguous = ", ".join(
+                    _instance_id(instance) or "?"
+                    for instance in hash_prefix_matches
+                )
+                raise InstanceTargetError(
+                    f"Hash prefix '{value}' is ambiguous ({ambiguous}). "
+                    "Provide the full Name@hash from mcpforunity://instances.",
+                    status_code=400,
+                )
+            raise InstanceTargetError(
+                f"Port-based targeting ('{value}') is not supported in HTTP transport mode. "
+                "Use Name@hash or a hash prefix. Read mcpforunity://instances for available instances.",
+                status_code=400,
+            )
+
+        port_matches = [
+            instance for instance in instances
+            if str(_instance_attribute(instance, "port", "")) == value
+        ]
+        if len(port_matches) == 1:
+            resolved_id = _instance_id(port_matches[0])
+            if resolved_id:
+                return resolved_id
+        available = ", ".join(
+            f"{_instance_id(instance) or '?'} (port {_instance_attribute(instance, 'port', '?')})"
+            for instance in instances
+        ) or "none"
+        if len(port_matches) > 1:
+            raise InstanceTargetError(
+                f"Port '{value}' is ambiguous. Available: {available}.",
+                status_code=400,
+            )
+        raise InstanceTargetError(
+            f"No Unity instance found on port {value}. Available: {available}.",
+            status_code=404,
+        )
+
+    ids = [resolved_id for resolved_id in (_instance_id(item) for item in instances) if resolved_id]
+
+    # A composite target is deliberately exact.  In particular, a wrong hash
+    # must never fall back to a matching project name.
+    if "@" in value:
+        for instance in instances:
+            instance_id = _instance_id(instance)
+            if instance_id and instance_id.lower() == value.lower():
+                return instance_id
+        available = ", ".join(ids) or "none"
+        raise InstanceTargetError(
+            f"Instance '{value}' not found. Available: {available}. "
+            "Read mcpforunity://instances for current sessions."
+        )
+
+    name_matches = [
+        instance for instance in instances
+        if (_instance_name(instance) or "") == value
+    ]
+    if len(name_matches) == 1:
+        resolved_id = _instance_id(name_matches[0])
+        if resolved_id:
+            return resolved_id
+    if len(name_matches) > 1:
+        ambiguous = ", ".join(_instance_id(instance) or "?" for instance in name_matches)
+        raise InstanceTargetError(
+            f"Project name '{value}' matches multiple Unity instances ({ambiguous}). "
+            "Provide the full Name@hash.",
+            status_code=400,
+        )
+
+    # Match project names before hash prefixes, as the stdio connection pool
+    # does. This keeps an intentional project-name target stable if its text
+    # also happens to prefix another instance hash.
+    lookup = value.lower()
+    hash_matches = [
+        instance for instance in instances
+        if (_instance_hash(instance) or "").lower().startswith(lookup)
+    ]
+    if len(hash_matches) == 1:
+        resolved_id = _instance_id(hash_matches[0])
+        if resolved_id:
+            return resolved_id
+    if len(hash_matches) > 1:
+        ambiguous = ", ".join(_instance_id(instance) or "?" for instance in hash_matches)
+        raise InstanceTargetError(
+            f"Hash prefix '{value}' is ambiguous ({ambiguous}). "
+            "Provide the full Name@hash from mcpforunity://instances.",
+            status_code=400,
+        )
+
+    available = ", ".join(ids) or "none"
+    raise InstanceTargetError(
+        f"No running Unity instance matches '{value}'. Available: {available}. "
+        "Read mcpforunity://instances for current sessions."
+    )
 
 
 def get_unity_instance_middleware() -> 'UnityInstanceMiddleware':
@@ -64,12 +268,13 @@ class UnityInstanceMiddleware(Middleware):
         self._unity_managed_tool_names: set[str] = set()
         self._tool_alias_to_unity_target: dict[str, str] = {}
         self._server_only_tool_names: set[str] = set()
+        self._unity_targetable_tool_names: set[str] = set()
         self._tool_visibility_signature: tuple[tuple[str, str], ...] = ()
         self._last_tool_visibility_refresh = 0.0
         self._tool_visibility_refresh_interval_seconds = 0.5
         self._has_logged_empty_registry_warning = False
 
-    async def set_active_instance(self, ctx, instance_id: str) -> None:
+    async def set_active_instance(self, ctx: Any, instance_id: str) -> None:
         """Store the active instance for this MCP session.
 
         Persisted via FastMCP's session-scoped state store, which keys by
@@ -80,11 +285,11 @@ class UnityInstanceMiddleware(Middleware):
         """
         await ctx.set_state(self._ACTIVE_INSTANCE_STATE_KEY, instance_id)
 
-    async def get_active_instance(self, ctx) -> str | None:
+    async def get_active_instance(self, ctx: Any) -> str | None:
         """Retrieve the active instance for this MCP session."""
         return await ctx.get_state(self._ACTIVE_INSTANCE_STATE_KEY)
 
-    async def clear_active_instance(self, ctx) -> None:
+    async def clear_active_instance(self, ctx: Any) -> None:
         """Clear the stored instance for this MCP session.
 
         Overwrites with None rather than calling ``delete_state``: the read
@@ -94,7 +299,7 @@ class UnityInstanceMiddleware(Middleware):
         """
         await ctx.set_state(self._ACTIVE_INSTANCE_STATE_KEY, None)
 
-    async def _discover_instances(self, ctx) -> list:
+    async def _discover_instances(self, ctx: Any) -> list[Any]:
         """
         Return running Unity instances across both HTTP (PluginHub) and stdio transports.
 
@@ -102,7 +307,7 @@ class UnityInstanceMiddleware(Middleware):
         """
         from types import SimpleNamespace
         transport = (config.transport_mode or "stdio").lower()
-        results: list = []
+        results: list[Any] = []
 
         if PluginHub.is_configured():
             try:
@@ -138,7 +343,7 @@ class UnityInstanceMiddleware(Middleware):
 
         return results
 
-    async def _resolve_instance_value(self, value: str, ctx) -> str:
+    async def _resolve_instance_value(self, value: str, ctx: Any) -> str:
         """
         Resolve a unity_instance string to a validated instance identifier.
 
@@ -149,70 +354,15 @@ class UnityInstanceMiddleware(Middleware):
 
         Raises ValueError with a user-friendly message on failure.
         """
-        value = value.strip()
-        if not value:
-            raise ValueError("unity_instance value must not be empty.")
-
         transport = (config.transport_mode or "stdio").lower()
-
-        # Port number (stdio only) — resolve to Name@hash via status file lookup
-        if value.isdigit():
-            if transport == "http":
-                raise ValueError(
-                    f"Port-based targeting ('{value}') is not supported in HTTP transport mode. "
-                    "Use Name@hash or a hash prefix. Read mcpforunity://instances for available instances."
-                )
-            port_int = int(value)
-            instances = await self._discover_instances(ctx)
-            for inst in instances:
-                if getattr(inst, "port", None) == port_int:
-                    return inst.id
-            available = ", ".join(
-                f"{getattr(i, 'id', '?')} (port {getattr(i, 'port', '?')})"
-                for i in instances
-            ) or "none"
-            raise ValueError(
-                f"No Unity instance found on port {value}. Available: {available}."
-            )
-
         instances = await self._discover_instances(ctx)
-        ids = {
-            getattr(inst, "id", None): inst
-            for inst in instances
-            if getattr(inst, "id", None)
-        }
-
-        # Exact Name@hash match
-        if "@" in value:
-            if value in ids:
-                return value
-            available = ", ".join(ids) or "none"
-            raise ValueError(
-                f"Instance '{value}' not found. Available: {available}. "
-                "Read mcpforunity://instances for current sessions."
-            )
-
-        # Hash prefix match
-        lookup = value.lower()
-        matches = [
-            inst for inst in instances
-            if getattr(inst, "hash", "") and getattr(inst, "hash", "").lower().startswith(lookup)
-        ]
-        if len(matches) == 1:
-            return matches[0].id
-        if len(matches) > 1:
-            ambiguous = ", ".join(getattr(m, "id", "?") for m in matches)
-            raise ValueError(
-                f"Hash prefix '{value}' is ambiguous ({ambiguous}). "
-                "Provide the full Name@hash from mcpforunity://instances."
-            )
-        available = ", ".join(ids) or "none"
-        raise ValueError(
-            f"No running Unity instance matches '{value}'. Available: {available}. "
-            "Read mcpforunity://instances for current sessions."
+        return resolve_instance_identifier(
+            value,
+            instances,
+            transport_mode=transport,
         )
 
-    async def _maybe_autoselect_instance(self, ctx) -> str | None:
+    async def _maybe_autoselect_instance(self, ctx: Any) -> str | None:
         """
         Auto-select the sole Unity instance when no active instance is set.
 
@@ -321,9 +471,82 @@ class UnityInstanceMiddleware(Middleware):
         from transport.unity_transport import _resolve_user_id_from_request
         return await _resolve_user_id_from_request()
 
-    async def _inject_unity_instance(self, context: MiddlewareContext) -> None:
-        """Inject active Unity instance and user_id into context if available."""
+    @staticmethod
+    async def _set_request_routing_state(ctx: Any, instance_id: str | None) -> None:
+        """Set routing state for this request without shadowing session state."""
+        set_state = getattr(ctx, "set_state", None)
+        if not callable(set_state):
+            return
+
+        try:
+            await set_state("unity_instance", instance_id, serializable=False)
+        except TypeError:
+            # Keep minimal test contexts and older Context shims usable. FastMCP
+            # 3.x accepts serializable=False and uses request-scoped state.
+            await set_state("unity_instance", instance_id)
+
+    @staticmethod
+    def _consume_resource_target(context: MiddlewareContext) -> tuple[str | None, MiddlewareContext]:
+        """Extract unity_instance from a Resource URI and return a clean context."""
+        message = getattr(context, "message", None)
+        uri = getattr(message, "uri", None)
+        if uri is None:
+            return None, context
+
+        uri_text = str(uri)
+        parsed = urlsplit(uri_text)
+        if not parsed.query:
+            return None, context
+
+        target_values: list[str] = []
+        clean_query_parts: list[str] = []
+        for part in parsed.query.split("&"):
+            key, separator, value = part.partition("=")
+            if unquote_plus(key) == "unity_instance":
+                target_values.append(unquote_plus(value) if separator else "")
+            else:
+                clean_query_parts.append(part)
+
+        if not target_values:
+            return None, context
+        if len(target_values) > 1:
+            raise ValueError(
+                "Resource URI must contain at most one unity_instance query parameter."
+            )
+
+        clean_uri = urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path,
+                "&".join(clean_query_parts),
+                parsed.fragment,
+            )
+        )
+
+        # MiddlewareContext is immutable, so carry a copied MCP request message
+        # into FastMCP's resource matcher. The fallback keeps direct test shims
+        # that expose a mutable SimpleNamespace compatible.
+        if clean_uri == uri_text:
+            return target_values[0], context
+        if hasattr(message, "model_copy"):
+            clean_message = message.model_copy(update={"uri": clean_uri})
+        else:
+            clean_message = copy(message)
+            setattr(clean_message, "uri", clean_uri)
+        if hasattr(context, "copy"):
+            return target_values[0], context.copy(message=clean_message)
+        return target_values[0], context
+
+    async def _inject_unity_instance(self, context: MiddlewareContext) -> MiddlewareContext:
+        """Inject active Unity instance and user_id into request-scoped state."""
         ctx = context.fastmcp_context
+        if ctx is None:
+            return context
+
+        # Always shadow the routing key for this request, including no-target
+        # calls, so a reused context cannot retain a prior per-call selection.
+        await self._set_request_routing_state(ctx, None)
 
         # Resolve user_id from the HTTP request's API key header
         user_id = await self._resolve_user_id()
@@ -334,68 +557,34 @@ class UnityInstanceMiddleware(Middleware):
         if user_id:
             await ctx.set_state("user_id", user_id)
 
-        # Per-call routing: check if this tool call explicitly specifies unity_instance.
-        # context.message.arguments is a mutable dict on CallToolRequestParams; resource
-        # reads use ReadResourceRequestParams which has no .arguments, so this is a no-op for them.
-        # We pop the key here so Pydantic's type_adapter.validate_python() never sees it.
-        active_instance: str | None = None
+        # Per-call routing: consume the Tool argument before FastMCP/Pydantic
+        # validation, or consume the Resource URI query before URI matching.
+        requested_instance: str | None = None
+        clean_context = context
         msg_args = getattr(getattr(context, "message", None), "arguments", None)
         if isinstance(msg_args, dict) and "unity_instance" in msg_args:
             raw = msg_args.pop("unity_instance")
             if raw is not None:
                 raw_str = str(raw).strip()
                 if raw_str:
-                    # Raises ValueError with a user-friendly message on invalid input.
-                    active_instance = await self._resolve_instance_value(raw_str, ctx)
-                    logger.debug("Per-call unity_instance resolved to: %s", active_instance)
+                    requested_instance = await self._resolve_instance_value(raw_str, ctx)
+                    logger.debug("Per-call unity_instance resolved to: %s", requested_instance)
+        elif getattr(getattr(context, "message", None), "uri", None) is not None:
+            raw, clean_context = self._consume_resource_target(context)
+            if raw:
+                requested_instance = await self._resolve_instance_value(raw, ctx)
+                logger.debug("Per-call resource unity_instance resolved to: %s", requested_instance)
 
-        if not active_instance:
-            active_instance = await self.get_active_instance(ctx)
-        if not active_instance:
-            active_instance = await self._maybe_autoselect_instance(ctx)
-        if active_instance:
-            # If using HTTP transport (PluginHub configured), validate session
-            # But for stdio transport (no PluginHub needed or maybe partially configured),
-            # we should be careful not to clear instance just because PluginHub can't resolve it.
-            # The 'active_instance' (Name@hash) might be valid for stdio even if PluginHub fails.
+        # Explicit target > session active instance > the existing auto/default
+        # behavior. Only the auto-select path is allowed to persist a selection.
+        effective_instance = requested_instance
+        if not effective_instance:
+            effective_instance = await self.get_active_instance(ctx)
+        if not effective_instance:
+            effective_instance = await self._maybe_autoselect_instance(ctx)
 
-            session_id: str | None = None
-            # Only validate via PluginHub if we are actually using HTTP transport.
-            # For stdio transport, skip PluginHub entirely - we only need the instance ID.
-            from transport.unity_transport import _is_http_transport
-            if _is_http_transport() and PluginHub.is_configured():
-                try:
-                    # resolving session_id might fail if the plugin disconnected
-                    # We only need session_id for HTTP transport routing.
-                    # For stdio, we just need the instance ID.
-                    # Pass user_id for remote-hosted mode session isolation
-                    session_id = await PluginHub._resolve_session_id(active_instance, user_id=user_id)
-                except (ConnectionError, ValueError, KeyError, TimeoutError) as exc:
-                    # If resolution fails, it means the Unity instance is not reachable via HTTP/WS.
-                    # If we are in stdio mode, this might still be fine if the user is just setting state?
-                    # But usually if PluginHub is configured, we expect it to work.
-                    # Let's LOG the error but NOT clear the instance immediately to avoid flickering,
-                    # or at least debug why it's failing.
-                    logger.debug(
-                        "PluginHub session resolution failed for %s: %s; leaving active_instance unchanged",
-                        active_instance,
-                        exc,
-                        exc_info=True,
-                    )
-                except Exception as exc:
-                    # Re-raise unexpected system exceptions to avoid swallowing critical failures
-                    if isinstance(exc, (SystemExit, KeyboardInterrupt)):
-                        raise
-                    logger.error(
-                        "Unexpected error during PluginHub session resolution for %s: %s",
-                        active_instance,
-                        exc,
-                        exc_info=True
-                    )
-
-            await ctx.set_state("unity_instance", active_instance)
-            if session_id is not None:
-                await ctx.set_state("unity_session_id", session_id)
+        await self._set_request_routing_state(ctx, effective_instance)
+        return clean_context
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
         """Inject active Unity instance into tool context if available."""
@@ -404,8 +593,8 @@ class UnityInstanceMiddleware(Middleware):
 
     async def on_read_resource(self, context: MiddlewareContext, call_next):
         """Inject active Unity instance into resource context if available."""
-        await self._inject_unity_instance(context)
-        return await call_next(context)
+        clean_context = await self._inject_unity_instance(context)
+        return await call_next(clean_context)
 
     async def on_list_tools(self, context: MiddlewareContext, call_next):
         """Filter MCP tool listing to the Unity-enabled set when session data is available."""
@@ -422,6 +611,8 @@ class UnityInstanceMiddleware(Middleware):
 
         tools = await call_next(context)
 
+        self._refresh_tool_visibility_metadata_from_registry()
+
         tool_names_from_fastmcp = sorted(getattr(t, "name", "?") for t in tools)
         _diag.debug(
             "on_list_tools: FastMCP returned %d tools: %s",
@@ -430,13 +621,12 @@ class UnityInstanceMiddleware(Middleware):
 
         if not self._should_filter_tool_listing():
             _diag.debug("on_list_tools: skipping middleware filter (not HTTP or PluginHub not configured)")
-            return tools
+            return [self._with_unity_instance_schema(tool) for tool in tools]
 
-        self._refresh_tool_visibility_metadata_from_registry()
         enabled_tool_names = await self._resolve_enabled_tool_names_for_context(context)
         if enabled_tool_names is None:
             _diag.debug("on_list_tools: no Unity session data, returning %d tools from FastMCP as-is", len(tools))
-            return tools
+            return [self._with_unity_instance_schema(tool) for tool in tools]
 
         filtered = []
         for tool in tools:
@@ -449,7 +639,7 @@ class UnityInstanceMiddleware(Middleware):
             "enabled_names=%s",
             len(filtered), len(tools), sorted(enabled_tool_names),
         )
-        return filtered
+        return [self._with_unity_instance_schema(tool) for tool in filtered]
 
     def _should_filter_tool_listing(self) -> bool:
         transport = (config.transport_mode or "stdio").lower()
@@ -563,6 +753,7 @@ class UnityInstanceMiddleware(Middleware):
             unity_managed_tool_names: set[str] = set()
             tool_alias_to_unity_target: dict[str, str] = {}
             server_only_tool_names: set[str] = set()
+            unity_targetable_tool_names: set[str] = set()
             signature_entries: list[tuple[str, str]] = []
 
             for tool_info in registry_tools:
@@ -571,9 +762,19 @@ class UnityInstanceMiddleware(Middleware):
                     continue
 
                 unity_target = tool_info.get("unity_target", tool_name)
+                unity_targetable = tool_info.get(
+                    "unity_targetable",
+                    unity_target is not None,
+                )
+                if unity_targetable is True:
+                    unity_targetable_tool_names.add(tool_name)
+
                 if unity_target is None:
                     server_only_tool_names.add(tool_name)
-                    signature_entries.append((tool_name, "<server-only>"))
+                    signature_entries.append((
+                        tool_name,
+                        f"<server-only>|targetable={unity_targetable is True}",
+                    ))
                     continue
 
                 if not isinstance(unity_target, str) or not unity_target:
@@ -585,12 +786,18 @@ class UnityInstanceMiddleware(Middleware):
 
                 if unity_target == tool_name:
                     unity_managed_tool_names.add(tool_name)
-                    signature_entries.append((tool_name, unity_target))
+                    signature_entries.append((
+                        tool_name,
+                        f"{unity_target}|targetable={unity_targetable is True}",
+                    ))
                     continue
 
                 tool_alias_to_unity_target[tool_name] = unity_target
                 unity_managed_tool_names.add(unity_target)
-                signature_entries.append((tool_name, unity_target))
+                signature_entries.append((
+                    tool_name,
+                    f"{unity_target}|targetable={unity_targetable is True}",
+                ))
 
             signature = tuple(sorted(signature_entries, key=lambda item: item[0]))
             if signature == self._tool_visibility_signature:
@@ -600,8 +807,38 @@ class UnityInstanceMiddleware(Middleware):
             self._unity_managed_tool_names = unity_managed_tool_names
             self._tool_alias_to_unity_target = tool_alias_to_unity_target
             self._server_only_tool_names = server_only_tool_names
+            self._unity_targetable_tool_names = unity_targetable_tool_names
             self._tool_visibility_signature = signature
             self._last_tool_visibility_refresh = now
+
+    def _is_tool_targetable(self, tool: Any) -> bool:
+        tool_name = getattr(tool, "name", None)
+        tags = getattr(tool, "tags", None) or set()
+        return (
+            UNITY_TARGETABLE_TAG in tags
+            or (
+                isinstance(tool_name, str)
+                and tool_name in self._unity_targetable_tool_names
+            )
+        )
+
+    def _with_unity_instance_schema(self, tool: Any) -> Any:
+        """Return a tool copy advertising the optional routing envelope."""
+        if not self._is_tool_targetable(tool):
+            return tool
+
+        parameters = getattr(tool, "parameters", None)
+        model_copy = getattr(tool, "model_copy", None)
+        if not isinstance(parameters, dict) or not callable(model_copy):
+            return tool
+
+        updated_parameters = deepcopy(parameters)
+        properties = updated_parameters.get("properties")
+        if not isinstance(properties, dict):
+            properties = {}
+            updated_parameters["properties"] = properties
+        properties["unity_instance"] = deepcopy(_UNITY_INSTANCE_PARAMETER_SCHEMA)
+        return model_copy(update={"parameters": updated_parameters})
 
     @staticmethod
     def _resolve_candidate_project_hashes(active_instance: str | None) -> list[str]:

--- a/Server/src/transport/unity_instance_middleware.py
+++ b/Server/src/transport/unity_instance_middleware.py
@@ -104,6 +104,39 @@ def resolve_instance_identifier(
         raise InstanceTargetError("unity_instance value must not be empty.", status_code=400)
 
     transport = (transport_mode or "stdio").lower()
+    ids = [resolved_id for resolved_id in (_instance_id(item) for item in instances) if resolved_id]
+
+    # A composite target is deliberately exact. In particular, a wrong hash
+    # must never fall back to a matching project name.
+    if "@" in value:
+        for instance in instances:
+            instance_id = _instance_id(instance)
+            if instance_id and instance_id.lower() == value.lower():
+                return instance_id
+        available = ", ".join(ids) or "none"
+        raise InstanceTargetError(
+            f"Instance '{value}' not found. Available: {available}. "
+            "Read mcpforunity://instances for current sessions."
+        )
+
+    # Project names take precedence over numeric hash/port shorthand, matching
+    # the legacy stdio connection-pool resolution order.
+    name_matches = [
+        instance for instance in instances
+        if (_instance_name(instance) or "") == value
+    ]
+    if len(name_matches) == 1:
+        resolved_id = _instance_id(name_matches[0])
+        if resolved_id:
+            return resolved_id
+    if len(name_matches) > 1:
+        ambiguous = ", ".join(_instance_id(instance) or "?" for instance in name_matches)
+        raise InstanceTargetError(
+            f"Project name '{value}' matches multiple Unity instances ({ambiguous}). "
+            "Provide the full Name@hash.",
+            status_code=400,
+        )
+
     if value.isdigit():
         if transport == "http":
             exact_hash_matches = [
@@ -170,40 +203,8 @@ def resolve_instance_identifier(
             status_code=404,
         )
 
-    ids = [resolved_id for resolved_id in (_instance_id(item) for item in instances) if resolved_id]
-
-    # A composite target is deliberately exact.  In particular, a wrong hash
-    # must never fall back to a matching project name.
-    if "@" in value:
-        for instance in instances:
-            instance_id = _instance_id(instance)
-            if instance_id and instance_id.lower() == value.lower():
-                return instance_id
-        available = ", ".join(ids) or "none"
-        raise InstanceTargetError(
-            f"Instance '{value}' not found. Available: {available}. "
-            "Read mcpforunity://instances for current sessions."
-        )
-
-    name_matches = [
-        instance for instance in instances
-        if (_instance_name(instance) or "") == value
-    ]
-    if len(name_matches) == 1:
-        resolved_id = _instance_id(name_matches[0])
-        if resolved_id:
-            return resolved_id
-    if len(name_matches) > 1:
-        ambiguous = ", ".join(_instance_id(instance) or "?" for instance in name_matches)
-        raise InstanceTargetError(
-            f"Project name '{value}' matches multiple Unity instances ({ambiguous}). "
-            "Provide the full Name@hash.",
-            status_code=400,
-        )
-
-    # Match project names before hash prefixes, as the stdio connection pool
-    # does. This keeps an intentional project-name target stable if its text
-    # also happens to prefix another instance hash.
+    # Match hash prefixes after exact IDs and project names, as the stdio
+    # connection pool does.
     lookup = value.lower()
     hash_matches = [
         instance for instance in instances

--- a/Server/tests/integration/test_helpers.py
+++ b/Server/tests/integration/test_helpers.py
@@ -26,6 +26,7 @@ class DummyContext:
         self.session_id = str(uuid.uuid4())
         # Add state storage to mimic FastMCP context state
         self._state = {}
+        self._request_state = {}
 
         class _RequestContext:
             def __init__(self, meta):
@@ -46,12 +47,18 @@ class DummyContext:
     async def error(self, message):
         self.log_error.append(message)
 
-    async def set_state(self, key, value):
-        """Set state value (mimics FastMCP context.set_state)"""
-        self._state[key] = value
+    async def set_state(self, key, value, *, serializable=True):
+        """Set session- or request-scoped state like FastMCP Context."""
+        if serializable:
+            self._state[key] = value
+            self._request_state.pop(key, None)
+        else:
+            self._request_state[key] = value
 
     async def get_state(self, key, default=None):
         """Get state value (mimics FastMCP context.get_state)"""
+        if key in self._request_state:
+            return self._request_state[key]
         return self._state.get(key, default)
 
 

--- a/Server/tests/integration/test_inline_unity_instance.py
+++ b/Server/tests/integration/test_inline_unity_instance.py
@@ -8,6 +8,7 @@ When a tool call includes unity_instance in its arguments, the middleware:
 """
 import sys
 import types
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -26,6 +27,20 @@ class DummyMiddlewareContext:
     def __init__(self, ctx, arguments: dict | None = None):
         self.fastmcp_context = ctx
         self.message = SimpleNamespace(arguments=arguments if arguments is not None else {})
+
+
+class CopyableMiddlewareContext:
+    """Small middleware context stand-in that supports context.copy()."""
+
+    def __init__(self, message, fastmcp_context):
+        self.message = message
+        self.fastmcp_context = fastmcp_context
+
+    def copy(self, **changes):
+        return CopyableMiddlewareContext(
+            changes.get("message", self.message),
+            changes.get("fastmcp_context", self.fastmcp_context),
+        )
 
 
 def _make_middleware(monkeypatch, *, transport="stdio", plugin_hub_configured=False, sessions=None, pool_instances=None):
@@ -146,6 +161,8 @@ async def test_inline_does_not_persist_to_session(monkeypatch):
     mw_ctx1 = DummyMiddlewareContext(ctx, arguments={"unity_instance": "bbb222"})
     await mw._inject_unity_instance(mw_ctx1)
     assert await ctx.get_state("unity_instance") == "ProjB@bbb222"
+    assert ctx._state[mw._ACTIVE_INSTANCE_STATE_KEY] == "ProjA@aaa111"
+    assert ctx._request_state["unity_instance"] == "ProjB@bbb222"
 
     # Call 2: no inline — must revert to session-persisted ProjA
     mw_ctx2 = DummyMiddlewareContext(ctx, arguments={})
@@ -172,6 +189,128 @@ async def test_inline_overrides_session_persisted_instance(monkeypatch):
     assert await ctx.get_state("unity_instance") == "ProjB@bbb222"
     # Session still pinned to ProjA
     assert await mw.get_active_instance(ctx) == "ProjA@aaa111"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_per_call_targets_are_request_scoped(monkeypatch):
+    """Two calls in one MCP session keep independent request routing state."""
+    instances = [
+        SimpleNamespace(id="ProjA@aaa111", hash="aaa111"),
+        SimpleNamespace(id="ProjB@bbb222", hash="bbb222"),
+    ]
+    mw = _make_middleware(monkeypatch, pool_instances=instances)
+
+    shared_session_state = {}
+    ctx_a = DummyContext()
+    ctx_b = DummyContext()
+    ctx_a.session_id = ctx_b.session_id = "same-mcp-session"
+    ctx_a._state = ctx_b._state = shared_session_state
+
+    async def inject(ctx, target):
+        await asyncio.sleep(0)
+        return await mw._inject_unity_instance(
+            CopyableMiddlewareContext(
+                SimpleNamespace(
+                    name="manage_scene",
+                    arguments={"unity_instance": target},
+                ),
+                ctx,
+            )
+        )
+
+    await asyncio.gather(inject(ctx_a, "aaa111"), inject(ctx_b, "bbb222"))
+
+    assert ctx_a._request_state["unity_instance"] == "ProjA@aaa111"
+    assert ctx_b._request_state["unity_instance"] == "ProjB@bbb222"
+    assert "mcpforunity.active_instance" not in shared_session_state
+
+
+@pytest.mark.asyncio
+async def test_tool_routing_is_consumed_before_call_next(monkeypatch):
+    """FastMCP receives the tool arguments with routing metadata removed."""
+    mw = _make_middleware(
+        monkeypatch,
+        pool_instances=[SimpleNamespace(id="Proj@abc123", hash="abc123")],
+    )
+    ctx = DummyContext()
+    middleware_ctx = CopyableMiddlewareContext(
+        SimpleNamespace(
+            name="manage_scene",
+            arguments={"action": "get_active", "unity_instance": "abc123"},
+        ),
+        ctx,
+    )
+    seen = {}
+
+    async def call_next(clean_context):
+        seen["arguments"] = clean_context.message.arguments
+        return {"success": True}
+
+    await mw.on_call_tool(middleware_ctx, call_next)
+
+    assert seen["arguments"] == {"action": "get_active"}
+    assert "unity_instance" not in seen["arguments"]
+
+
+@pytest.mark.asyncio
+async def test_resource_target_is_consumed_and_command_params_stay_unchanged(monkeypatch):
+    """Resource routing query is removed before FastMCP and Unity execution."""
+    mw = _make_middleware(
+        monkeypatch,
+        pool_instances=[SimpleNamespace(id="Proj@abc123", hash="abc123")],
+    )
+    ctx = DummyContext()
+    resource_ctx = CopyableMiddlewareContext(
+        SimpleNamespace(
+            uri="mcpforunity://project/info?unity_instance=Proj%40abc123",
+        ),
+        ctx,
+    )
+    seen = {}
+
+    import services.resources.project_info as project_info
+
+    async def fake_send(_send_fn, target, command_type, params, **_kwargs):
+        seen["target"] = target
+        seen["command_type"] = command_type
+        seen["params"] = params
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(project_info, "send_with_unity_instance", fake_send)
+
+    async def call_next(clean_context):
+        seen["uri"] = str(clean_context.message.uri)
+        return await project_info.get_project_info(ctx)
+
+    await mw.on_read_resource(resource_ctx, call_next)
+
+    assert seen["uri"] == "mcpforunity://project/info"
+    assert seen["target"] == "Proj@abc123"
+    assert seen["command_type"] == "get_project_info"
+    assert seen["params"] == {}
+    assert await ctx.get_state("unity_instance") == "Proj@abc123"
+
+
+@pytest.mark.asyncio
+async def test_resource_without_query_keeps_original_uri(monkeypatch):
+    """The original resource URI remains unchanged when no target is supplied."""
+    mw = _make_middleware(monkeypatch)
+    ctx = DummyContext()
+    resource_ctx = CopyableMiddlewareContext(
+        SimpleNamespace(uri="mcpforunity://editor/state"),
+        ctx,
+    )
+    seen = {}
+
+    async def call_next(clean_context):
+        seen["uri"] = str(clean_context.message.uri)
+        return {"success": True}
+
+    await mw.on_read_resource(resource_ctx, call_next)
+
+    assert seen["uri"] == "mcpforunity://editor/state"
+    assert await ctx.get_state("unity_instance") is None
+    assert ctx._request_state["unity_instance"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/Server/tests/integration/test_instance_autoselect.py
+++ b/Server/tests/integration/test_instance_autoselect.py
@@ -106,6 +106,41 @@ async def test_auto_selects_single_instance_via_stdio(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_stdio_instance_discovery_forces_refresh(monkeypatch):
+    plugin_hub = types.ModuleType("transport.plugin_hub")
+
+    class PluginHub:
+        @classmethod
+        def is_configured(cls) -> bool:
+            return False
+
+    plugin_hub.PluginHub = PluginHub
+    monkeypatch.setitem(sys.modules, "transport.plugin_hub", plugin_hub)
+    monkeypatch.delitem(sys.modules, "transport.unity_instance_middleware", raising=False)
+
+    from transport.unity_instance_middleware import UnityInstanceMiddleware
+
+    monkeypatch.setattr(config, "transport_mode", "stdio")
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    refresh_values = []
+
+    class PoolStub:
+        def discover_all_instances(self, force_refresh=False):
+            refresh_values.append(force_refresh)
+            return [SimpleNamespace(id="UnityMCPTests@cc8756d4")]
+
+    unity_connection = types.ModuleType("transport.legacy.unity_connection")
+    unity_connection.get_unity_connection_pool = lambda: PoolStub()
+    monkeypatch.setitem(sys.modules, "transport.legacy.unity_connection", unity_connection)
+
+    instances = await middleware._discover_instances(ctx)
+
+    assert [instance.id for instance in instances] == ["UnityMCPTests@cc8756d4"]
+    assert refresh_values == [True]
+
+
+@pytest.mark.asyncio
 async def test_auto_select_handles_stdio_errors(monkeypatch):
     plugin_hub = types.ModuleType("transport.plugin_hub")
 

--- a/Server/tests/test_instance_targeting_http.py
+++ b/Server/tests/test_instance_targeting_http.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+
+import pytest
+
+from core.config import config
+from transport.unity_instance_middleware import (
+    InstanceTargetError,
+    resolve_instance_identifier,
+)
+from transport.unity_transport import send_with_unity_instance
+
+
+def _instances():
+    return [
+        SimpleNamespace(
+            id="Project@aaa111",
+            project="Project",
+            name="Project",
+            hash="aaa111",
+            port=6400,
+        ),
+        SimpleNamespace(
+            id="Project@bbb222",
+            project="Project",
+            name="Project",
+            hash="bbb222",
+            port=6401,
+        ),
+        SimpleNamespace(
+            id="Numeric@12345678",
+            project="Numeric",
+            name="Numeric",
+            hash="12345678",
+            port=6402,
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("token", "expected_id"),
+    [
+        ("Project@bbb222", "Project@bbb222"),
+        ("bbb2", "Project@bbb222"),
+        ("123", "Numeric@12345678"),
+        ("12345678", "Numeric@12345678"),
+    ],
+)
+def test_http_target_resolution_returns_canonical_id(token, expected_id):
+    assert resolve_instance_identifier(
+        token,
+        _instances(),
+        transport_mode="http",
+    ) == expected_id
+
+
+def test_http_target_resolution_rejects_duplicate_project_name():
+    with pytest.raises(InstanceTargetError, match="Project name 'Project'.*multiple"):
+        resolve_instance_identifier("Project", _instances(), transport_mode="http")
+
+
+def test_http_target_resolution_rejects_wrong_hash_without_name_fallback():
+    with pytest.raises(InstanceTargetError, match="not found"):
+        resolve_instance_identifier("Project@wrong", _instances(), transport_mode="http")
+
+
+def test_http_target_resolution_rejects_ambiguous_hash_prefix():
+    with pytest.raises(InstanceTargetError, match="ambiguous"):
+        resolve_instance_identifier(
+            "b",
+            [
+                SimpleNamespace(id="A@bbb111", project="A", hash="bbb111"),
+                SimpleNamespace(id="B@bbb222", project="B", hash="bbb222"),
+            ],
+            transport_mode="http",
+        )
+
+
+def test_http_target_resolution_rejects_port_targeting():
+    with pytest.raises(InstanceTargetError, match="not supported in HTTP transport mode"):
+        resolve_instance_identifier("6401", _instances(), transport_mode="http")
+
+
+def test_http_numeric_hash_precedes_port_rejection():
+    instance = SimpleNamespace(
+        id="Numeric@1234",
+        project="Numeric",
+        name="Numeric",
+        hash="1234",
+        port=1234,
+    )
+
+    assert resolve_instance_identifier(
+        "1234", [instance], transport_mode="http") == "Numeric@1234"
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_keeps_routing_out_of_command_params(monkeypatch):
+    monkeypatch.setattr(config, "transport_mode", "stdio")
+    captured = {}
+
+    async def fake_send(command_type, params, **kwargs):
+        captured.update(command_type=command_type, params=params, kwargs=kwargs)
+        return {"success": True}
+
+    await send_with_unity_instance(
+        fake_send,
+        "Project@bbb222",
+        "manage_scene",
+        {"action": "get_active"},
+    )
+
+    assert captured == {
+        "command_type": "manage_scene",
+        "params": {"action": "get_active"},
+        "kwargs": {"instance_id": "Project@bbb222"},
+    }

--- a/Server/tests/test_instance_targeting_http.py
+++ b/Server/tests/test_instance_targeting_http.py
@@ -58,6 +58,27 @@ def test_http_target_resolution_rejects_duplicate_project_name():
         resolve_instance_identifier("Project", _instances(), transport_mode="http")
 
 
+def test_http_target_resolution_prefers_numeric_project_name():
+    numeric_project = SimpleNamespace(
+        id="123@aaa111",
+        project="123",
+        name="123",
+        hash="aaa111",
+    )
+    hash_prefix_match = SimpleNamespace(
+        id="Other@123bbb",
+        project="Other",
+        name="Other",
+        hash="123bbb",
+    )
+
+    assert resolve_instance_identifier(
+        "123",
+        [numeric_project, hash_prefix_match],
+        transport_mode="http",
+    ) == "123@aaa111"
+
+
 def test_http_target_resolution_rejects_wrong_hash_without_name_fallback():
     with pytest.raises(InstanceTargetError, match="not found"):
         resolve_instance_identifier("Project@wrong", _instances(), transport_mode="http")

--- a/Server/tests/test_resource_targeting_metadata.py
+++ b/Server/tests/test_resource_targeting_metadata.py
@@ -1,0 +1,64 @@
+"""Regression tests for per-call Unity targeting in resource metadata."""
+
+import services.resources as resources_module
+
+
+async def _resource(_ctx):
+    return {"success": True}
+
+
+class _RecordingMcp:
+    """Capture registrations without importing a live FastMCP server."""
+
+    def __init__(self):
+        self.registrations = []
+
+    def resource(self, *, uri, name, description, **kwargs):
+        def decorator(func):
+            self.registrations.append(
+                {
+                    "uri": uri,
+                    "name": name,
+                    "description": description,
+                    "kwargs": kwargs,
+                    "func": func,
+                }
+            )
+            return func
+
+        return decorator
+
+
+def test_targetable_resource_is_advertised_in_both_resource_lists(monkeypatch):
+    """Concrete and template registrations both describe the routing query."""
+    resource_uri = "mcpforunity://editor/state"
+    resource_info = {
+        "func": _resource,
+        "uri": resource_uri,
+        "name": "editor_state",
+        "description": "Editor state.",
+        "unity_targetable": True,
+        "kwargs": {},
+    }
+
+    monkeypatch.setattr(resources_module, "discover_modules", lambda *_args: [])
+    monkeypatch.setattr(
+        resources_module,
+        "get_registered_resources",
+        lambda: [resource_info],
+    )
+
+    mcp = _RecordingMcp()
+    resources_module.register_all_resources(mcp)
+
+    resource = next(
+        item for item in mcp.registrations if item["uri"] == resource_uri
+    )
+    template = next(
+        item
+        for item in mcp.registrations
+        if "editor/state" in item["uri"] and "{?" in item["uri"]
+    )
+
+    assert "unity_instance" in (resource["description"] or "")
+    assert template["uri"] == f"{resource_uri}{{?unity_instance}}"

--- a/Server/tests/test_tool_registry_metadata.py
+++ b/Server/tests/test_tool_registry_metadata.py
@@ -1,6 +1,10 @@
 import pytest
 
-from services.registry import get_registered_tools, mcp_for_unity_tool
+from services.registry import (
+    UNITY_TARGETABLE_TAG,
+    get_registered_tools,
+    mcp_for_unity_tool,
+)
 import services.registry.tool_registry as tool_registry_module
 
 
@@ -21,6 +25,8 @@ def test_tool_registry_defaults_unity_target_to_tool_name():
     registered_tools = get_registered_tools()
     tool_info = next(item for item in registered_tools if item["name"] == "_default_target_tool")
     assert tool_info["unity_target"] == "_default_target_tool"
+    assert tool_info["unity_targetable"] is True
+    assert UNITY_TARGETABLE_TAG in tool_info["kwargs"]["tags"]
 
 
 def test_tool_registry_supports_server_only_and_alias_targets():
@@ -37,7 +43,20 @@ def test_tool_registry_supports_server_only_and_alias_targets():
     alias_tool = next(item for item in registered_tools if item["name"] == "_manage_script_alias_tool")
 
     assert server_only["unity_target"] is None
+    assert server_only["unity_targetable"] is False
     assert alias_tool["unity_target"] == "manage_script"
+    assert alias_tool["unity_targetable"] is True
+
+
+def test_server_only_tool_can_opt_into_per_call_targeting():
+    @mcp_for_unity_tool(unity_target=None, unity_targetable=True)
+    def _project_scoped_tool():
+        return None
+
+    tool_info = next(item for item in get_registered_tools() if item["name"] == "_project_scoped_tool")
+    assert tool_info["unity_target"] is None
+    assert tool_info["unity_targetable"] is True
+    assert UNITY_TARGETABLE_TAG in tool_info["kwargs"]["tags"]
 
 
 def test_tool_registry_does_not_leak_unity_target_into_tool_kwargs():
@@ -48,7 +67,9 @@ def test_tool_registry_does_not_leak_unity_target_into_tool_kwargs():
     registered_tools = get_registered_tools()
     tool_info = next(item for item in registered_tools if item["name"] == "_non_leaking_target_tool")
     assert tool_info["unity_target"] == "manage_script"
+    assert tool_info["unity_targetable"] is True
     assert "unity_target" not in tool_info["kwargs"]
+    assert "unity_targetable" not in tool_info["kwargs"]
     assert tool_info["kwargs"]["annotations"] == {"title": "x"}
 
 
@@ -61,4 +82,9 @@ def test_tool_registry_rejects_invalid_unity_target_values():
     with pytest.raises(ValueError, match="Invalid unity_target"):
         @mcp_for_unity_tool(unity_target=123)  # type: ignore[arg-type]
         def _invalid_non_string_target_tool():
+            return None
+
+    with pytest.raises(ValueError, match="Invalid unity_targetable"):
+        @mcp_for_unity_tool(unity_targetable=1)  # type: ignore[arg-type]
+        def _invalid_targetable_tool():
             return None

--- a/Server/tests/test_tool_registry_metadata.py
+++ b/Server/tests/test_tool_registry_metadata.py
@@ -59,6 +59,19 @@ def test_server_only_tool_can_opt_into_per_call_targeting():
     assert UNITY_TARGETABLE_TAG in tool_info["kwargs"]["tags"]
 
 
+def test_tool_registry_preserves_group_position_argument():
+    @mcp_for_unity_tool(None, None, "self", "vfx")
+    def _positional_group_tool():
+        return None
+
+    tool_info = next(
+        item for item in get_registered_tools()
+        if item["name"] == "_positional_group_tool"
+    )
+    assert tool_info["group"] == "vfx"
+    assert tool_info["unity_targetable"] is True
+
+
 def test_tool_registry_does_not_leak_unity_target_into_tool_kwargs():
     @mcp_for_unity_tool(unity_target="manage_script", annotations={"title": "x"})
     def _non_leaking_target_tool():

--- a/Server/tests/test_transport_characterization.py
+++ b/Server/tests/test_transport_characterization.py
@@ -244,8 +244,8 @@ class TestUnityInstanceMiddlewareInjection:
     @pytest.mark.asyncio
     async def test_middleware_does_not_inject_when_no_instance(self, mock_context):
         """
-        Current behavior: When no active instance is set and auto-select fails,
-        middleware does not inject anything (None instance not stored).
+        When no active instance is set and auto-select fails, middleware still
+        initializes request-scoped routing state to None.
         """
         middleware = UnityInstanceMiddleware()
 
@@ -261,10 +261,11 @@ class TestUnityInstanceMiddlewareInjection:
             with patch("transport.legacy.unity_connection.get_unity_connection_pool", return_value=None):
                 await middleware.on_call_tool(middleware_ctx, mock_call_next)
 
-        # set_state should not be called for unity_instance if no instance found
+        # Every request explicitly shadows routing state, including no target.
         calls = [c for c in mock_context.set_state.call_args_list
                 if len(c[0]) > 0 and c[0][0] == "unity_instance"]
-        assert len(calls) == 0
+        assert calls
+        assert calls[-1][0][1] is None
 
     @pytest.mark.asyncio
     async def test_list_tools_filters_disabled_unity_tools_and_aliases(self, mock_context, monkeypatch):
@@ -1057,6 +1058,154 @@ class TestPluginHubCommandRouting:
         # unity_timeout_s = max(30, 100) = 100
         # server_wait_s = max(30, 100 + 5) = 105
         assert True  # This is implicit in send_command implementation
+
+
+class TestExplicitStdioInstanceRouting:
+    """Explicit per-call stdio targets must not fall back after disconnect."""
+
+    def test_explicit_target_disconnect_does_not_use_registry_default(self, monkeypatch):
+        from transport.legacy import unity_connection as legacy
+
+        class DeadSocket:
+            def sendall(self, _payload):
+                raise ConnectionResetError("target disconnected")
+
+            def close(self):
+                return None
+
+            def gettimeout(self):
+                return None
+
+        conn = legacy.UnityConnection(port=6401, instance_id="Project@target-hash")
+        conn.sock = DeadSocket()
+        monkeypatch.setattr(conn, "_ensure_live_connection", lambda: None)
+
+        monkeypatch.setattr(
+            legacy.stdio_port_registry,
+            "get_instance",
+            lambda _instance_id: None,
+        )
+        monkeypatch.setattr(
+            legacy.stdio_port_registry,
+            "get_port",
+            lambda _instance_id=None: pytest.fail("explicit target fell back to default port"),
+        )
+
+        with pytest.raises(ConnectionError, match="target-hash.*no longer available"):
+            conn.send_command(
+                "manage_scene",
+                {},
+                max_attempts=0,
+                allow_default_fallback=False,
+            )
+
+    def test_explicit_target_disconnect_retries_before_failing(self, monkeypatch):
+        from transport.legacy import unity_connection as legacy
+
+        class DeadSocket:
+            def sendall(self, _payload):
+                raise ConnectionResetError("target disconnected")
+
+            def close(self):
+                return None
+
+            def gettimeout(self):
+                return None
+
+        conn = legacy.UnityConnection(port=6401, instance_id="Project@target-hash")
+        conn.sock = DeadSocket()
+        monkeypatch.setattr(conn, "_ensure_live_connection", lambda: None)
+        monkeypatch.setattr(conn, "connect", lambda *_args, **_kwargs: False)
+        monkeypatch.setattr(legacy.time, "sleep", lambda _seconds: None)
+
+        registry_calls = 0
+
+        def missing_target(_instance_id):
+            nonlocal registry_calls
+            registry_calls += 1
+            return None
+
+        monkeypatch.setattr(
+            legacy.stdio_port_registry,
+            "get_instance",
+            missing_target,
+        )
+        monkeypatch.setattr(
+            legacy.stdio_port_registry,
+            "get_port",
+            lambda _instance_id=None: pytest.fail("explicit target fell back to default port"),
+        )
+
+        with pytest.raises(ConnectionError, match="target-hash.*no longer available"):
+            conn.send_command(
+                "manage_scene",
+                {},
+                max_attempts=1,
+                allow_default_fallback=False,
+            )
+
+        assert registry_calls == 2
+        assert conn.port is None
+
+    def test_explicit_target_recovery_is_discovered_before_retry_connect(self, monkeypatch):
+        from transport.legacy import unity_connection as legacy
+
+        class DeadSocket:
+            def sendall(self, _payload):
+                raise ConnectionResetError("target disconnected")
+
+            def close(self):
+                return None
+
+            def gettimeout(self):
+                return None
+
+        class LiveSocket:
+            def sendall(self, _payload):
+                return None
+
+            def gettimeout(self):
+                return None
+
+            def settimeout(self, _timeout):
+                return None
+
+        conn = legacy.UnityConnection(port=6401, instance_id="Project@target-hash")
+        conn.sock = DeadSocket()
+        monkeypatch.setattr(conn, "_ensure_live_connection", lambda: None)
+        monkeypatch.setattr(legacy.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(
+            conn,
+            "receive_full_response",
+            lambda _sock: b'{"status":"success","result":{"ok":true}}',
+        )
+
+        recovered = type("RecoveredInstance", (), {"port": 6410})()
+        registry_results = iter([None, recovered])
+        monkeypatch.setattr(
+            legacy.stdio_port_registry,
+            "get_instance",
+            lambda _instance_id: next(registry_results),
+        )
+
+        connect_ports = []
+
+        def reconnect(*_args, **_kwargs):
+            connect_ports.append(conn.port)
+            conn.sock = LiveSocket()
+            return True
+
+        monkeypatch.setattr(conn, "connect", reconnect)
+
+        result = conn.send_command(
+            "manage_scene",
+            {},
+            max_attempts=1,
+            allow_default_fallback=False,
+        )
+
+        assert result == {"ok": True}
+        assert connect_ports == [6410]
 
 
 # ============================================================================

--- a/website/docs/architecture/remote-auth.md
+++ b/website/docs/architecture/remote-auth.md
@@ -26,8 +26,8 @@ MCP Client                    MCP Server                      External Auth
      |                           |                               |
      |                   Cache result (TTL)                      |
      |                           |                               |
-     |            ctx.set_state("user_id", "user-42")            |
-     |            ctx.set_state("unity_instance", "Proj@hash")   |
+     |            session user_id + active instance              |
+     |            request effective target                      |
      |                           |                               |
      |            PluginHub.send_command_for_instance             |
      |            (user_id scoped session lookup)                 |
@@ -118,7 +118,9 @@ Key methods:
 
 **File:** `Server/src/transport/unity_instance_middleware.py`
 
-FastMCP middleware that intercepts all tool and resource calls to inject the active Unity instance and user identity into the request-scoped context.
+FastMCP middleware that resolves the authenticated user and effective Unity
+target for every tool call and resource read. The authenticated user and active
+instance are MCP-session state; an explicit per-call target is request-local.
 
 Entry points:
 
@@ -129,9 +131,13 @@ Both delegate to `_inject_unity_instance(context)`, which:
 
 1. Calls `_resolve_user_id()` to extract the user identity from the HTTP request.
 2. If remote-hosted mode is active and no `user_id` is resolved, raises `RuntimeError` (surfaces as MCP error).
-3. Sets `ctx.set_state("user_id", user_id)`.
-4. Looks up or auto-selects the active Unity instance.
-5. Sets `ctx.set_state("unity_instance", active_instance)`.
+3. Stores the authenticated user in MCP session state so discovery and selector resolution are user-scoped.
+4. Consumes an explicit `unity_instance` from a targetable tool envelope or resource URI query, if present.
+5. Otherwise reads the active instance from FastMCP session state and applies the existing auto/default behavior when allowed.
+6. Stores the resulting effective target in request-scoped `unity_instance` state with `serializable=False`.
+
+The explicit target is never written to the session's active-instance key. This
+keeps concurrent calls in one MCP session isolated from one another.
 
 ### _resolve_user_id_from_request
 
@@ -153,13 +159,13 @@ The middleware calls this indirectly through `_resolve_user_id()`, which adds an
 
 ## Request Lifecycle
 
-A complete authenticated MCP tool call follows this path:
+A complete authenticated MCP tool call or resource read follows this path:
 
 1. **HTTP request arrives** at `/mcp` with `X-API-Key: <key>` header.
 
-2. **FastMCP dispatches** the MCP tool call through its middleware chain.
+2. **FastMCP dispatches** the MCP request through its middleware chain.
 
-3. **`UnityInstanceMiddleware.on_call_tool`** is invoked.
+3. **The middleware entry point** is invoked: `on_call_tool` for a tool call or `on_read_resource` for a resource read.
 
 4. **`_inject_unity_instance`** runs:
    - Calls `_resolve_user_id()`, which calls `_resolve_user_id_from_request()`.
@@ -168,19 +174,20 @@ A complete authenticated MCP tool call follows this path:
    - If valid, `user_id` is returned. If invalid or missing, `None` is returned.
    - In remote-hosted mode, `None` causes a `RuntimeError`.
 
-5. **`user_id` stored in context** via `ctx.set_state("user_id", user_id)`.
+5. **`user_id` stored in MCP session state** and used to scope visible Unity sessions.
 
-6. **Session key derived** by `get_session_key(ctx)`:
-   - Priority: `client_id` (if available) > `user:{user_id}` > `"global"`.
-   - The `user:{user_id}` fallback ensures session isolation when MCP transports don't provide stable client IDs.
+6. **Explicit target consumed**, if present:
+   - For a targetable tool, `unity_instance` is removed from the tool argument envelope before FastMCP validates the business arguments.
+   - For a targetable resource, `unity_instance` is removed from the URI before FastMCP matches the resource template.
+   - The selector is resolved against the authenticated user's sessions. Invalid and ambiguous selectors fail without fallback.
 
-7. **Active Unity instance looked up** from `_active_by_key` dict using the session key. If none is set, `_maybe_autoselect_instance` is called (but returns `None` in remote-hosted mode).
+7. **Session active instance looked up** from FastMCP's session-scoped state. If no active instance exists, the existing auto/default behavior runs; remote-hosted mode disables auto-selection.
 
-8. **Instance injected** via `ctx.set_state("unity_instance", active_instance)`.
+8. **Effective target injected** via request-scoped `ctx.set_state("unity_instance", target, serializable=False)`.
 
-9. **Tool executes**, reading the instance from `ctx.get_state("unity_instance")`.
+9. **Tool or resource executes**, reading the effective target from request state. A call without an explicit selector still uses the active session target.
 
-10. **Command routed** through `PluginHub.send_command_for_instance(unity_instance, ..., user_id=user_id)`, which resolves the session using `PluginRegistry.get_session_id_by_hash(project_hash, user_id)`.
+10. **Command routed** through the user-scoped PluginHub session. The `unity_instance` routing envelope is Python-only and is not included in Unity command `params`.
 
 ## WebSocket Auth Flow
 
@@ -293,19 +300,27 @@ The system fails closed at every boundary:
 
 API keys are never logged in full. Keys longer than 8 characters are redacted to `xxxx...yyyy` in log messages.
 
-## Session Key Derivation
+## Session and request state
 
-`UnityInstanceMiddleware.get_session_key(ctx)` determines which dict key to use for storing/retrieving the active Unity instance per session:
+FastMCP stores persistent state under the MCP session ID. MCP for Unity uses
+session-scoped state for authentication and the normal selection, and
+request-scoped state for the effective target of one request:
 
-```
-1. client_id (string, non-empty)  ->  return client_id
-2. ctx.get_state("user_id")       ->  return "user:{user_id}"
-3. fallback                       ->  return "global"
-```
+| State | Scope | Purpose |
+|-------|-------|---------|
+| `user_id` | MCP session | Authenticated identity used to scope remote session discovery |
+| `mcpforunity.active_instance` | MCP session | The instance selected by `set_active_instance` |
+| `unity_instance` | Current request (`serializable=False`) | The resolved target used by one tool call or resource read |
 
-- **`client_id`:** Stable per MCP client connection. Preferred when available.
-- **`user:{user_id}`:** Used in remote-hosted mode when the MCP transport doesn't provide a stable client ID. Ensures different users don't share instance selections.
-- **`"global"`:** Local-dev fallback for single-user scenarios. Unreachable in remote-hosted mode because the auth enforcement raises `RuntimeError` before this point if no `user_id` is available.
+The active selection is isolated by FastMCP's session ID, not by a peer-supplied
+`client_id` and not by a process-global dictionary. An explicit per-call target
+is resolved after authentication and is never written to the active-instance
+state. This allows concurrent requests in one session to target different
+Editors without changing the session default.
+
+In remote-hosted mode, the authenticated `user_id` limits instance discovery
+and selector resolution. The same user's MCP sessions still keep independent
+active selections.
 
 ## Disabled Features in Remote-Hosted Mode
 
@@ -359,5 +374,5 @@ create_mcp_server()
 | `Server/src/services/api_key_service.py` | API key validation singleton with caching and retry |
 | `Server/src/transport/plugin_hub.py` | WebSocket auth gate, user-scoped session queries |
 | `Server/src/transport/plugin_registry.py` | Dual-index session storage (local + user-scoped) |
-| `Server/src/transport/unity_instance_middleware.py` | Per-request user_id and instance injection |
+| `Server/src/transport/unity_instance_middleware.py` | User-scoped discovery, session active-instance state, and request-local effective-target injection |
 | `Server/src/transport/unity_transport.py` | `_resolve_user_id_from_request` helper |

--- a/website/docs/guides/multi-instance.md
+++ b/website/docs/guides/multi-instance.md
@@ -3,12 +3,14 @@ id: multi-instance
 slug: /guides/multi-instance
 title: Multi-Instance Routing
 sidebar_label: Multi-Instance Routing
-description: Drive several Unity Editors from a single MCP session with set_active_instance and per-call routing.
+description: Drive several Unity Editors from a single MCP session with an active instance and optional per-call routing.
 ---
 
 # Multi-Instance Routing
 
-You can have several Unity Editors open at once and aim a single MCP session at any of them.
+MCP for Unity can drive several connected Unity Editors from one MCP session.
+The normal workflow is active-instance based: select an Editor once, then omit routing
+parameters from ordinary tool calls and resource reads.
 
 ## When this comes up
 
@@ -17,66 +19,145 @@ You can have several Unity Editors open at once and aim a single MCP session at 
 - You have a runtime project + a tooling project both connected
 - You're driving a CI fixture project alongside your day-to-day work
 
-## How instances are identified
+## Instance identifiers
 
-Each connected Unity Editor advertises a stable ID of the form `Name@hash`, where:
-
-- `Name` is the project's `productName` from Player Settings
-- `hash` is a stable 8-character hash derived from the project path
-
-Example: `MyGame@a1b2c3d4`.
-
-You can also reference an instance by:
-
-- **Hash prefix** (e.g. `a1b` if it's unambiguous)
-- **Port number** — stdio transport only
-
-## Discovering instances
-
-Read the resource:
+Read the discovery resource before selecting an instance:
 
 > `mcpforunity://instances`
 
-It returns the list of currently connected Editors with their `Name@hash`, project path, transport, and port. Most MCP clients expose this as the `unity_instances` resource.
+Each entry contains an `id` in the form `Name@hash`, where `Name` is derived
+from the project directory name and `hash` identifies the project path.
+Selectors support:
 
-## Setting the active instance for the session
+- An exact `Name@hash` ID, which is the recommended form
+- A unique hash prefix
+- A port number in stdio mode only
 
-```
+Invalid or ambiguous explicit selectors fail instead of falling back to the
+active or default instance.
+
+## Set the active instance
+
+```text
 set_active_instance(instance="MyGame@a1b2c3d4")
 ```
 
-Once set, **every subsequent tool call** in the session routes to that instance until you change it. This is the most common pattern: choose once, then prompt normally.
+The active instance is stored in the current MCP session. Subsequent targetable
+tools and Unity-backed resources use it until the session changes it. This is
+the recommended pattern for normal work.
 
-You can also use:
+You can also use a unique hash prefix or, in stdio mode, a port:
 
-```
-set_active_instance(instance="a1b")         # hash prefix
-set_active_instance(instance="6401")        # port number (stdio only)
-```
-
-## Routing a single call without changing the session default
-
-Pass `unity_instance` on the individual tool call:
-
-```
-manage_scene(action="get_hierarchy", unity_instance="MyGame@a1b2c3d4")
+```text
+set_active_instance(instance="a1b")
+set_active_instance(instance="6401")
 ```
 
-This is useful for comparing two projects in the same prompt — e.g., "Read the same script from both projects and tell me what differs."
+## Route one tool call
 
-The server accepts the same value formats as `set_active_instance`: `Name@hash`, hash prefix, or (stdio) port number.
+Targetable tools expose an optional `unity_instance` parameter in `tools/list`.
+It is an advanced override and is normally omitted:
 
-## What happens with no active instance
+```text
+manage_scene(
+  action="get_hierarchy",
+  unity_instance="OtherProject@f6e7d8c9"
+)
+```
 
-- **One Unity Editor connected** → it's used automatically.
-- **Multiple Editors connected and no active set** → the server errors with the available instance list. Call `set_active_instance` and retry.
+The override applies only to this call. It does not update the active instance
+or affect later calls. Project-scoped custom tools use the same contract through
+`execute_custom_tool`.
 
-## HTTP vs stdio differences
+Server-only tools such as `set_active_instance`, `manage_tools`, and
+`debug_request_context` do not expose this routing parameter because their
+behavior is not a Unity Editor operation.
 
-- **HTTP**: instance state is keyed per-session by `client_id`, so two MCP clients can target different Editors at the same time on the same Python server.
-- **Stdio**: port-number shorthand works because there's a separate Python process per client. HTTP shares one process and uses `Name@hash` exclusively.
+## Route one resource read
+
+MCP resource reads do not have tool arguments. Unity-backed resources therefore
+advertise an RFC 6570 query form through `resources/templates/list`:
+
+```text
+mcpforunity://editor/state{?unity_instance}
+```
+
+Expand it as a normal URI query. URL-encoding `@` is recommended:
+
+```text
+mcpforunity://editor/state?unity_instance=OtherProject%40f6e7d8c9
+```
+
+Existing resource URIs remain valid. Parameterized resources keep their
+business query parameters in the same template. For example:
+
+```text
+mcpforunity://scene/gameobject/123/components?page_size=5&cursor=0&include_properties=false&unity_instance=OtherProject%40f6e7d8c9
+```
+
+Inspect both `resources/list` and `resources/templates/list`: concrete default
+resources remain discoverable through the former, while parameterized and
+per-call forms are advertised through the latter.
+
+The discovery and server-only resources `unity_instances`, `tool_groups`,
+`gameobject_api`, and `prefab_api` do not expose per-call targeting.
+
+## Routing priority and compatibility
+
+Targetable MCP calls resolve their effective instance in this order:
+
+1. Explicit per-call `unity_instance`
+2. The MCP session's active instance
+3. The server's existing auto/default behavior
+
+When `unity_instance` is omitted, existing behavior is unchanged. A sole local
+Editor can still be auto-selected; multiple Editors with no active selection
+still produce the existing selection error.
+
+## Concurrent calls
+
+Per-call routing is request-local, not session state. Calls in the same MCP
+session can overlap while targeting different Editors, including Tool/Tool,
+Resource/Resource, and Tool/Resource combinations. An explicit override can
+also run alongside an unqualified call that uses the active instance.
+
+Completion, errors, timeouts, and cancellation cannot write the override back to
+the active instance or leak it into a later request.
+
+## Local HTTP REST API
+
+The local REST endpoints use request-local routing as well. They do not use the
+MCP session's active instance.
+
+For `POST /api/command`, put `unity_instance` at the request envelope's top
+level. It must not appear inside the Unity command `params`:
+
+```json
+{
+  "type": "manage_scene",
+  "unity_instance": "OtherProject@f6e7d8c9",
+  "params": {
+    "action": "get_active"
+  }
+}
+```
+
+For project-scoped tool discovery, use the historical query name:
+
+```text
+GET /api/custom-tools?instance=OtherProject%40f6e7d8c9
+```
+
+These local REST routes are disabled in remote-hosted mode.
+
+## HTTP and stdio
+
+- **HTTP MCP:** active selection is isolated by the FastMCP session ID. Multiple sessions can hold different active instances on one Python server.
+- **stdio MCP:** one server process normally belongs to one client session. Port-number selectors are available because local Editor port discovery exists.
+- **Remote-hosted HTTP:** instance discovery and selector resolution are scoped to the authenticated user. Auto-selection is disabled, so set an active instance or provide an explicit per-call selector.
 
 ## Related reference
 
 - [`set_active_instance`](/reference/tools/core/set_active_instance) — full tool reference
 - [`unity_instances` resource](/reference/resources) — discovery surface
+- [Transport Modes](/architecture/transports)

--- a/website/docs/reference/tools/core/manage_material.md
+++ b/website/docs/reference/tools/core/manage_material.md
@@ -23,7 +23,7 @@ Manages Unity materials (set properties, colors, shaders, etc). Read-only action
 | `property` | `str \| None` | — | Shader property name (e.g., _BaseColor, _MainTex) |
 | `shader` | `str \| None` | — | Shader name (default: Standard) |
 | `properties` | `dict[str, Any] \| str \| None` | — | Initial properties to set as {name: value} dict. |
-| `value` | `list \| float \| int \| str \| bool \| None` | — | Value to set (color array, float, texture path/instruction) |
+| `value` | `list[Any] \| float \| int \| str \| bool \| None` | — | Value to set (color array, float, texture path/instruction) |
 | `color` | `list[float] \| dict[str, float] \| str \| None` | — | Color as [r, g, b] or [r, g, b, a] array, {r, g, b, a} object, or JSON string. |
 | `target` | `str \| None` | — | Target GameObject (name, path, or find instruction) |
 | `search_method` | `Literal['by_id', 'by_name', 'by_path', 'by_tag', 'by_layer', 'by_component'] \| None` | — | Search method for target |

--- a/website/docs/reference/tools/vfx/manage_texture.md
+++ b/website/docs/reference/tools/vfx/manage_texture.md
@@ -33,7 +33,7 @@ Procedural texture generation for Unity. Creates textures with solid fills, patt
 | `noise_scale` | `float \| None` | — | Noise scale/frequency (default: 0.1) |
 | `octaves` | `int \| None` | — | Number of noise octaves for detail (default: 1) |
 | `set_pixels` | `dict[Any] \| None` | — | Region to modify: {x, y, width, height, color or pixels} |
-| `as_sprite` | `dict \| bool \| None` | — | Configure as sprite: {pivot: [x,y], pixels_per_unit: 100} or true for defaults |
+| `as_sprite` | `dict[Any] \| bool \| None` | — | Configure as sprite: {pivot: [x,y], pixels_per_unit: 100} or true for defaults |
 | `import_settings` | `dict[Any] \| None` | — | TextureImporter settings dict. Keys: texture_type (default/normal_map/sprite/etc), texture_shape (2d/cube), srgb (bool), alpha_source (none/from_input/from_gray_scale), alpha_is_transparency (bool), readable (bool), generate_mipmaps (bool), wrap_mode/wrap_mode_u/wrap_mode_v (repeat/clamp/mirror/mirror_once), filter_mode (point/bilinear/trilinear), aniso_level (0-16), max_texture_size (32-16384), compression (none/low_quality/normal_quality/high_quality), compression_quality (0-100), sprite_mode (single/multiple/polygon), sprite_pixels_per_unit, sprite_pivot, sprite_mesh_type (full_rect/tight), sprite_extrude (0-32) |
 
 ## Returns


### PR DESCRIPTION
## Description

This PR adds per-call Unity Editor instance targeting in the Python transport layer. The normal session-scoped active instance remains the recommended workflow; an explicit selector is an optional override for one call. We do need this feature for concurrent agent workflows in our practical development.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## What

- Add request-local per-call Unity instance routing for HTTP `/api/command`, HTTP `/api/custom-tools?instance=...`, targetable MCP Tools, and Unity-backed MCP Resources.
- Resolve explicit targets before active/default routing, with the priority `per-call target > session active instance > existing beta auto/default behavior`.
- Keep active-instance state session-scoped and keep per-call effective routing request-scoped, so explicit targets do not persist or cross-contaminate concurrent calls.
- Consume routing metadata in the Python middleware before FastMCP validation or Resource dispatch. Unity command `params` remain unchanged.
- Preserve the existing selector forms and no-target behavior, including `Name@hash`, unique hash prefixes, stdio port selectors, HTTP numeric hashes, active selection, single-instance auto-selection, and the existing REST fallback behavior.
- Keep `batch_execute` inner-command routing out of the Unity payload.

No Unity C# production code, `Command` model, WebSocket execute envelope, or `HandleCommand(JObject @params)` signature was changed. This change adds routing logic on the Python side only.

## Why

In practical development, multiple Agents frequently work concurrently against multiple Unity Editors and/or separate repository copies. A session-wide active instance is useful for normal work, but it cannot safely express overlapping calls that must go to different Editors. A request-local explicit target provides atomic per-call routing without switching or mutating the session default.

## Compatibility / Package Source

- Unity version tested: Unity `6000.0.75f1`.
- Package source used: local `file:` reference to the current working tree's `MCPForUnity` package.
- Two temporary projects (`Alpha` and `Beta`) imported and compiled the package successfully.
- No Unity C# production files are changed by this PR.

## Testing / Screenshots / Recordings

- [x] Python tests: `Server\.venv\Scripts\python.exe -m pytest tests/ -q` (`1351 passed, 3 skipped, 3 warnings`).
- [ ] Unity EditMode tests (not run; this change does not modify Unity C# production code).
- [ ] Unity PlayMode tests (not run; this change does not modify Unity C# production code).
- [x] Package import/compile check.
- [x] Real local two-Editor HTTP/WebSocket E2E.

The E2E used one local Python Server, two real Unity Editor processes, and one FastMCP Client with one MCP session. It verified:

- HTTP `/api/command` and `/api/custom-tools?instance=...` targeting A/B and overlapping HTTP calls.
- MCP Tool and Unity-backed Resource targeting A/B concurrently in the same MCP session.
- Explicit Beta calls leaving an active Alpha fallback unchanged.
- Invalid selectors failing without falling back to another instance.
- Project-root and active-scene identities returned by the two Editors remaining distinguishable.

The repository's documented `uv run --frozen pytest` invocation was also attempted but could not start because of the local uv trampoline error (`uv trampoline failed to canonicalize script path`); the full suite passed through the repository virtualenv invocation above.

## Documentation Updates

- [x] I have added/removed/modified tools or resources.
- [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` was not used.
- [x] The related multi-instance and remote-auth documentation changes were manually reviewed.

## Related Issues

None.

## Additional Notes

This is one implementation generated by GPT 5.6 Luna Max. It works well in the tested scenario, and I would appreciate maintainers' review, feedback, and suggestions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-call Unity instance targeting for tools, resources, and HTTP commands.
  * Added clearer instance selection using names, hashes, and supported transport-specific selectors.
  * Targetable tools and resources now advertise the `unity_instance` routing option.
  * Added request-scoped routing to support concurrent calls without instance-selection leakage.

* **Bug Fixes**
  * Explicitly targeted instances no longer silently fall back after disconnects.
  * Improved validation and error responses for invalid or ambiguous selectors.

* **Documentation**
  * Updated multi-instance, remote authentication, and tool reference documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->