### PR TITLE
feat(asset-gen): register MiniMax image provider in the image tool chain

### DIFF
--- a/MCPForUnity/Editor/Security/SecureKeyStore/SecureKeyStoreConstants.cs
+++ b/MCPForUnity/Editor/Security/SecureKeyStore/SecureKeyStoreConstants.cs
@@ -9,7 +9,7 @@ namespace MCPForUnity.Editor.Security
         /// <summary>Known asset-generation provider ids (lowercase).</summary>
         internal static readonly string[] ProviderIds =
         {
-            "tripo", "meshy", "sketchfab", "fal", "openrouter"
+            "tripo", "meshy", "sketchfab", "fal", "openrouter", "minimax", "minimax"
         };
     }
 }

--- a/MCPForUnity/Editor/Security/SecureKeyStore/SecureKeyStoreConstants.cs
+++ b/MCPForUnity/Editor/Security/SecureKeyStore/SecureKeyStoreConstants.cs
@@ -9,7 +9,7 @@ namespace MCPForUnity.Editor.Security
         /// <summary>Known asset-generation provider ids (lowercase).</summary>
         internal static readonly string[] ProviderIds =
         {
-            "tripo", "meshy", "sketchfab", "fal", "openrouter", "minimax", "minimax"
+            "tripo", "meshy", "sketchfab", "fal", "openrouter", "minimax"
         };
     }
 }

--- a/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/AssetGenModelCatalog.cs
@@ -53,6 +53,10 @@ namespace MCPForUnity.Editor.Services.AssetGen
             // Image — openrouter
             new ModelEntry { Id = OpenRouterAdapter.DefaultModel, Label = "Gemini 2.5 Flash Image", Provider = "openrouter", Kind = "image", UseCase = "General image" },
 
+            // Image — minimax (MiniMaxImageAdapter.DefaultModel is first => the default)
+            new ModelEntry { Id = MiniMaxImageAdapter.DefaultModel, Label = "MiniMax image-01", Provider = "minimax", Kind = "image", UseCase = "General image" },
+            new ModelEntry { Id = "image-01-live", Label = "MiniMax image-01-live", Provider = "minimax", Kind = "image", UseCase = "Live image" },
+
             // 3D — tripo / meshy (defaults reference the adapter constants)
             new ModelEntry { Id = TripoAdapter.ModelVersion, Label = "Tripo v3.1", Provider = "tripo", Kind = "model", UseCase = "Text / image -> 3D" },
             new ModelEntry { Id = "P1-20260311", Label = "Tripo P1 (premium)", Provider = "tripo", Kind = "model", UseCase = "Premium 3D" },

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/AssetGenProviders.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/AssetGenProviders.cs
@@ -33,6 +33,8 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                     return new FalAdapter();
                 case "openrouter":
                     return new OpenRouterAdapter();
+                case "minimax":
+                    return new MiniMaxImageAdapter();
                 default:
                     throw new NotSupportedException($"Unknown image provider '{id}'.");
             }
@@ -69,6 +71,7 @@ namespace MCPForUnity.Editor.Services.AssetGen.Providers
                 new ProviderInfo { Id = "sketchfab", Kind = "marketplace", Configured = IsConfigured("sketchfab"), Capabilities = new[] { "search", "import" } },
                 new ProviderInfo { Id = "fal", Kind = "image", Configured = IsConfigured("fal"), Capabilities = new[] { "text", "image" } },
                 new ProviderInfo { Id = "openrouter", Kind = "image", Configured = IsConfigured("openrouter"), Capabilities = new[] { "text", "image" } },
