### PR TITLE
fix: Claude Code registrations invisible to CheckStatus (duplicate path-variant keys, git worktrees)

### DIFF
--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -1370,13 +1370,24 @@ namespace MCPForUnity.Editor.Clients
                 if (projects == null)
                     return (null, null);
 
-                // Build a dictionary of normalized paths for quick lookup
-                // Use last entry for duplicates (forward/backslash variants) as it's typically more recent
+                // Build a dictionary of normalized paths for quick lookup.
+                // Duplicate keys (forward/backslash variants of the same path)
+                // are merged by preferring the entry that actually carries a
+                // UnityMCP registration: JSON property order is not correlated
+                // with recency across variants, so blind last-entry-wins lets a
+                // stale variant without mcpServers shadow a real registration
+                // and CheckStatus reports NotConfigured despite a working
+                // `claude mcp add --scope local` setup.
                 var normalizedProjects = new Dictionary<string, JObject>(StringComparer.OrdinalIgnoreCase);
                 foreach (var project in projects.Properties())
                 {
                     string normalizedPath = NormalizePath(project.Name);
-                    normalizedProjects[normalizedPath] = project.Value as JObject;
+                    var value = project.Value as JObject;
+                    if (!normalizedProjects.TryGetValue(normalizedPath, out var existing)
+                        || RegistrationRank(value) >= RegistrationRank(existing))
+                    {
+                        normalizedProjects[normalizedPath] = value;
+                    }
                 }
 
                 // Walk up the directory tree to find a matching project config
