### PR TITLE
fix: prevent Windows stdio socket inheritance

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using MCPForUnity.Editor.Constants;
@@ -62,6 +63,16 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         private static readonly Stopwatch _uptime = Stopwatch.StartNew();
         private static volatile int _consecutiveTimeouts = 0;
         private static bool _processCommandsHooked = false;
+#if UNITY_EDITOR_WIN
+        private const uint HandleFlagInherit = 0x00000001;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetHandleInformation(
+            IntPtr handle,
+            uint mask,
+            uint flags);
+#endif
 
         private static void IoInfo(string s) { McpLog.Info(s, always: false); }
 
@@ -370,25 +381,44 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
             }
         }
 
-        private static TcpListener CreateConfiguredListener(int port)
+        internal static TcpListener CreateConfiguredListener(int port)
         {
             var newListener = new TcpListener(IPAddress.Loopback, port);
-#if UNITY_EDITOR_OSX
-            // SO_REUSEADDR is intentionally NOT set. On macOS it allows multiple
-            // processes (including AssetImportWorkers) to bind the same port,
-            // causing connections to land on a worker that can't process commands.
-            // The ExclusiveAddressUse flag prevents this; port-busy conflicts are
-            // handled by the retry/fallback logic in Start() and the reload handler.
-            try { newListener.Server.ExclusiveAddressUse = true; } catch { }
-#endif
             try
             {
-                newListener.Server.LingerState = new LingerOption(true, 0);
+#if UNITY_EDITOR_WIN
+                if (!SetHandleInformation(
+                    newListener.Server.Handle,
+                    HandleFlagInherit,
+                    0))
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+                    throw new SocketException(errorCode);
+                }
+#endif
+#if UNITY_EDITOR_OSX
+                // SO_REUSEADDR is intentionally NOT set. On macOS it allows multiple
+                // processes (including AssetImportWorkers) to bind the same port,
+                // causing connections to land on a worker that can't process commands.
+                // The ExclusiveAddressUse flag prevents this; port-busy conflicts are
+                // handled by the retry/fallback logic in Start() and the reload handler.
+                try { newListener.Server.ExclusiveAddressUse = true; } catch { }
+#endif
+                try
+                {
+                    newListener.Server.LingerState = new LingerOption(true, 0);
+                }
+                catch (Exception)
+                {
+                }
+                return newListener;
             }
-            catch (Exception)
+            catch
             {
+                try { newListener.Stop(); } catch { }
+                try { newListener.Server?.Dispose(); } catch { }
+                throw;
             }
-            return newListener;
         }
 
         public static void Stop()

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Transport/StdioBridgeHostTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Transport/StdioBridgeHostTests.cs
@@ -1,0 +1,45 @@
+#if UNITY_EDITOR_WIN
+using System;
+using System.ComponentModel;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using MCPForUnity.Editor.Services.Transport.Transports;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.Transport
+{
+    public class StdioBridgeHostTests
+    {
+        private const uint HandleFlagInherit = 0x00000001;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetHandleInformation(
+            IntPtr handle,
+            out uint flags);
+
+        [Test]
+        public void CreateConfiguredListener_ClearsHandleInheritance()
+        {
+            TcpListener listener = StdioBridgeHost.CreateConfiguredListener(0);
+            try
+            {
+                bool queried = GetHandleInformation(listener.Server.Handle, out uint flags);
+                int errorCode = queried ? 0 : Marshal.GetLastWin32Error();
+
+                Assert.IsTrue(
+                    queried,
+                    $"GetHandleInformation failed: {new Win32Exception(errorCode).Message}");
+                Assert.AreEqual(
+                    0u,
+                    flags & HandleFlagInherit,
+                    "The stdio listener socket must not be inherited by child processes.");
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+    }
+}
+#endif

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Transport/StdioBridgeHostTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Transport/StdioBridgeHostTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c7de9f0c63a405c8f99bc0582f8bd39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Description

Prevent the Windows stdio bridge listener socket from being inherited by child processes launched from the Unity Editor. This avoids stale listeners remaining alive in processes such as VS Code after a domain reload or Editor shutdown, which previously forced the bridge to fall back from port 6400 to 6401.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Clear HANDLE_FLAG_INHERIT on the Windows TcpListener socket before it starts listening.
- Surface SetHandleInformation failures as SocketException and dispose unpublished listeners safely.
- Add a Windows EditMode regression test that checks the production listener factory with GetHandleInformation.
- Preserve the existing macOS exclusive-address and cross-platform listener behavior.

## Compatibility / Package Source

- Unity version(s) tested: Tuanjie 2022.3.62t11 on Windows 11 (Unity 2022.3-compatible)
- Package source used (beta, main, tag, branch, or file): local file checkout from this branch in MyGame
- Resolved commit hash from Packages/packages-lock.json (if using a Git package URL): not applicable (file source)

## Testing/Screenshots/Recordings

- [x] Python tests (cd Server && uv run pytest tests/ -v): 1330 passed, 3 skipped
- [ ] Unity EditMode tests: regression test added, but the upstream UnityMCPTests project was not opened during validation
- [ ] Unity PlayMode tests
- [x] Package import/compile check: MyGame compiled and reconnected with 0 MCP errors/warnings
- [ ] Not applicable (explain why in Additional Notes)

Runtime regression in MyGame:

- Started VS Code from the Editor after port 6400 was listening.
- Kept VS Code running across two forced script/domain reloads.
- Verified each new listener handle had inheritance flags = 0.
- Verified only the current Editor owned port 6400 after each reload; port 6401 was never used.

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at tools/UPDATE_DOCS_PROMPT.md (recommended)
  - [ ] Manual review of the generated changes

No tool or resource surface changed.

## Related Issues

None.

## Additional Notes

The failure was caused by Windows socket-handle inheritance, not by the stdio server process itself. Clearing the inheritance bit immediately after socket creation prevents child processes from retaining the listener through Editor teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows TCP listener configuration to prevent unintended handle inheritance.
  - Enhanced listener cleanup when setup encounters an error, reducing the risk of lingering resources.

- **Tests**
  - Added Windows-specific coverage to verify listener handles are created with inheritance disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->