+                new ProviderInfo { Id = "minimax", Kind = "image", Configured = IsConfigured("minimax"), Capabilities = new[] { "text", "image" } },
                 // fal appears twice by design — once per kind (image + audio) — sharing the single "fal" key.
                 new ProviderInfo { Id = "fal", Kind = "audio", Configured = IsConfigured("fal"), Capabilities = new[] { "text", "music", "sfx" } },
             };

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/MiniMaxImageAdapter.cs
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/MiniMaxImageAdapter.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MCPForUnity.Editor.Security;
+using MCPForUnity.Editor.Services.AssetGen.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MCPForUnity.Editor.Services.AssetGen.Providers
+{
+    /// <summary>
+    /// MiniMax 2D image provider via the synchronous <c>/v1/image_generation</c> endpoint. Text→image
+    /// submits a prompt; image→image attaches a <c>subject_reference</c> (a hosted URL or an inline
+    /// base64 data URI for a local image_path). The image is returned inline (base64) or as a URL the
+    /// job manager downloads, so all work happens in <see cref="SubmitAsync"/> and
+    /// <see cref="PollAsync"/> returns the captured result immediately. One adapter instance handles a
+    /// single job (the job manager captures it for submit+poll).
+    /// </summary>
+    public sealed class MiniMaxImageAdapter : IImageProviderAdapter
+    {
+        private const string Endpoint = "https://api.minimax.io/v1/image_generation";
+        private const string Host = "api.minimax.io";
+        // internal so the model catalog references it directly (single source of truth, drift-guarded).
+        internal const string DefaultModel = "image-01";
+
+        public string Id => "minimax";
+
+        private byte[] _inlineData;
+        private string _downloadUrl;
+        private string _error;
+
+        public async Task<string> SubmitAsync(ImageGenRequest req, string apiKey, IHttpTransport http, CancellationToken ct)
+        {
+            if (req == null) throw new ArgumentNullException(nameof(req));
+            if (http == null) throw new ArgumentNullException(nameof(http));
+
+            string model = string.IsNullOrEmpty(req.Model) ? DefaultModel : req.Model;
+
+            var body = new JObject
+            {
+                ["model"] = model,
+                ["prompt"] = req.Prompt ?? string.Empty
+            };
+
+            // image→image: attach the reference image as a subject_reference entry. image_file accepts
+            // a hosted URL or an inline base64 data URI (for a local image_path). Plain text→image
+            // sends prompt only.
+            bool image = string.Equals(req.Mode, "image", StringComparison.OrdinalIgnoreCase)
+                         && (!string.IsNullOrEmpty(req.ImageUrl) || !string.IsNullOrEmpty(req.ImagePath));
+            if (image)
+            {
+                string imageRef = !string.IsNullOrEmpty(req.ImageUrl) ? req.ImageUrl : LocalImage.ToDataUri(req.ImagePath);
+                body["subject_reference"] = new JArray(
+                    new JObject { ["type"] = "character", ["image_file"] = imageRef });
+            }
+
+            // Forward explicit output dimensions for text→image only; the provider accepts a
+            // {width,height} pair. (image→image derives size from the subject reference.)
+            if (!image && req.Width > 0 && req.Height > 0)
+            {
+                body["width"] = req.Width;
+                body["height"] = req.Height;
+            }
+
+            ProviderHttp.RequireHost(Endpoint, Host, apiKey, "minimax submit");
+
+            var spec = new HttpRequestSpec
+            {
+                Method = "POST",
+                Url = Endpoint,
+                ContentType = "application/json",
+                Body = Encoding.UTF8.GetBytes(body.ToString(Formatting.None))
+            };
+            spec.Headers["Authorization"] = "Bearer " + apiKey;
+
+            HttpResult res = await http.SendAsync(spec, ct);
+            JObject json = ParseOk(res, apiKey);
+
+            // Prefer a URL result (default response_format=url); fall back to inline base64.
+            string url = ExtractImageUrl(json);
+            if (!string.IsNullOrEmpty(url))
+            {
+                _downloadUrl = url;
+            }
+            else
+            {
+                string b64 = ExtractImageBase64(json);
+                if (!string.IsNullOrEmpty(b64))
+                {
+                    try { _inlineData = Convert.FromBase64String(b64); }
+                    catch { _error = "MiniMax returned an image payload that was not valid base64."; }
+                }
+                else
+                {
+                    _error = "MiniMax returned no image. The selected model may not support image output.";
+                }
+            }
+            return "ready";
+        }
+
+        public Task<ProviderPollResult> PollAsync(string providerJobId, string apiKey, IHttpTransport http, CancellationToken ct)
+        {
+            var result = new ProviderPollResult { Progress = 1f };
+            if (!string.IsNullOrEmpty(_error) || (_inlineData == null && string.IsNullOrEmpty(_downloadUrl)))
+            {
+                result.State = ProviderPollState.Failed;
+                result.Error = _error ?? "MiniMax produced no image.";
+            }
+            else
+            {
+                result.State = ProviderPollState.Succeeded;
+                result.InlineData = _inlineData;
+                result.DownloadUrl = _downloadUrl;
+            }
+            return Task.FromResult(result);
+        }
+
+        private static string ExtractImageUrl(JObject json)
+            => (json["data"]?["image_urls"] as JArray)?[0]?.ToString();
+
+        private static string ExtractImageBase64(JObject json)
+            => (json["data"]?["image_base64"] as JArray)?[0]?.ToString();
+
+        private static JObject ParseOk(HttpResult res, string apiKey)
+        {
+            string text = ProviderHttp.BodyText(res);
+
+            JObject json = null;
+            if (!string.IsNullOrEmpty(text))
+            {
+                try { json = JObject.Parse(text); } catch { /* non-JSON */ }
+            }
+
+            bool ok = res?.Ok == true;
+            // MiniMax signals failure with a non-zero base_resp.status_code even on HTTP 200.
+            int status = json?["base_resp"]?["status_code"]?.Type == JTokenType.Integer
+                ? (int)json["base_resp"]["status_code"]
+                : 0;
+            if (!ok || status != 0)
+            {
+                string detail = json?["base_resp"]?["status_msg"]?.ToString()
+                                ?? json?["error"]?["message"]?.ToString()
+                                ?? json?["error"]?.ToString()
+                                ?? ProviderHttp.Truncate(text);
+                throw new Exception(SecretRedactor.Scrub(
+                    $"MiniMax request failed (status={res?.Status}, base_resp.status_code={status}): {detail}", apiKey));
+            }
+            return json ?? new JObject();
+        }
+    }
+}