@@ -1415,6 +1426,21 @@ namespace MCPForUnity.Editor.Clients
             {
                 return (null, $"Error reading user Claude config: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Ranks a ~/.claude.json project entry for duplicate-key merging:
+        /// 2 = has a UnityMCP registration, 1 = has other mcpServers, 0 = none.
+        /// </summary>
+        private static int RegistrationRank(JObject projectConfig)
+        {
+            if (!(projectConfig?["mcpServers"] is JObject servers)) return 0;
+            foreach (var server in servers.Properties())
+            {
+                if (string.Equals(server.Name, "UnityMCP", StringComparison.OrdinalIgnoreCase))
+                    return 2;
+            }
+            return servers.HasValues ? 1 : 0;
         }
 
         /// <summary>

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -1393,31 +1393,21 @@ namespace MCPForUnity.Editor.Clients
                 // Walk up the directory tree to find a matching project config
                 // Claude Code may be configured at a parent directory (e.g., repo root)
                 // while Unity project is in a subdirectory (e.g., TestProjects/UnityMCPTests)
-                string currentDir = NormalizePath(projectDir);
-                while (!string.IsNullOrEmpty(currentDir))
-                {
-                    if (normalizedProjects.TryGetValue(currentDir, out var projectConfig))
-                    {
-                        var mcpServers = projectConfig?["mcpServers"] as JObject;
-                        if (mcpServers != null)
-                        {
-                            foreach (var server in mcpServers.Properties())
-                            {
-                                if (string.Equals(server.Name, "UnityMCP", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    return (server.Value as JObject, null);
-                                }
-                            }
-                        }
-                        // Found the project but no UnityMCP - don't continue walking up
-                        return (null, null);
-                    }
+                var fromProjectDir = FindUnityServerFromWalk(normalizedProjects, NormalizePath(projectDir));
+                if (fromProjectDir != null)
+                    return (fromProjectDir, null);
 
-                    // Move up one directory
-                    int lastSlash = currentDir.LastIndexOf('/');
-                    if (lastSlash <= 0)
-                        break;
-                    currentDir = currentDir.Substring(0, lastSlash);
+                // `claude mcp add --scope local` keys the registration by the
+                // git MAIN repo root. When the Unity project lives in a linked
+                // worktree, that root is a sibling path the ancestor walk above
+                // can never reach — retry from the parsed main root.
+                string mainRoot = GetGitMainRepoRoot(projectDir);
+                if (!string.IsNullOrEmpty(mainRoot)
+                    && !string.Equals(mainRoot, NormalizePath(projectDir), StringComparison.OrdinalIgnoreCase))
+                {
+                    var fromMainRoot = FindUnityServerFromWalk(normalizedProjects, mainRoot);
+                    if (fromMainRoot != null)
+                        return (fromMainRoot, null);
                 }
 
                 return (null, null);
@@ -1426,6 +1416,65 @@ namespace MCPForUnity.Editor.Clients
             {
                 return (null, $"Error reading user Claude config: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Walks up from startDir (normalized) looking for a project entry with
+        /// a UnityMCP registration. Stops at the first project entry found even
+        /// if it lacks UnityMCP (a configured project boundary).
+        /// </summary>
+        private static JObject FindUnityServerFromWalk(Dictionary<string, JObject> normalizedProjects, string startDir)
+        {
+            string currentDir = startDir;
+            while (!string.IsNullOrEmpty(currentDir))
+            {
+                if (normalizedProjects.TryGetValue(currentDir, out var projectConfig))
+                {
+                    var mcpServers = projectConfig?["mcpServers"] as JObject;
+                    if (mcpServers != null)
+                    {
+                        foreach (var server in mcpServers.Properties())
+                        {
+                            if (string.Equals(server.Name, "UnityMCP", StringComparison.OrdinalIgnoreCase))
+                            {
+                                return server.Value as JObject;
+                            }
+                        }
+                    }
+                    // Found the project but no UnityMCP - don't continue walking up
+                    return null;
+                }
+
+                // Move up one directory
+                int lastSlash = currentDir.LastIndexOf('/');
+                if (lastSlash <= 0)
+                    break;
+                currentDir = currentDir.Substring(0, lastSlash);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// For a linked git worktree, the main repo root parsed from the .git
+        /// pointer file ("gitdir: &lt;root&gt;/.git/worktrees/&lt;name&gt;"),
+        /// normalized. Null for a regular checkout (.git directory) or
+        /// anything unparseable.
+        /// </summary>
+        private static string GetGitMainRepoRoot(string dir)
+        {
+            try
+            {
+                string gitPath = Path.Combine(dir, ".git");
+                if (!File.Exists(gitPath)) return null;
+                string line = File.ReadAllText(gitPath).Trim();
+                if (!line.StartsWith("gitdir:", StringComparison.OrdinalIgnoreCase)) return null;
+                string gitDir = line.Substring("gitdir:".Length).Trim();
+                if (!Path.IsPathRooted(gitDir)) gitDir = Path.Combine(dir, gitDir);
+                gitDir = NormalizePath(Path.GetFullPath(gitDir));
+                int i = gitDir.LastIndexOf("/.git/", StringComparison.OrdinalIgnoreCase);
+                return i > 0 ? gitDir.Substring(0, i) : null;
+            }
+            catch { return null; }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Using claude multi-agent, I often have worktrees open in Unity while also having changes to a branch. In these circumstances, `ReadUserScopeConfig` can report `NotConfigured` for a working `claude mcp add --scope local` registration — `claude mcp list` shows UnityMCP Connected, but the MCP for Unity window says Claude Code isn't configured. Two independent causes, both observed live on Windows 11 on 2026-07-20:

1. **Duplicate path-variant keys shadow the real registration.** `~/.claude.json` accumulates duplicate `projects` keys for the same directory in different separator forms (`D:/Dev/X` vs `D:\Dev\X`). The reader merges duplicates last-entry-wins on the assumption the last is most recent, but JSON property order is not correlated with recency across variants — a stale variant without `mcpServers` can shadow the real entry.
2. **Git-worktree projects register under an unreachable key.** `claude mcp add --scope local` keys the registration by the git **main repo root**. For a Unity project in a linked worktree (e.g. `C:/Dev/stay-booping` → repo `C:/Dev/stay`) that key is a *sibling* path, so the reader's ancestor walk can never reach it. The CLI resolves worktrees symmetrically, so the registration genuinely works — only the status check is blind.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made
All in `MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs`:

- Merge duplicate normalized project keys by preferring the entry that actually carries a UnityMCP registration (new `RegistrationRank`: UnityMCP > any `mcpServers` > none; last-wins preserved among equal ranks).
- After the ancestor walk finds nothing, parse the main repo root from a linked worktree's `.git` pointer file (`gitdir: <root>/.git/worktrees/<name>`, relative paths resolved) and retry the walk from there (new `GetGitMainRepoRoot`). Regular checkouts (`.git` directory) are unaffected.
- The walk itself is extracted into `FindUnityServerFromWalk` so both starting points share it; existing semantics preserved, including "stop at the first project entry found even without UnityMCP".

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f2 and 6000.4.1f1 (both editors running simultaneously against one local HTTP server)
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `https://github.com/conjoyco/unity-mcp.git?path=/MCPForUnity#v10.1.0-conjoyco.1` (branch `fix/claude-config-key-matching`, cut from `v10.1.0`)
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): `2d00ed2e877fdeb103fa64e3b0ed72f5c112a857`

## Testing/Screenshots/Recordings
- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

Live verification against both original failures (details in Additional Notes):
- Worktree: `CheckStatus` on the worktree project returned `NotConfigured` before the patch and `Configured` after, with identical inputs (`claude mcp list` Connected throughout).
- Duplicate keys: deliberately re-injected the observed failure configuration (stale backslash-variant key with empty `mcpServers` ordered *after* the real forward-slash key) — patched reader still reports `Configured`. No regression on a project with a single clean key.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

## Related Issues
Relates to #664 (the `--scope local` registration path this reader parses).

## Additional Notes
- Changes are C#-only in the Claude config reader; Python server untouched, hence no Python tests. No EditMode coverage exists for this path today — happy to add a small test for `RegistrationRank`/`GetGitMainRepoRoot` if you'd like it as part of this PR.
- Branch is cut from `v10.1.0`; happy to rebase onto `beta` if preferred — both commits are self-contained in one file and should cherry-pick cleanly.
- Both failure modes arise naturally on Windows: separator-variant duplicates accumulate from tools writing `~/.claude.json` with different cwd string forms, and worktree-based Unity projects are common in multi-branch workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent identity tracking for commands and test runs.
  * Added resources to view connected agents and the current agent lease.
  * Added tools to check, acquire, and release advisory leases for state-changing Editor operations.
  * Added structured access-control responses when commands are denied.

* **Bug Fixes**
  * Improved Claude CLI configuration discovery when duplicate project entries exist.
  * Improved Unity MCP detection for linked Git worktrees and nested project directories.
  * Added more reliable project configuration precedence and fallback lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->