--- a/MCPForUnity/Editor/Services/AssetGen/Providers/MiniMaxImageAdapter.cs.meta
+++ b/MCPForUnity/Editor/Services/AssetGen/Providers/MiniMaxImageAdapter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e3c1a9b4d2e4f0a8b6c5d7e9f1a2b3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Tools/AssetGen/GenerateImage.cs
+++ b/MCPForUnity/Editor/Tools/AssetGen/GenerateImage.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 namespace MCPForUnity.Editor.Tools.AssetGen
 {
     /// <summary>
-    /// 2D image generation via an aggregator (fal.ai / OpenRouter). Triggered here (never from the
+    /// 2D image generation via an aggregator (fal.ai / OpenRouter / MiniMax). Triggered here (never from the
     /// GUI); the C# side reads the provider key from the secure store and runs the job. Returns a
     /// job_id immediately; the client polls the `status` action. Status / cancel / list_providers are
     /// shared across the generate_* tools via <see cref="AssetGenToolHelpers"/>.

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
@@ -34,6 +34,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         {
             ("fal", "fal"),
             ("openrouter", "OpenRouter"),
+            ("minimax", "MiniMax"),
         };
 
         // UI Elements

--- a/Server/src/cli/commands/asset_gen.py
+++ b/Server/src/cli/commands/asset_gen.py
@@ -146,7 +146,7 @@ def import_model_file(source_path, name, output_folder, target_size, animation_t
 
 
 @asset_gen.command("generate-image")
-@click.option("--provider", default=None, help="Provider id (fal, openrouter).")
+@click.option("--provider", default=None, help="Provider id (fal, openrouter, minimax).")
 @click.option("--mode", default=None, help="Generation mode: text or image.")
 @click.option("--prompt", default=None, help="Text prompt for text->image.")
 @click.option("--image-path", default=None, help="Source image path for image->image.")

--- a/Server/src/services/tools/generate_image.py
+++ b/Server/src/services/tools/generate_image.py
@@ -19,7 +19,7 @@ from transport.legacy.unity_connection import async_send_command_with_retry
 @mcp_for_unity_tool(
     group="asset_gen",
     description=(
-        "Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as "
+        "Generate 2D images with AI providers (fal.ai, OpenRouter, MiniMax) and import them as "
         "textures/sprites into the Unity project. Bring-your-own-key: provider keys live "
         "in the editor's secure store and never cross the bridge.\n\n"
         "ACTIONS:\n"
@@ -42,7 +42,7 @@ async def generate_image(
     action: Annotated[Literal["generate", "remove_background", "status", "cancel", "list_providers"],
                       "Action to perform."],
 
-    provider: Annotated[str, "Provider id (fal, openrouter)."] | None = None,
+    provider: Annotated[str, "Provider id (fal, openrouter, minimax)."] | None = None,
     mode: Annotated[str, "Generation mode: text or image."] | None = None,
     prompt: Annotated[str, "Text prompt for text->image."] | None = None,
     image_path: Annotated[str, "Path to a source image for image->image mode."] | None = None,

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/AssetGenModelCatalogTests.cs
@@ -67,6 +67,7 @@ namespace MCPForUnityTests.Editor.AssetGen
             Assert.AreEqual("fal-ai/stable-audio-25/text-to-audio", AssetGenModelCatalog.DefaultModelId("fal", "audio"));
             Assert.AreEqual("v3.1-20260211", AssetGenModelCatalog.DefaultModelId("tripo", "model"));
             Assert.AreEqual("meshy-6", AssetGenModelCatalog.DefaultModelId("meshy", "model"));
+            Assert.AreEqual("image-01", AssetGenModelCatalog.DefaultModelId("minimax", "image"));
             Assert.IsNull(AssetGenModelCatalog.DefaultModelId("nope", "audio"), "unknown provider => null, not a throw");
         }
 
@@ -79,6 +80,7 @@ namespace MCPForUnityTests.Editor.AssetGen
             Assert.AreEqual(TripoAdapter.ModelVersion, AssetGenModelCatalog.DefaultModelId("tripo", "model"));
             Assert.AreEqual(MeshyAdapter.DefaultModel, AssetGenModelCatalog.DefaultModelId("meshy", "model"));
             Assert.AreEqual(FalAdapter.DefaultModel, AssetGenModelCatalog.DefaultModelId("fal", "image"));
+            Assert.AreEqual(MiniMaxImageAdapter.DefaultModel, AssetGenModelCatalog.DefaultModelId("minimax", "image"));
             Assert.AreEqual(FalAudioAdapter.DefaultModel, AssetGenModelCatalog.DefaultModelId("fal", "audio"));
         }
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateImageTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/GenerateImageTests.cs
@@ -25,6 +25,7 @@ namespace MCPForUnityTests.Editor.AssetGen
             AssetGenJobManager.ResetForTests();
             Environment.SetEnvironmentVariable("MCPFORUNITY_FAL_API_KEY", null);
             Environment.SetEnvironmentVariable("MCPFORUNITY_OPENROUTER_API_KEY", null);
+            Environment.SetEnvironmentVariable("MCPFORUNITY_MINIMAX_API_KEY", null);
             _dir = Path.Combine(Path.GetTempPath(), "mcp_imghandler_" + Guid.NewGuid().ToString("N"));
             _store = new EncryptedFileKeyStore(_dir);
             SecureKeyStore.OverrideForTests(_store);
@@ -69,6 +70,20 @@ namespace MCPForUnityTests.Editor.AssetGen
         {
             _store.Set("fal", "falkey");
             JObject gen = Call(new JObject { ["action"] = "generate", ["provider"] = "fal", ["mode"] = "text", ["prompt"] = "a cat" });
+            Assert.AreEqual("pending", (string)gen["_mcp_status"]);
+            Assert.IsFalse(string.IsNullOrEmpty((string)gen["data"]["job_id"]));
+        }
+
+        [Test]
+        public void Generate_MiniMax_WithKey_ReturnsPendingJobId()
+        {
+            _store.Set("minimax", "mmkey");
+            AssetGenJobManager.TransportOverrideForTests = new FakeHttpTransport
+            {
+                Handler = spec => new HttpResult { Status = 200, IsSuccess = true,
+                    Text = "{\"data\":{\"image_urls\":[\"https://cdn.minimax.io/img/x.png\"]},\"base_resp\":{\"status_code\":0}}" }
+            };
+            JObject gen = Call(new JObject { ["action"] = "generate", ["provider"] = "minimax", ["mode"] = "text", ["prompt"] = "a cat" });
             Assert.AreEqual("pending", (string)gen["_mcp_status"]);
             Assert.IsFalse(string.IsNullOrEmpty((string)gen["data"]["job_id"]));
         }
@@ -136,6 +151,7 @@ namespace MCPForUnityTests.Editor.AssetGen
             string s = resp.ToString();
             StringAssert.Contains("fal", s);
             StringAssert.Contains("openrouter", s);
+            StringAssert.Contains("minimax", s);
             StringAssert.DoesNotContain("tripo", s); // model providers excluded
         }
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/MiniMaxImageAdapterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/MiniMaxImageAdapterTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.IO;
+using System.Threading;
+using MCPForUnity.Editor.Services.AssetGen.Http;
+using MCPForUnity.Editor.Services.AssetGen.Providers;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace MCPForUnityTests.Editor.AssetGen
+{
+    public class MiniMaxImageAdapterTests
+    {
+        private static string ProjectRoot()
+        {
+            string dp = Application.dataPath.Replace('\\', '/');
+            return dp.Substring(0, dp.Length - "Assets".Length);
+        }
+
+        private static string WriteProjectFile(string rel, byte[] bytes)
+        {
+            string abs = Path.Combine(ProjectRoot(), rel).Replace('\\', '/');
+            Directory.CreateDirectory(Path.GetDirectoryName(abs));
+            File.WriteAllBytes(abs, bytes);
+            return rel;
+        }
+
+        private static HttpResult Json(string body) => new HttpResult { Status = 200, IsSuccess = true, Text = body };
+
+        [Test]
+        public void Submit_TextMode_PostsToImageGeneration_WithBearerKey()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"data\":{\"image_urls\":[\"https://cdn.minimax.io/img/x.png\"]},\"metadata\":{\"success_count\":\"1\",\"failed_count\":\"0\"},\"base_resp\":{\"status_code\":0}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "text", Prompt = "a cat" };
+
+            string pid = adapter.SubmitAsync(req, "mmkey123", fake, CancellationToken.None).GetAwaiter().GetResult();
+            Assert.AreEqual("ready", pid);
+
+            HttpRequestSpec sent = fake.RecordedRequests[0];
+            Assert.AreEqual("POST", sent.Method);
+            StringAssert.Contains("image_generation", sent.Url);
+            StringAssert.Contains("api.minimax.io", sent.Url);
+            StringAssert.StartsWith("Bearer ", sent.Headers["Authorization"]);
+
+            string body = System.Text.Encoding.UTF8.GetString(sent.Body);
+            StringAssert.Contains("\"model\":\"image-01\"", body);
+            StringAssert.Contains("\"prompt\":\"a cat\"", body);
+            // No subject_reference for plain text->image.
+            StringAssert.DoesNotContain("subject_reference", body);
+        }
+
+        [Test]
+        public void Submit_ExplicitModel_OverridesDefault()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"data\":{\"image_urls\":[\"https://cdn.minimax.io/img/y.png\"]},\"base_resp\":{\"status_code\":0}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "text", Prompt = "a dog", Model = "image-01-live" };
+
+            adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = System.Text.Encoding.UTF8.GetString(fake.RecordedRequests[0].Body);
+            StringAssert.Contains("\"model\":\"image-01-live\"", body);
+        }
+
+        [Test]
+        public void Submit_TextMode_ForwardsWidthAndHeight()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"data\":{\"image_urls\":[\"https://cdn.minimax.io/img/z.png\"]},\"base_resp\":{\"status_code\":0}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "text", Prompt = "a cat", Width = 768, Height = 1024 };
+
+            adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = System.Text.Encoding.UTF8.GetString(fake.RecordedRequests[0].Body);
+            StringAssert.Contains("\"width\":768", body);
+            StringAssert.Contains("\"height\":1024", body);
+        }
+
+        [Test]
+        public void Submit_ImageMode_IncludesSubjectReferenceWithUrl()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"data\":{\"image_urls\":[\"https://cdn.minimax.io/img/r.png\"]},\"base_resp\":{\"status_code\":0}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "image", Prompt = "make it watercolor", ImageUrl = "https://ex.com/in.png" };
+
+            adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            string body = System.Text.Encoding.UTF8.GetString(fake.RecordedRequests[0].Body);
+            StringAssert.Contains("subject_reference", body);
+            StringAssert.Contains("\"type\":\"character\"", body);
+            StringAssert.Contains("\"image_file\":\"https://ex.com/in.png\"", body);
+        }
+
+        [Test]
+        public void Submit_ImageMode_LocalPath_SendsDataUri()
+        {
+            string rel = WriteProjectFile("Assets/Generated/__assetgen_minimax_adapter/ref.png", new byte[] { 137, 80, 78, 71 });
+            try
+            {
+                var fake = new FakeHttpTransport
+                {
+                    Handler = spec => Json("{\"data\":{\"image_urls\":[\"https://cdn.minimax.io/img/r.png\"]},\"base_resp\":{\"status_code\":0}}")
+                };
+                var adapter = new MiniMaxImageAdapter();
+                var req = new ImageGenRequest { Provider = "minimax", Mode = "image", Prompt = "watercolor", ImagePath = rel };
+
+                adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+                string body = System.Text.Encoding.UTF8.GetString(fake.RecordedRequests[0].Body);
+                StringAssert.Contains("subject_reference", body);
+                StringAssert.Contains("data:image/png;base64,", body);
+            }
+            finally { try { Directory.Delete(Path.Combine(ProjectRoot(), "Assets/Generated/__assetgen_minimax_adapter"), true); } catch { } }
+        }
+
+        [Test]
+        public void Submit_Then_Poll_ReturnsDownloadUrl()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"data\":{\"image_urls\":[\"https://cdn.minimax.io/img/dl.png\"]},\"base_resp\":{\"status_code\":0}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "text", Prompt = "a cat" };
+
+            string pid = adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+            ProviderPollResult pr = adapter.PollAsync(pid, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Succeeded, pr.State);
+            Assert.AreEqual("https://cdn.minimax.io/img/dl.png", pr.DownloadUrl);
+        }
+
+        [Test]
+        public void Submit_Base64Response_PollReturnsInlineBytes()
+        {
+            byte[] expected = { 5, 6, 7, 8 };
+            string b64 = Convert.ToBase64String(expected);
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"data\":{\"image_base64\":[\"" + b64 + "\"]},\"base_resp\":{\"status_code\":0}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "text", Prompt = "a cat" };
+
+            string pid = adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+            ProviderPollResult pr = adapter.PollAsync(pid, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Succeeded, pr.State);
+            CollectionAssert.AreEqual(expected, pr.InlineData);
+        }
+
+        [Test]
+        public void Submit_NoImage_PollFails()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"data\":{},\"base_resp\":{\"status_code\":0}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "text", Prompt = "a cat" };
+
+            adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+            ProviderPollResult pr = adapter.PollAsync("ready", "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual(ProviderPollState.Failed, pr.State);
+            Assert.IsNotEmpty(pr.Error);
+        }
+
+        [Test]
+        public void Submit_NonZeroBaseRespStatus_Throws()
+        {
+            var fake = new FakeHttpTransport
+            {
+                Handler = spec => Json("{\"base_resp\":{\"status_code\":1001,\"status_msg\":\"invalid prompt\"}}")
+            };
+            var adapter = new MiniMaxImageAdapter();
+            var req = new ImageGenRequest { Provider = "minimax", Mode = "text", Prompt = "a cat" };
+
+            Exception ex = Assert.Throws<Exception>(() =>
+                adapter.SubmitAsync(req, "mmkey", fake, CancellationToken.None).GetAwaiter().GetResult());
+            StringAssert.Contains("MiniMax", ex.Message);
+            StringAssert.Contains("1001", ex.Message);
+            // The key must not leak into the thrown message.
+            StringAssert.DoesNotContain("mmkey", ex.Message);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/MiniMaxImageAdapterTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/MiniMaxImageAdapterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f2a3b4c5d6e4f0a8b6c7d8e9f0a1b2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/asset-gen-manual-verification.md
+++ b/docs/asset-gen-manual-verification.md
@@ -38,6 +38,14 @@ genuine provider keys and an interactive Editor before shipping.
 - [ ] `generate_image(provider=openrouter, prompt="...")`.
 - [ ] Confirm the inline-image path works (image bytes decode and import as a sprite).
 
+## MiniMax (2D image)
+
+- [ ] Enter the MiniMax key.
+- [ ] `generate_image(provider=minimax, prompt="...")`.
+- [ ] Confirm the returned image URL downloads and imports as a sprite.
+- [ ] `generate_image(provider=minimax, mode=image, image_url=..., prompt="...")`
+      → confirm the subject reference influences the result.
+
 ## Sketchfab (3D import)
 
 - [ ] Enter the Sketchfab token.

--- a/website/docs/reference/tools/asset_gen/generate_image.md
+++ b/website/docs/reference/tools/asset_gen/generate_image.md
@@ -1,7 +1,7 @@
 ---
 title: generate_image
 sidebar_label: generate_image
-description: "Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project."
+description: "Generate 2D images with AI providers (fal.ai, OpenRouter, MiniMax) and import them as textures/sprites into the Unity project."
 ---
 
 # `generate_image`
@@ -12,7 +12,7 @@ description: "Generate 2D images with AI providers (fal.ai, OpenRouter) and impo
 
 ## Description
 
-Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project. Bring-your-own-key: provider keys live in the editor's secure store and never cross the bridge.
+Generate 2D images with AI providers (fal.ai, OpenRouter, MiniMax) and import them as textures/sprites into the Unity project. Bring-your-own-key: provider keys live in the editor's secure store and never cross the bridge.
 
 ACTIONS:
 - generate: Submit an image job (text->image or image->image). Returns { job_id }; poll with the status action. Params: provider, mode (text|image), prompt, image_path|image_url, model, transparent, width, height, name, output_folder.
@@ -26,7 +26,7 @@ ACTIONS:
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `action` | `Literal['generate', 'remove_background', 'status', 'cancel', 'list_providers']` | yes | Action to perform. |
-| `provider` | `str \| None` | — | Provider id (fal, openrouter). |
+| `provider` | `str \| None` | — | Provider id (fal, openrouter, minimax). |
 | `mode` | `str \| None` | — | Generation mode: text or image. |
 | `prompt` | `str \| None` | — | Text prompt for text->image. |
 | `image_path` | `str \| None` | — | Path to a source image for image->image mode. |

--- a/website/docs/reference/tools/asset_gen/index.md
+++ b/website/docs/reference/tools/asset_gen/index.md
@@ -9,7 +9,7 @@ description: "MCP for Unity tools in the asset_gen group."
 AI asset generation – 3D model gen/import, 2D image gen & audio gen (bring-your-own-key)
 
 - **[`generate_audio`](./generate_audio.md)** — Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project.
-- **[`generate_image`](./generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project.
+- **[`generate_image`](./generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter, MiniMax) and import them as textures/sprites into the Unity project.
 - **[`generate_model`](./generate_model.md)** — Generate 3D models with AI providers (Tripo, Meshy) and import them into the Unity project.
 - **[`import_model`](./import_model.md)** — Import 3D models from the Sketchfab marketplace into the Unity project.
 - **[`import_model_file`](./import_model_file.md)** — Import a local 3D model file that already exists on disk (e.g. an FBX/OBJ/glTF exported from Blender or another DCC tool) into the Unity project.

--- a/website/docs/reference/tools/index.md
+++ b/website/docs/reference/tools/index.md
@@ -19,7 +19,7 @@ Animator control & AnimationClip creation
 ## `asset_gen` &nbsp; (5 tools)
 AI asset generation – 3D model gen/import, 2D image gen & audio gen (bring-your-own-key)
 - **[`generate_audio`](./asset_gen/generate_audio.md)** — Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project.
-- **[`generate_image`](./asset_gen/generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project.
+- **[`generate_image`](./asset_gen/generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter, MiniMax) and import them as textures/sprites into the Unity project.
 - **[`generate_model`](./asset_gen/generate_model.md)** — Generate 3D models with AI providers (Tripo, Meshy) and import them into the Unity project.
 - **[`import_model`](./asset_gen/import_model.md)** — Import 3D models from the Sketchfab marketplace into the Unity project.
 - **[`import_model_file`](./asset_gen/import_model_file.md)** — Import a local 3D model file that already exists on disk (e.g. an FBX/OBJ/glTF exported from Blender or another DCC tool) into the Unity project.


### PR DESCRIPTION
Reason: Register the MiniMax image provider in the existing image-generation provider chain.

Changes
- Add `MiniMaxImageAdapter`, a synchronous `IImageProviderAdapter` that calls the MiniMax `POST /v1/image_generation` endpoint with `Bearer` auth. Text→image sends `model` + `prompt` (and optional `width`/`height`); image→image attaches a `subject_reference` entry whose `image_file` accepts a hosted URL or an inline base64 data URI (local `image_path`). Results are read from `data.image_urls` (default `url` format) or `data.image_base64`, and provider-level failures surfaced via `base_resp.status_code` are treated as errors. The endpoint host is re-validated before the key is attached, matching the existing adapters.
- Register `minimax` in `AssetGenProviders.Image(...)` and the `List()` provider table (kind `image`, capabilities `text`/`image`).
- Add the MiniMax image models (`image-01` default, `image-01-live`) to `AssetGenModelCatalog`, with the default referencing `MiniMaxImageAdapter.DefaultModel` so the drift-guard test pins them together.
- Add `minimax` to the secure-store provider id list and the Asset Generation panel image provider rows.
- Surface `minimax` in the Python `generate_image` tool description and the `asset-gen generate-image` CLI `--provider` help text (the Python side remains a thin pass-through; the C# side owns the key and provider call).

Tests
- `MiniMaxImageAdapterTests`: submit/poll for URL and base64 results, image-mode subject_reference (hosted URL + local data URI), no-image failure, and `base_resp.status_code` error handling.
- `AssetGenProvidersTests`: `Image_MiniMax_ReturnsAdapter`.
- `AssetGenModelCatalogTests`: `Curated_HasMiniMaxImageModels` and minimax assertions in the default/drift-guard tests.
- `GenerateImageTests`: `Generate_MiniMax_WithKey_ReturnsPendingJobId`, `minimax` in `ListProviders_ImageOnly`, and the `MCPFORUNITY_MINIMAX_API_KEY` env reset.

Checks run
- `uv run pytest Server/tests/test_asset_gen_image.py` — 10 passed.
- `uv run pytest Server/tests/test_asset_gen_scaffold.py` — 2 passed.
- Unity EditMode tests for the C# adapters/catalog are run by the repo's `unity-tests.yml` CI (requires a Unity license; not runnable in this work environment).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported image-generation provider (including image URLs and inline image data support).
  * Added MiniMax image models to the Asset Generation catalog and exposed it in the Unity 2D Images panel.
  * Updated the asset-gen CLI and asset_gen/generate_image tool to recognize the MiniMax provider.
* **Documentation**
  * Added manual verification steps for MiniMax image generation.
* **Tests**
  * Added/expanded tests for MiniMax requests, polling behavior, subject reference handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->