### PR TITLE
Scope HTTP endpoint and server ownership per project

### DIFF
--- a/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
+++ b/MCPForUnity/Editor/Helpers/CodexConfigHelper.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Services;
 using MCPForUnity.External.Tommy;
-using UnityEditor;
-using UnityEngine;
 
 namespace MCPForUnity.Editor.Helpers
 {
@@ -31,7 +29,7 @@ namespace MCPForUnity.Editor.Helpers
             var unityMCP = new TomlTable();
 
             // Check transport preference
-            bool useHttpTransport = EditorPrefs.GetBool(MCPForUnity.Editor.Constants.EditorPrefKeys.UseHttpTransport, true);
+            bool useHttpTransport = EditorConfigurationCache.Instance.UseHttpTransport;
 
             if (useHttpTransport)
             {
@@ -88,7 +86,7 @@ namespace MCPForUnity.Editor.Helpers
             // Parse existing TOML or create new root table
             var root = TryParseToml(existingToml) ?? new TomlTable();
 
-            bool useHttpTransport = EditorPrefs.GetBool(MCPForUnity.Editor.Constants.EditorPrefKeys.UseHttpTransport, true);
+            bool useHttpTransport = EditorConfigurationCache.Instance.UseHttpTransport;
 
             // Ensure mcp_servers table exists
             if (!root.TryGetNode("mcp_servers", out var mcpServersNode) || !(mcpServersNode is TomlTable))
@@ -186,7 +184,7 @@ namespace MCPForUnity.Editor.Helpers
             var unityMCP = new TomlTable();
 
             // Check transport preference
-            bool useHttpTransport = EditorPrefs.GetBool(MCPForUnity.Editor.Constants.EditorPrefKeys.UseHttpTransport, true);
+            bool useHttpTransport = EditorConfigurationCache.Instance.UseHttpTransport;
 
             if (useHttpTransport)
             {

--- a/MCPForUnity/Editor/Helpers/HttpEndpointUtility.cs
+++ b/MCPForUnity/Editor/Helpers/HttpEndpointUtility.cs
@@ -21,6 +21,7 @@ namespace MCPForUnity.Editor.Helpers
         private const string RemotePrefKey = EditorPrefKeys.HttpRemoteBaseUrl;
         private const string DefaultLocalBaseUrl = "http://127.0.0.1:8080";
         private const string DefaultRemoteBaseUrl = "";
+        private const string LocalBaseUrlEnvironmentVariable = "UNITY_MCP_HTTP_URL";
 
         /// <summary>
         /// Returns the normalized base URL for the currently active HTTP scope.
@@ -28,6 +29,11 @@ namespace MCPForUnity.Editor.Helpers
         /// </summary>
         public static string GetBaseUrl()
         {
+            if (TryGetLocalEnvironmentOverride(out string environmentOverride))
+            {
+                return environmentOverride;
+            }
+
             return IsRemoteScope() ? GetRemoteBaseUrl() : GetLocalBaseUrl();
         }
 
@@ -51,7 +57,12 @@ namespace MCPForUnity.Editor.Helpers
         /// </summary>
         public static string GetLocalBaseUrl()
         {
-            string stored = EditorPrefs.GetString(LocalPrefKey, DefaultLocalBaseUrl);
+            if (TryGetLocalEnvironmentOverride(out string environmentOverride))
+            {
+                return environmentOverride;
+            }
+
+            string stored = ProjectScopedEditorPrefs.GetString(LocalPrefKey, DefaultLocalBaseUrl);
             return NormalizeBaseUrl(stored, DefaultLocalBaseUrl, remoteScope: false);
         }
 
@@ -61,7 +72,7 @@ namespace MCPForUnity.Editor.Helpers
         public static void SaveLocalBaseUrl(string userValue)
         {
             string normalized = NormalizeBaseUrl(userValue, DefaultLocalBaseUrl, remoteScope: false);
-            EditorPrefs.SetString(LocalPrefKey, normalized);
+            ProjectScopedEditorPrefs.SetString(LocalPrefKey, normalized);
         }
 
         /// <summary>
@@ -131,6 +142,11 @@ namespace MCPForUnity.Editor.Helpers
         /// </summary>
         public static bool IsRemoteScope()
         {
+            if (TryGetLocalEnvironmentOverride(out _))
+            {
+                return false;
+            }
+
             string scope = EditorConfigurationCache.Instance.HttpTransportScope;
             return string.Equals(scope, "remote", StringComparison.OrdinalIgnoreCase);
         }
@@ -224,6 +240,13 @@ namespace MCPForUnity.Editor.Helpers
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
             {
                 error = $"Invalid URL: {url}";
+                return false;
+            }
+
+            if (!uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
+                && !uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+            {
+                error = $"Unsupported URL scheme '{uri.Scheme}'. Use http:// or https://.";
                 return false;
             }
 
@@ -348,6 +371,29 @@ namespace MCPForUnity.Editor.Helpers
             }
 
             return trimmed;
+        }
+
+        private static bool TryGetLocalEnvironmentOverride(out string normalized)
+        {
+            string value = Environment.GetEnvironmentVariable(LocalBaseUrlEnvironmentVariable);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                normalized = null;
+                return false;
+            }
+
+            string candidate = NormalizeBaseUrl(
+                value,
+                DefaultLocalBaseUrl,
+                remoteScope: false);
+            if (!IsHttpLocalUrlAllowedForLaunch(candidate, out _))
+            {
+                normalized = null;
+                return false;
+            }
+
+            normalized = candidate;
+            return true;
         }
 
         private static string AppendPathSegment(string baseUrl, string segment)

--- a/MCPForUnity/Editor/Helpers/ProjectIdentityUtility.cs
+++ b/MCPForUnity/Editor/Helpers/ProjectIdentityUtility.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using MCPForUnity.Editor.Constants;
 using UnityEditor;
 using UnityEngine;
@@ -254,6 +256,193 @@ namespace MCPForUnity.Editor.Helpers
             catch
             {
                 return "default";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stores connection and local-server lifecycle preferences per Unity project while
+    /// retaining a single-owner read fallback for legacy machine-global preferences.
+    /// </summary>
+    internal static class ProjectScopedEditorPrefs
+    {
+        private const string MigrationOwnerKey = "MCPForUnity.ProjectScopedPrefs.MigrationOwner";
+        private const string MigrationMutexName = "MCPForUnity.ProjectPreferenceMigration";
+        private static readonly HashSet<string> KnownProjectScopedKeys = new HashSet<string>
+        {
+            EditorPrefKeys.UseHttpTransport,
+            EditorPrefKeys.HttpBaseUrl,
+            EditorPrefKeys.HttpTransportScope,
+            EditorPrefKeys.LastLocalHttpServerPid,
+            EditorPrefKeys.LastLocalHttpServerPort,
+            EditorPrefKeys.LastLocalHttpServerStartedUtc,
+            EditorPrefKeys.LastLocalHttpServerPidArgsHash,
+            EditorPrefKeys.LastLocalHttpServerPidFilePath,
+            EditorPrefKeys.LastLocalHttpServerInstanceToken,
+        };
+
+        internal static string GetKey(string baseKey, string projectHash = null)
+        {
+            string hash = string.IsNullOrWhiteSpace(projectHash)
+                ? ProjectIdentityUtility.GetProjectHash()
+                : projectHash;
+            return $"{baseKey}.{hash}";
+        }
+
+        internal static string GetMigrationOwnerKey()
+        {
+            return MigrationOwnerKey;
+        }
+
+        internal static string ResolveStorageKey(string baseKey, string projectHash = null)
+        {
+            return KnownProjectScopedKeys.Contains(baseKey) ? GetKey(baseKey, projectHash) : baseKey;
+        }
+
+        internal static bool HasKey(string baseKey)
+        {
+            return EditorPrefs.HasKey(ResolveStorageKey(baseKey));
+        }
+
+        internal static bool GetBool(
+            string baseKey,
+            bool defaultValue,
+            string projectHash = null,
+            bool allowLegacyFallback = true)
+        {
+            string scopedKey = ResolveStorageKey(baseKey, projectHash);
+            if (EditorPrefs.HasKey(scopedKey))
+            {
+                return EditorPrefs.GetBool(scopedKey, defaultValue);
+            }
+
+            if (allowLegacyFallback
+                && EditorPrefs.HasKey(baseKey)
+                && TryClaimLegacyPreference(projectHash))
+            {
+                bool migrated = EditorPrefs.GetBool(baseKey, defaultValue);
+                EditorPrefs.SetBool(scopedKey, migrated);
+                return migrated;
+            }
+
+            return defaultValue;
+        }
+
+        internal static int GetInt(
+            string baseKey,
+            int defaultValue,
+            string projectHash = null,
+            bool allowLegacyFallback = true)
+        {
+            string scopedKey = ResolveStorageKey(baseKey, projectHash);
+            if (EditorPrefs.HasKey(scopedKey))
+            {
+                return EditorPrefs.GetInt(scopedKey, defaultValue);
+            }
+
+            if (allowLegacyFallback
+                && EditorPrefs.HasKey(baseKey)
+                && TryClaimLegacyPreference(projectHash))
+            {
+                int migrated = EditorPrefs.GetInt(baseKey, defaultValue);
+                EditorPrefs.SetInt(scopedKey, migrated);
+                return migrated;
+            }
+
+            return defaultValue;
+        }
+
+        internal static string GetString(
+            string baseKey,
+            string defaultValue,
+            string projectHash = null,
+            bool allowLegacyFallback = true)
+        {
+            string scopedKey = ResolveStorageKey(baseKey, projectHash);
+            if (EditorPrefs.HasKey(scopedKey))
+            {
+                return EditorPrefs.GetString(scopedKey, defaultValue);
+            }
+
+            if (allowLegacyFallback
+                && EditorPrefs.HasKey(baseKey)
+                && TryClaimLegacyPreference(projectHash))
+            {
+                string migrated = EditorPrefs.GetString(baseKey, defaultValue);
+                EditorPrefs.SetString(scopedKey, migrated);
+                return migrated;
+            }
+
+            return defaultValue;
+        }
+
+        internal static void SetBool(string baseKey, bool value)
+        {
+            EditorPrefs.SetBool(ResolveStorageKey(baseKey), value);
+        }
+
+        internal static void SetInt(string baseKey, int value)
+        {
+            EditorPrefs.SetInt(ResolveStorageKey(baseKey), value);
+        }
+
+        internal static void SetString(string baseKey, string value)
+        {
+            EditorPrefs.SetString(ResolveStorageKey(baseKey), value);
+        }
+
+        internal static void DeleteKey(string baseKey)
+        {
+            EditorPrefs.DeleteKey(ResolveStorageKey(baseKey));
+        }
+
+        private static bool TryClaimLegacyPreference(string projectHash)
+        {
+            string hash = string.IsNullOrWhiteSpace(projectHash)
+                ? ProjectIdentityUtility.GetProjectHash()
+                : projectHash;
+            string ownerKey = GetMigrationOwnerKey();
+
+            Mutex migrationMutex = null;
+            bool lockTaken = false;
+            try
+            {
+                migrationMutex = new Mutex(false, MigrationMutexName);
+                try
+                {
+                    lockTaken = migrationMutex.WaitOne(TimeSpan.FromSeconds(2));
+                }
+                catch (AbandonedMutexException)
+                {
+                    lockTaken = true;
+                }
+
+                if (!lockTaken)
+                {
+                    return false;
+                }
+
+                string owner = EditorPrefs.GetString(ownerKey, string.Empty);
+                if (string.IsNullOrEmpty(owner))
+                {
+                    EditorPrefs.SetString(ownerKey, hash);
+                    owner = EditorPrefs.GetString(ownerKey, string.Empty);
+                }
+
+                return string.Equals(owner, hash, StringComparison.Ordinal);
+            }
+            catch
+            {
+                return false;
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    try { migrationMutex.ReleaseMutex(); } catch { }
+                }
+
+                migrationMutex?.Dispose();
             }
         }
     }

--- a/MCPForUnity/Editor/McpCiBoot.cs
+++ b/MCPForUnity/Editor/McpCiBoot.cs
@@ -1,7 +1,6 @@
 using System;
-using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Services;
 using MCPForUnity.Editor.Services.Transport.Transports;
-using UnityEditor;
 
 namespace MCPForUnity.Editor
 {
@@ -11,7 +10,7 @@ namespace MCPForUnity.Editor
         {
             try 
             { 
-                EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false); 
+                EditorConfigurationCache.Instance.SetUseHttpTransport(false);
             }
             catch { /* ignore */ }
 

--- a/MCPForUnity/Editor/Services/EditorConfigurationCache.cs
+++ b/MCPForUnity/Editor/Services/EditorConfigurationCache.cs
@@ -1,5 +1,6 @@
 using System;
 using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
 using UnityEditor;
 
 namespace MCPForUnity.Editor.Services
@@ -128,15 +129,29 @@ namespace MCPForUnity.Editor.Services
         /// </summary>
         public void Refresh()
         {
-            _useHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
+            Refresh(allowLegacyFallback: true);
+        }
+
+        internal void Refresh(bool allowLegacyFallback)
+        {
+            _useHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                EditorPrefKeys.UseHttpTransport,
+                true,
+                allowLegacyFallback: allowLegacyFallback);
             _debugLogs = EditorPrefs.GetBool(EditorPrefKeys.DebugLogs, false);
             _devModeForceServerRefresh = EditorPrefs.GetBool(EditorPrefKeys.DevModeForceServerRefresh, false);
             _uvxPathOverride = EditorPrefs.GetString(EditorPrefKeys.UvxPathOverride, string.Empty);
             _gitUrlOverride = EditorPrefs.GetString(EditorPrefKeys.GitUrlOverride, string.Empty);
-            _httpBaseUrl = EditorPrefs.GetString(EditorPrefKeys.HttpBaseUrl, string.Empty);
+            _httpBaseUrl = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpBaseUrl,
+                string.Empty,
+                allowLegacyFallback: allowLegacyFallback);
             _httpRemoteBaseUrl = EditorPrefs.GetString(EditorPrefKeys.HttpRemoteBaseUrl, string.Empty);
             _claudeCliPathOverride = EditorPrefs.GetString(EditorPrefKeys.ClaudeCliPathOverride, string.Empty);
-            _httpTransportScope = EditorPrefs.GetString(EditorPrefKeys.HttpTransportScope, string.Empty);
+            _httpTransportScope = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpTransportScope,
+                string.Empty,
+                allowLegacyFallback: allowLegacyFallback);
             _unitySocketPort = EditorPrefs.GetInt(EditorPrefKeys.UnitySocketPort, 0);
         }
 
@@ -145,10 +160,19 @@ namespace MCPForUnity.Editor.Services
         /// </summary>
         public void SetUseHttpTransport(bool value)
         {
-            if (_useHttpTransport != value)
+            bool changed = _useHttpTransport != value;
+            if (changed)
             {
                 _useHttpTransport = value;
-                EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, value);
+            }
+
+            if (changed || !ProjectScopedEditorPrefs.HasKey(EditorPrefKeys.UseHttpTransport))
+            {
+                ProjectScopedEditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, value);
+            }
+
+            if (changed)
+            {
                 OnConfigurationChanged?.Invoke(nameof(UseHttpTransport));
             }
         }
@@ -213,10 +237,19 @@ namespace MCPForUnity.Editor.Services
         public void SetHttpBaseUrl(string value)
         {
             value = value ?? string.Empty;
-            if (_httpBaseUrl != value)
+            bool changed = _httpBaseUrl != value;
+            if (changed)
             {
                 _httpBaseUrl = value;
-                EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, value);
+            }
+
+            if (changed || !ProjectScopedEditorPrefs.HasKey(EditorPrefKeys.HttpBaseUrl))
+            {
+                ProjectScopedEditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, value);
+            }
+
+            if (changed)
+            {
                 OnConfigurationChanged?.Invoke(nameof(HttpBaseUrl));
             }
         }
@@ -255,10 +288,19 @@ namespace MCPForUnity.Editor.Services
         public void SetHttpTransportScope(string value)
         {
             value = value ?? string.Empty;
-            if (_httpTransportScope != value)
+            bool changed = _httpTransportScope != value;
+            if (changed)
             {
                 _httpTransportScope = value;
-                EditorPrefs.SetString(EditorPrefKeys.HttpTransportScope, value);
+            }
+
+            if (changed || !ProjectScopedEditorPrefs.HasKey(EditorPrefKeys.HttpTransportScope))
+            {
+                ProjectScopedEditorPrefs.SetString(EditorPrefKeys.HttpTransportScope, value);
+            }
+
+            if (changed)
+            {
                 OnConfigurationChanged?.Invoke(nameof(HttpTransportScope));
             }
         }
@@ -285,7 +327,7 @@ namespace MCPForUnity.Editor.Services
             switch (keyName)
             {
                 case nameof(UseHttpTransport):
-                    _useHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
+                    _useHttpTransport = ProjectScopedEditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
                     break;
                 case nameof(DebugLogs):
                     _debugLogs = EditorPrefs.GetBool(EditorPrefKeys.DebugLogs, false);
@@ -300,7 +342,7 @@ namespace MCPForUnity.Editor.Services
                     _gitUrlOverride = EditorPrefs.GetString(EditorPrefKeys.GitUrlOverride, string.Empty);
                     break;
                 case nameof(HttpBaseUrl):
-                    _httpBaseUrl = EditorPrefs.GetString(EditorPrefKeys.HttpBaseUrl, string.Empty);
+                    _httpBaseUrl = ProjectScopedEditorPrefs.GetString(EditorPrefKeys.HttpBaseUrl, string.Empty);
                     break;
                 case nameof(HttpRemoteBaseUrl):
                     _httpRemoteBaseUrl = EditorPrefs.GetString(EditorPrefKeys.HttpRemoteBaseUrl, string.Empty);
@@ -309,7 +351,7 @@ namespace MCPForUnity.Editor.Services
                     _claudeCliPathOverride = EditorPrefs.GetString(EditorPrefKeys.ClaudeCliPathOverride, string.Empty);
                     break;
                 case nameof(HttpTransportScope):
-                    _httpTransportScope = EditorPrefs.GetString(EditorPrefKeys.HttpTransportScope, string.Empty);
+                    _httpTransportScope = ProjectScopedEditorPrefs.GetString(EditorPrefKeys.HttpTransportScope, string.Empty);
                     break;
                 case nameof(UnitySocketPort):
                     _unitySocketPort = EditorPrefs.GetInt(EditorPrefKeys.UnitySocketPort, 0);

--- a/MCPForUnity/Editor/Services/Server/IPidFileManager.cs
+++ b/MCPForUnity/Editor/Services/Server/IPidFileManager.cs
@@ -42,14 +42,14 @@ namespace MCPForUnity.Editor.Services.Server
         void DeletePidFile(string pidFilePath);
 
         /// <summary>
-        /// Stores the handshake information (PID file path and instance token) in EditorPrefs.
+        /// Stores the handshake information (PID file path and instance token) in project-scoped EditorPrefs.
         /// </summary>
         /// <param name="pidFilePath">Path to the PID file</param>
         /// <param name="instanceToken">Unique instance token for the server</param>
         void StoreHandshake(string pidFilePath, string instanceToken);
 
         /// <summary>
-        /// Attempts to retrieve stored handshake information from EditorPrefs.
+        /// Attempts to retrieve stored project-scoped handshake information.
         /// </summary>
         /// <param name="pidFilePath">Output: stored PID file path</param>
         /// <param name="instanceToken">Output: stored instance token</param>
@@ -57,7 +57,7 @@ namespace MCPForUnity.Editor.Services.Server
         bool TryGetHandshake(out string pidFilePath, out string instanceToken);
 
         /// <summary>
-        /// Stores PID tracking information in EditorPrefs.
+        /// Stores PID tracking information in project-scoped EditorPrefs.
         /// </summary>
         /// <param name="pid">The process ID</param>
         /// <param name="port">The port number</param>
@@ -80,7 +80,7 @@ namespace MCPForUnity.Editor.Services.Server
         string GetStoredArgsHash();
 
         /// <summary>
-        /// Clears all PID tracking information from EditorPrefs.
+        /// Clears this project's PID tracking information from EditorPrefs.
         /// </summary>
         void ClearTracking();
 

--- a/MCPForUnity/Editor/Services/Server/PidFileManager.cs
+++ b/MCPForUnity/Editor/Services/Server/PidFileManager.cs
@@ -5,14 +5,14 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using MCPForUnity.Editor.Constants;
-using UnityEditor;
+using MCPForUnity.Editor.Helpers;
 using UnityEngine;
 
 namespace MCPForUnity.Editor.Services.Server
 {
     /// <summary>
     /// Manages PID files and handshake state for the local HTTP server.
-    /// Handles persistence of server process information across Unity domain reloads.
+    /// Handles project-scoped persistence of server process information across Unity domain reloads.
     /// </summary>
     public class PidFileManager : IPidFileManager
     {
@@ -117,7 +117,7 @@ namespace MCPForUnity.Editor.Services.Server
             {
                 if (!string.IsNullOrEmpty(pidFilePath))
                 {
-                    EditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerPidFilePath, pidFilePath);
+                    ProjectScopedEditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerPidFilePath, pidFilePath);
                 }
             }
             catch { }
@@ -126,7 +126,7 @@ namespace MCPForUnity.Editor.Services.Server
             {
                 if (!string.IsNullOrEmpty(instanceToken))
                 {
-                    EditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerInstanceToken, instanceToken);
+                    ProjectScopedEditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerInstanceToken, instanceToken);
                 }
             }
             catch { }
@@ -139,8 +139,14 @@ namespace MCPForUnity.Editor.Services.Server
             instanceToken = null;
             try
             {
-                pidFilePath = EditorPrefs.GetString(EditorPrefKeys.LastLocalHttpServerPidFilePath, string.Empty);
-                instanceToken = EditorPrefs.GetString(EditorPrefKeys.LastLocalHttpServerInstanceToken, string.Empty);
+                pidFilePath = ProjectScopedEditorPrefs.GetString(
+                    EditorPrefKeys.LastLocalHttpServerPidFilePath,
+                    string.Empty,
+                    allowLegacyFallback: false);
+                instanceToken = ProjectScopedEditorPrefs.GetString(
+                    EditorPrefKeys.LastLocalHttpServerInstanceToken,
+                    string.Empty,
+                    allowLegacyFallback: false);
                 if (string.IsNullOrEmpty(pidFilePath) || string.IsNullOrEmpty(instanceToken))
                 {
                     pidFilePath = null;
@@ -160,18 +166,18 @@ namespace MCPForUnity.Editor.Services.Server
         /// <inheritdoc/>
         public void StoreTracking(int pid, int port, string argsHash = null)
         {
-            try { EditorPrefs.SetInt(EditorPrefKeys.LastLocalHttpServerPid, pid); } catch { }
-            try { EditorPrefs.SetInt(EditorPrefKeys.LastLocalHttpServerPort, port); } catch { }
-            try { EditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerStartedUtc, DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)); } catch { }
+            try { ProjectScopedEditorPrefs.SetInt(EditorPrefKeys.LastLocalHttpServerPid, pid); } catch { }
+            try { ProjectScopedEditorPrefs.SetInt(EditorPrefKeys.LastLocalHttpServerPort, port); } catch { }
+            try { ProjectScopedEditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerStartedUtc, DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)); } catch { }
             try
             {
                 if (!string.IsNullOrEmpty(argsHash))
                 {
-                    EditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerPidArgsHash, argsHash);
+                    ProjectScopedEditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerPidArgsHash, argsHash);
                 }
                 else
                 {
-                    EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidArgsHash);
+                    ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidArgsHash);
                 }
             }
             catch { }
@@ -183,9 +189,18 @@ namespace MCPForUnity.Editor.Services.Server
             pid = 0;
             try
             {
-                int storedPid = EditorPrefs.GetInt(EditorPrefKeys.LastLocalHttpServerPid, 0);
-                int storedPort = EditorPrefs.GetInt(EditorPrefKeys.LastLocalHttpServerPort, 0);
-                string storedUtc = EditorPrefs.GetString(EditorPrefKeys.LastLocalHttpServerStartedUtc, string.Empty);
+                int storedPid = ProjectScopedEditorPrefs.GetInt(
+                    EditorPrefKeys.LastLocalHttpServerPid,
+                    0,
+                    allowLegacyFallback: false);
+                int storedPort = ProjectScopedEditorPrefs.GetInt(
+                    EditorPrefKeys.LastLocalHttpServerPort,
+                    0,
+                    allowLegacyFallback: false);
+                string storedUtc = ProjectScopedEditorPrefs.GetString(
+                    EditorPrefKeys.LastLocalHttpServerStartedUtc,
+                    string.Empty,
+                    allowLegacyFallback: false);
 
                 if (storedPid <= 0 || storedPort != expectedPort)
                 {
@@ -217,7 +232,10 @@ namespace MCPForUnity.Editor.Services.Server
         {
             try
             {
-                return EditorPrefs.GetString(EditorPrefKeys.LastLocalHttpServerPidArgsHash, string.Empty);
+                return ProjectScopedEditorPrefs.GetString(
+                    EditorPrefKeys.LastLocalHttpServerPidArgsHash,
+                    string.Empty,
+                    allowLegacyFallback: false);
             }
             catch
             {
@@ -228,12 +246,12 @@ namespace MCPForUnity.Editor.Services.Server
         /// <inheritdoc/>
         public void ClearTracking()
         {
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPid); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPort); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerStartedUtc); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidArgsHash); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidFilePath); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerInstanceToken); } catch { }
+            try { ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPid); } catch { }
+            try { ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPort); } catch { }
+            try { ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerStartedUtc); } catch { }
+            try { ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidArgsHash); } catch { }
+            try { ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidFilePath); } catch { }
+            try { ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerInstanceToken); } catch { }
         }
 
         /// <inheritdoc/>

--- a/MCPForUnity/Editor/Windows/Components/Connection/McpConnectionSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/Connection/McpConnectionSection.cs
@@ -133,13 +133,13 @@ namespace MCPForUnity.Editor.Windows.Components.Connection
             else
             {
                 // Back-compat: if scope pref isn't set yet, infer from current URL.
-                string scope = EditorPrefs.GetString(EditorPrefKeys.HttpTransportScope, string.Empty);
+                string scope = EditorConfigurationCache.Instance.HttpTransportScope;
                 if (string.IsNullOrEmpty(scope))
                 {
                     scope = MCPServiceLocator.Server.IsLocalUrl() ? "local" : "remote";
                     try
                     {
-                        EditorPrefs.SetString(EditorPrefKeys.HttpTransportScope, scope);
+                        EditorConfigurationCache.Instance.SetHttpTransportScope(scope);
                     }
                     catch
                     {

--- a/MCPForUnity/Editor/Windows/EditorPrefs/EditorPrefsWindow.cs
+++ b/MCPForUnity/Editor/Windows/EditorPrefs/EditorPrefsWindow.cs
@@ -212,9 +212,12 @@ namespace MCPForUnity.Editor.Windows
                 // Skip Customer UUID but show everything else that's defined
                 if (key != EditorPrefKeys.CustomerUuid)
                 {
+                    string storageKey = ProjectScopedEditorPrefs.ResolveStorageKey(key);
+
                     // Apply search filter using OrdinalIgnoreCase for fewer allocations
                     if (!string.IsNullOrEmpty(filter) &&
-                        key.IndexOf(filter, StringComparison.OrdinalIgnoreCase) < 0)
+                        key.IndexOf(filter, StringComparison.OrdinalIgnoreCase) < 0 &&
+                        storageKey.IndexOf(filter, StringComparison.OrdinalIgnoreCase) < 0)
                     {
                         continue;
                     }
@@ -244,32 +247,33 @@ namespace MCPForUnity.Editor.Windows
 
         private EditorPrefItem CreateEditorPrefItem(string key)
         {
-            var item = new EditorPrefItem { Key = key, IsKnown = knownMcpKeys.Contains(key) };
+            string storageKey = ProjectScopedEditorPrefs.ResolveStorageKey(key);
+            var item = new EditorPrefItem { Key = storageKey, IsKnown = knownMcpKeys.Contains(key) };
 
             // Check if we know the type of this pref
             if (knownPrefTypes.TryGetValue(key, out var knownType))
             {
                 // Check if the key actually exists
-                item.IsUnset = !EditorPrefs.HasKey(key);
+                item.IsUnset = !EditorPrefs.HasKey(storageKey);
 
                 // Use the known type
                 switch (knownType)
                 {
                     case EditorPrefType.Bool:
                         item.Type = EditorPrefType.Bool;
-                        item.Value = item.IsUnset ? "Unset. Default: False" : EditorPrefs.GetBool(key, false).ToString();
+                        item.Value = item.IsUnset ? "Unset. Default: False" : EditorPrefs.GetBool(storageKey, false).ToString();
                         break;
                     case EditorPrefType.Int:
                         item.Type = EditorPrefType.Int;
-                        item.Value = item.IsUnset ? "Unset. Default: 0" : EditorPrefs.GetInt(key, 0).ToString();
+                        item.Value = item.IsUnset ? "Unset. Default: 0" : EditorPrefs.GetInt(storageKey, 0).ToString();
                         break;
                     case EditorPrefType.Float:
                         item.Type = EditorPrefType.Float;
-                        item.Value = item.IsUnset ? "Unset. Default: 0" : EditorPrefs.GetFloat(key, 0f).ToString();
+                        item.Value = item.IsUnset ? "Unset. Default: 0" : EditorPrefs.GetFloat(storageKey, 0f).ToString();
                         break;
                     case EditorPrefType.String:
                         item.Type = EditorPrefType.String;
-                        item.Value = item.IsUnset ? "Unset. Default: (empty)" : EditorPrefs.GetString(key, "");
+                        item.Value = item.IsUnset ? "Unset. Default: (empty)" : EditorPrefs.GetString(storageKey, "");
                         break;
                 }
             }
@@ -353,15 +357,16 @@ namespace MCPForUnity.Editor.Windows
 
         private void SaveValue(string key, string value, EditorPrefType type)
         {
+            string storageKey = ProjectScopedEditorPrefs.ResolveStorageKey(key);
             switch (type)
             {
                 case EditorPrefType.String:
-                    EditorPrefs.SetString(key, value);
+                    EditorPrefs.SetString(storageKey, value);
                     break;
                 case EditorPrefType.Int:
                     if (int.TryParse(value, out var intValue))
                     {
-                        EditorPrefs.SetInt(key, intValue);
+                        EditorPrefs.SetInt(storageKey, intValue);
                     }
                     else
                     {
@@ -372,7 +377,7 @@ namespace MCPForUnity.Editor.Windows
                 case EditorPrefType.Float:
                     if (float.TryParse(value, out var floatValue))
                     {
-                        EditorPrefs.SetFloat(key, floatValue);
+                        EditorPrefs.SetFloat(storageKey, floatValue);
                     }
                     else
                     {
@@ -383,7 +388,7 @@ namespace MCPForUnity.Editor.Windows
                 case EditorPrefType.Bool:
                     if (bool.TryParse(value, out var boolValue))
                     {
-                        EditorPrefs.SetBool(key, boolValue);
+                        EditorPrefs.SetBool(storageKey, boolValue);
                     }
                     else
                     {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ClientConfigFormatTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ClientConfigFormatTests.cs
@@ -23,26 +23,41 @@ namespace MCPForUnityTests.Editor.Helpers
 
         private bool _hadHttpTransport;
         private bool _originalHttpTransport;
+        private bool _hadHttpTransportScope;
+        private string _originalHttpTransportScope;
 
         [SetUp]
         public void SetUp()
         {
-            _hadHttpTransport = EditorPrefs.HasKey(UseHttpTransportPrefKey);
-            _originalHttpTransport = EditorPrefs.GetBool(UseHttpTransportPrefKey, true);
+            _hadHttpTransport = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(UseHttpTransportPrefKey));
+            _originalHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                UseHttpTransportPrefKey,
+                true,
+                allowLegacyFallback: false);
+            _hadHttpTransportScope = EditorPrefs.HasKey(
+                ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpTransportScope));
+            _originalHttpTransportScope = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpTransportScope,
+                "local",
+                allowLegacyFallback: false);
 
             // Force HTTP transport so the remote/streamableHttp branch is exercised.
-            EditorPrefs.SetBool(UseHttpTransportPrefKey, true);
-            EditorConfigCache.Instance.Refresh();
+            EditorConfigCache.Instance.SetUseHttpTransport(true);
+            EditorConfigCache.Instance.SetHttpTransportScope("local");
         }
 
         [TearDown]
         public void TearDown()
         {
             if (_hadHttpTransport)
-                EditorPrefs.SetBool(UseHttpTransportPrefKey, _originalHttpTransport);
+                EditorConfigCache.Instance.SetUseHttpTransport(_originalHttpTransport);
             else
-                EditorPrefs.DeleteKey(UseHttpTransportPrefKey);
-            EditorConfigCache.Instance.Refresh();
+                ProjectScopedEditorPrefs.DeleteKey(UseHttpTransportPrefKey);
+            if (_hadHttpTransportScope)
+                EditorConfigCache.Instance.SetHttpTransportScope(_originalHttpTransportScope);
+            else
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpTransportScope);
+            EditorConfigCache.Instance.Refresh(allowLegacyFallback: false);
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/CodexConfigHelperTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/CodexConfigHelperTests.cs
@@ -59,6 +59,10 @@ namespace MCPForUnityTests.Editor.Helpers
         private string _originalGitOverride;
         private bool _hadHttpTransport;
         private bool _originalHttpTransport;
+        private string _httpTransportKey;
+        private bool _hadHttpTransportScope;
+        private string _originalHttpTransportScope;
+        private string _httpTransportScopeKey;
         private bool _hadDevForceRefresh;
         private bool _originalDevForceRefresh;
         private IPlatformService _originalPlatformService;
@@ -68,8 +72,18 @@ namespace MCPForUnityTests.Editor.Helpers
         {
             _hadGitOverride = EditorPrefs.HasKey(EditorPrefKeys.GitUrlOverride);
             _originalGitOverride = EditorPrefs.GetString(EditorPrefKeys.GitUrlOverride, string.Empty);
-            _hadHttpTransport = EditorPrefs.HasKey(EditorPrefKeys.UseHttpTransport);
-            _originalHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
+            _httpTransportKey = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.UseHttpTransport);
+            _hadHttpTransport = EditorPrefs.HasKey(_httpTransportKey);
+            _originalHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                EditorPrefKeys.UseHttpTransport,
+                true,
+                allowLegacyFallback: false);
+            _httpTransportScopeKey = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpTransportScope);
+            _hadHttpTransportScope = EditorPrefs.HasKey(_httpTransportScopeKey);
+            _originalHttpTransportScope = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpTransportScope,
+                "local",
+                allowLegacyFallback: false);
             _hadDevForceRefresh = EditorPrefs.HasKey(EditorPrefKeys.DevModeForceServerRefresh);
             _originalDevForceRefresh = EditorPrefs.GetBool(EditorPrefKeys.DevModeForceServerRefresh, false);
             _originalPlatformService = MCPServiceLocator.Platform;
@@ -81,7 +95,8 @@ namespace MCPForUnityTests.Editor.Helpers
             // Ensure per-test deterministic Git URL (ignore developer overrides)
             EditorPrefs.DeleteKey(EditorPrefKeys.GitUrlOverride);
             // Default to stdio mode for existing tests unless specified otherwise
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
+            EditorConfigurationCache.Instance.SetHttpTransportScope("local");
             // Ensure deterministic uvx args ordering for these tests regardless of editor settings
             // (dev-mode inserts --no-cache/--refresh, which changes the first args).
             EditorPrefs.SetBool(EditorPrefKeys.DevModeForceServerRefresh, false);
@@ -122,11 +137,20 @@ namespace MCPForUnityTests.Editor.Helpers
 
             if (_hadHttpTransport)
             {
-                EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, _originalHttpTransport);
+                EditorConfigurationCache.Instance.SetUseHttpTransport(_originalHttpTransport);
             }
             else
             {
-                EditorPrefs.DeleteKey(EditorPrefKeys.UseHttpTransport);
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.UseHttpTransport);
+            }
+
+            if (_hadHttpTransportScope)
+            {
+                EditorConfigurationCache.Instance.SetHttpTransportScope(_originalHttpTransportScope);
+            }
+            else
+            {
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpTransportScope);
             }
 
             if (_hadDevForceRefresh)
@@ -138,6 +162,7 @@ namespace MCPForUnityTests.Editor.Helpers
                 EditorPrefs.DeleteKey(EditorPrefKeys.DevModeForceServerRefresh);
             }
 
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
         }
 
         [Test]
@@ -235,7 +260,7 @@ namespace MCPForUnityTests.Editor.Helpers
             // This test verifies that Windows-specific environment configuration is included in stdio mode
 
             // Force stdio mode
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
 
             // Mock Windows platform
             MCPServiceLocator.Register<IPlatformService>(new MockPlatformService(isWindows: true));
@@ -292,7 +317,7 @@ namespace MCPForUnityTests.Editor.Helpers
             // This test verifies that non-Windows platforms don't include env configuration in stdio mode
 
             // Force stdio mode
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
 
             // Mock non-Windows platform (e.g., macOS/Linux)
             MCPServiceLocator.Register<IPlatformService>(new MockPlatformService(isWindows: false));
@@ -342,7 +367,7 @@ namespace MCPForUnityTests.Editor.Helpers
             // Ensures that upsert operations also include Windows-specific env configuration in stdio mode
 
             // Force stdio mode
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
 
             // Mock Windows platform
             MCPServiceLocator.Register<IPlatformService>(new MockPlatformService(isWindows: true, systemRoot: "C:\\Windows"));
@@ -408,7 +433,7 @@ namespace MCPForUnityTests.Editor.Helpers
             // This test verifies that upsert operations on non-Windows platforms don't include env configuration in stdio mode
 
             // Force stdio mode
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
 
             // Mock non-Windows platform (e.g., macOS/Linux)
             MCPServiceLocator.Register<IPlatformService>(new MockPlatformService(isWindows: false));
@@ -466,7 +491,8 @@ namespace MCPForUnityTests.Editor.Helpers
             // This test verifies HTTP transport mode generates url field instead of command/args
 
             // Force HTTP mode
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            Assert.IsTrue(EditorConfigurationCache.Instance.UseHttpTransport);
 
             string uvPath = "C:\\Program Files\\uv\\uv.exe";
 
@@ -538,7 +564,8 @@ namespace MCPForUnityTests.Editor.Helpers
             // This test verifies HTTP mode upsert generates url field
 
             // Force HTTP mode
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            Assert.IsTrue(EditorConfigurationCache.Instance.UseHttpTransport);
 
             string existingToml = string.Join("\n", new[]
             {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/WriteToConfigTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/WriteToConfigTests.cs
@@ -27,15 +27,29 @@ namespace MCPForUnityTests.Editor.Helpers
         private bool _originalHttpTransport;
         private bool _hadHttpUrl;
         private string _originalHttpUrl;
+        private bool _hadHttpTransportScope;
+        private string _originalHttpTransportScope;
 
         [SetUp]
         public void SetUp()
         {
             // Save original pref values FIRST - TearDown runs even when test is ignored!
-            _hadHttpTransport = EditorPrefs.HasKey(UseHttpTransportPrefKey);
-            _originalHttpTransport = EditorPrefs.GetBool(UseHttpTransportPrefKey, true);
-            _hadHttpUrl = EditorPrefs.HasKey(HttpUrlPrefKey);
-            _originalHttpUrl = EditorPrefs.GetString(HttpUrlPrefKey, "");
+            _hadHttpTransport = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(UseHttpTransportPrefKey));
+            _originalHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                UseHttpTransportPrefKey,
+                true,
+                allowLegacyFallback: false);
+            _hadHttpUrl = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(HttpUrlPrefKey));
+            _originalHttpUrl = ProjectScopedEditorPrefs.GetString(
+                HttpUrlPrefKey,
+                "",
+                allowLegacyFallback: false);
+            _hadHttpTransportScope = EditorPrefs.HasKey(
+                ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpTransportScope));
+            _originalHttpTransportScope = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpTransportScope,
+                "local",
+                allowLegacyFallback: false);
 
             // Tests are designed for Linux/macOS runners. Skip on Windows due to ProcessStartInfo
             // restrictions when UseShellExecute=false for .cmd/.bat scripts.
@@ -64,9 +78,9 @@ namespace MCPForUnityTests.Editor.Helpers
             // Disable auto-registration to avoid hitting user configs during tests
             EditorPrefs.SetBool(EditorPrefKeys.AutoRegisterEnabled, false);
             // Force HTTP transport defaults so expectations match current behavior
-            EditorPrefs.SetBool(UseHttpTransportPrefKey, true);
-            EditorPrefs.SetString(HttpUrlPrefKey, "http://localhost:8080");
-            EditorConfigCache.Instance.Refresh();
+            EditorConfigCache.Instance.SetUseHttpTransport(true);
+            EditorConfigCache.Instance.SetHttpBaseUrl("http://localhost:8080");
+            EditorConfigCache.Instance.SetHttpTransportScope("local");
         }
 
         [TearDown]
@@ -79,14 +93,20 @@ namespace MCPForUnityTests.Editor.Helpers
 
             // Restore original pref values (don't delete if user had them set!)
             if (_hadHttpTransport)
-                EditorPrefs.SetBool(UseHttpTransportPrefKey, _originalHttpTransport);
+                EditorConfigCache.Instance.SetUseHttpTransport(_originalHttpTransport);
             else
-                EditorPrefs.DeleteKey(UseHttpTransportPrefKey);
+                ProjectScopedEditorPrefs.DeleteKey(UseHttpTransportPrefKey);
 
             if (_hadHttpUrl)
-                EditorPrefs.SetString(HttpUrlPrefKey, _originalHttpUrl);
+                EditorConfigCache.Instance.SetHttpBaseUrl(_originalHttpUrl);
             else
-                EditorPrefs.DeleteKey(HttpUrlPrefKey);
+                ProjectScopedEditorPrefs.DeleteKey(HttpUrlPrefKey);
+
+            if (_hadHttpTransportScope)
+                EditorConfigCache.Instance.SetHttpTransportScope(_originalHttpTransportScope);
+            else
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpTransportScope);
+            EditorConfigCache.Instance.Refresh(allowLegacyFallback: false);
 
             // Remove temp files
             try { if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, true); } catch { }
@@ -407,7 +427,7 @@ namespace MCPForUnityTests.Editor.Helpers
 
         private static void AssertTransportConfiguration(JObject unity, McpClient client)
         {
-            bool useHttp = EditorPrefs.GetBool(UseHttpTransportPrefKey, true);
+            bool useHttp = EditorConfigCache.Instance.UseHttpTransport;
             bool isWindsurf = string.Equals(client.HttpUrlProperty, "serverUrl", StringComparison.OrdinalIgnoreCase);
 
             if (useHttp)
@@ -458,17 +478,15 @@ namespace MCPForUnityTests.Editor.Helpers
 
         private static void WithTransportPreference(bool useHttp, Action action)
         {
-            bool original = EditorPrefs.GetBool(UseHttpTransportPrefKey, true);
-            EditorPrefs.SetBool(UseHttpTransportPrefKey, useHttp);
-            EditorConfigCache.Instance.Refresh();
+            bool original = EditorConfigCache.Instance.UseHttpTransport;
+            EditorConfigCache.Instance.SetUseHttpTransport(useHttp);
             try
             {
                 action();
             }
             finally
             {
-                EditorPrefs.SetBool(UseHttpTransportPrefKey, original);
-                EditorConfigCache.Instance.Refresh();
+                EditorConfigCache.Instance.SetUseHttpTransport(original);
             }
         }
     }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Characterization/ServerManagementServiceCharacterizationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Characterization/ServerManagementServiceCharacterizationTests.cs
@@ -23,9 +23,12 @@ namespace MCPForUnityTests.Editor.Services.Characterization
     {
         private ServerManagementService _service;
         private bool _savedUseHttpTransport;
+        private bool _hadUseHttpTransport;
         private string _savedHttpUrl;
+        private bool _hadHttpUrl;
         private string _savedHttpRemoteUrl;
         private string _savedHttpTransportScope;
+        private bool _hadHttpTransportScope;
         private bool _savedAllowLanHttpBind;
         private bool _savedAllowInsecureRemoteHttp;
         private bool _savedLaunchConfirmed;
@@ -36,10 +39,22 @@ namespace MCPForUnityTests.Editor.Services.Characterization
             _service = new ServerManagementService();
             // Save current settings
             _savedLaunchConfirmed = EditorPrefs.GetBool(EditorPrefKeys.HttpServerLaunchConfirmed, false);
-            _savedUseHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
-            _savedHttpUrl = EditorPrefs.GetString(EditorPrefKeys.HttpBaseUrl, string.Empty);
+            _hadUseHttpTransport = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.UseHttpTransport));
+            _savedUseHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                EditorPrefKeys.UseHttpTransport,
+                true,
+                allowLegacyFallback: false);
+            _hadHttpUrl = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpBaseUrl));
+            _savedHttpUrl = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpBaseUrl,
+                string.Empty,
+                allowLegacyFallback: false);
             _savedHttpRemoteUrl = EditorPrefs.GetString(EditorPrefKeys.HttpRemoteBaseUrl, string.Empty);
-            _savedHttpTransportScope = EditorPrefs.GetString(EditorPrefKeys.HttpTransportScope, string.Empty);
+            _hadHttpTransportScope = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpTransportScope));
+            _savedHttpTransportScope = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpTransportScope,
+                string.Empty,
+                allowLegacyFallback: false);
             _savedAllowLanHttpBind = EditorPrefs.GetBool(EditorPrefKeys.AllowLanHttpBind, false);
             _savedAllowInsecureRemoteHttp = EditorPrefs.GetBool(EditorPrefKeys.AllowInsecureRemoteHttp, false);
         }
@@ -48,14 +63,17 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void TearDown()
         {
             // Restore settings
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, _savedUseHttpTransport);
-            if (!string.IsNullOrEmpty(_savedHttpUrl))
+            if (_hadUseHttpTransport)
+                EditorConfigurationCache.Instance.SetUseHttpTransport(_savedUseHttpTransport);
+            else
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.UseHttpTransport);
+            if (_hadHttpUrl)
             {
-                EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, _savedHttpUrl);
+                EditorConfigurationCache.Instance.SetHttpBaseUrl( _savedHttpUrl);
             }
             else
             {
-                EditorPrefs.DeleteKey(EditorPrefKeys.HttpBaseUrl);
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpBaseUrl);
             }
             if (!string.IsNullOrEmpty(_savedHttpRemoteUrl))
             {
@@ -65,19 +83,19 @@ namespace MCPForUnityTests.Editor.Services.Characterization
             {
                 EditorPrefs.DeleteKey(EditorPrefKeys.HttpRemoteBaseUrl);
             }
-            if (!string.IsNullOrEmpty(_savedHttpTransportScope))
+            if (_hadHttpTransportScope)
             {
-                EditorPrefs.SetString(EditorPrefKeys.HttpTransportScope, _savedHttpTransportScope);
+                ProjectScopedEditorPrefs.SetString(EditorPrefKeys.HttpTransportScope, _savedHttpTransportScope);
             }
             else
             {
-                EditorPrefs.DeleteKey(EditorPrefKeys.HttpTransportScope);
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpTransportScope);
             }
             EditorPrefs.SetBool(EditorPrefKeys.AllowLanHttpBind, _savedAllowLanHttpBind);
             EditorPrefs.SetBool(EditorPrefKeys.AllowInsecureRemoteHttp, _savedAllowInsecureRemoteHttp);
             EditorPrefs.SetBool(EditorPrefKeys.HttpServerLaunchConfirmed, _savedLaunchConfirmed);
-            // Refresh cache to reflect restored values
-            EditorConfigurationCache.Instance.Refresh();
+            // Refresh without recreating originally absent scoped keys from legacy prefs.
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
         }
 
         #region StartLocalHttpServer First-Time-Confirm Gating
@@ -176,8 +194,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void StartLocalHttpServer_AlreadyConfirmed_SkipsDialogAndLaunchesHeadless()
         {
             // Arrange - local URL + HTTP enabled + confirmation already given.
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:59998");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:59998");
             EditorPrefs.SetBool(EditorPrefKeys.HttpServerLaunchConfirmed, true);
             EditorConfigurationCache.Instance.Refresh();
 
@@ -206,8 +224,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void StartLocalHttpServer_Quiet_BypassesDialogAndDoesNotSetConfirmedFlag()
         {
             // Arrange - local URL + HTTP enabled + NOT yet confirmed.
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:59997");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:59997");
             EditorPrefs.SetBool(EditorPrefKeys.HttpServerLaunchConfirmed, false);
             EditorConfigurationCache.Instance.Refresh();
 
@@ -235,8 +253,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void StartLocalHttpServer_LaunchesIntoPerPortLaunchLog()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:59996");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:59996");
             EditorPrefs.SetBool(EditorPrefKeys.HttpServerLaunchConfirmed, true);
             EditorConfigurationCache.Instance.Refresh();
 
@@ -268,7 +286,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_Localhost_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -282,7 +300,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_127001_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://127.0.0.1:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://127.0.0.1:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -296,7 +314,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_127002_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://127.0.0.2:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://127.0.0.2:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -310,7 +328,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_0000_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://0.0.0.0:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://0.0.0.0:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -324,7 +342,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_IPv6Loopback_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://[::1]:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://[::1]:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -338,7 +356,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_IPv6LoopbackLongForm_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://[0:0:0:0:0:0:0:1]:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://[0:0:0:0:0:0:0:1]:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -352,7 +370,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_RemoteUrl_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://example.com:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://example.com:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -366,7 +384,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalUrl_EmptyString_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, string.Empty);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl(string.Empty);
             _service = new ServerManagementService();
 
             // Act
@@ -385,8 +403,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void CanStartLocalServer_HttpDisabled_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:8080");
             EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
@@ -401,8 +419,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void CanStartLocalServer_HttpEnabledLocalUrl_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:8080");
             EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
@@ -417,8 +435,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void CanStartLocalServer_HttpEnabledRemoteUrl_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://remote.server.com:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://remote.server.com:8080");
             EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
@@ -433,9 +451,9 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void CanStartLocalServer_HttpEnabledZeroBind_DisallowedByDefault_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
             EditorPrefs.SetBool(EditorPrefKeys.AllowLanHttpBind, false);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://0.0.0.0:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://0.0.0.0:8080");
             EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
@@ -450,9 +468,9 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void CanStartLocalServer_HttpEnabledZeroBind_WithOptIn_ReturnsTrue()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
             EditorPrefs.SetBool(EditorPrefKeys.AllowLanHttpBind, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://0.0.0.0:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://0.0.0.0:8080");
             EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
@@ -547,8 +565,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void TryGetLocalHttpServerCommand_HttpDisabled_ReturnsFalseWithError()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:8080");
             EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
@@ -566,8 +584,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void TryGetLocalHttpServerCommand_RemoteUrl_ReturnsFalseWithError()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://remote.server.com:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://remote.server.com:8080");
             EditorConfigurationCache.Instance.Refresh();
             _service = new ServerManagementService();
 
@@ -585,8 +603,8 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void TryGetLocalHttpServerCommand_LocalUrl_ReturnsCommandOrError()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -615,7 +633,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalHttpServerReachable_NoServer_ReturnsFalse()
         {
             // Arrange - Use a port that's unlikely to have a server running
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:59999");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:59999");
             _service = new ServerManagementService();
 
             // Act
@@ -629,7 +647,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalHttpServerReachable_RemoteUrl_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://remote.server.com:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://remote.server.com:8080");
             _service = new ServerManagementService();
 
             // Act
@@ -660,7 +678,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         public void IsLocalHttpServerRunning_RemoteUrl_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://remote.server.com:8080");
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://remote.server.com:8080");
             _service = new ServerManagementService();
 
             // Act

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Characterization/Services_Characterization.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Characterization/Services_Characterization.cs
@@ -46,7 +46,7 @@ namespace MCPForUnityTests.Editor.Services.Characterization
         }
 
         /// <summary>
-        /// Current behavior: Server metadata is stored in EditorPrefs for persistence
+        /// Current behavior: Server metadata is stored in project-scoped EditorPrefs for persistence
         /// across domain reloads. Keys include LastLocalHttpServerPid, Port, StartedUtc, etc.
         /// </summary>
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/EditorConfigurationCacheTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/EditorConfigurationCacheTests.cs
@@ -1,6 +1,8 @@
+using System;
 using NUnit.Framework;
 using MCPForUnity.Editor.Services;
 using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
 using UnityEditor;
 
 namespace MCPForUnityTests.Editor.Services
@@ -14,6 +16,18 @@ namespace MCPForUnityTests.Editor.Services
         private bool _originalUseHttpTransport;
         private bool _originalDebugLogs;
         private string _originalUvxPath;
+        private string _scopedUseHttpTransportKey;
+        private string _scopedHttpBaseUrlKey;
+        private string _scopedHttpTransportScopeKey;
+        private string _migrationOwnerKey;
+        private bool _hadScopedUseHttpTransport;
+        private bool _originalScopedUseHttpTransport;
+        private bool _hadScopedHttpBaseUrl;
+        private string _originalScopedHttpBaseUrl;
+        private bool _hadScopedHttpTransportScope;
+        private string _originalScopedHttpTransportScope;
+        private bool _hadMigrationOwner;
+        private string _originalMigrationOwner;
 
         [SetUp]
         public void SetUp()
@@ -22,9 +36,26 @@ namespace MCPForUnityTests.Editor.Services
             _originalUseHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
             _originalDebugLogs = EditorPrefs.GetBool(EditorPrefKeys.DebugLogs, false);
             _originalUvxPath = EditorPrefs.GetString(EditorPrefKeys.UvxPathOverride, string.Empty);
+            _scopedUseHttpTransportKey = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.UseHttpTransport);
+            _scopedHttpBaseUrlKey = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpBaseUrl);
+            _scopedHttpTransportScopeKey = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpTransportScope);
+            _migrationOwnerKey = ProjectScopedEditorPrefs.GetMigrationOwnerKey();
+            _hadScopedUseHttpTransport = EditorPrefs.HasKey(_scopedUseHttpTransportKey);
+            _originalScopedUseHttpTransport = EditorPrefs.GetBool(_scopedUseHttpTransportKey, true);
+            _hadScopedHttpBaseUrl = EditorPrefs.HasKey(_scopedHttpBaseUrlKey);
+            _originalScopedHttpBaseUrl = EditorPrefs.GetString(_scopedHttpBaseUrlKey, string.Empty);
+            _hadScopedHttpTransportScope = EditorPrefs.HasKey(_scopedHttpTransportScopeKey);
+            _originalScopedHttpTransportScope = EditorPrefs.GetString(_scopedHttpTransportScopeKey, string.Empty);
+            _hadMigrationOwner = EditorPrefs.HasKey(_migrationOwnerKey);
+            _originalMigrationOwner = EditorPrefs.GetString(_migrationOwnerKey, string.Empty);
+
+            EditorPrefs.DeleteKey(_scopedUseHttpTransportKey);
+            EditorPrefs.DeleteKey(_scopedHttpBaseUrlKey);
+            EditorPrefs.DeleteKey(_scopedHttpTransportScopeKey);
+            EditorPrefs.DeleteKey(_migrationOwnerKey);
 
             // Refresh cache to ensure clean state
-            EditorConfigurationCache.Instance.Refresh();
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
         }
 
         [TearDown]
@@ -34,9 +65,18 @@ namespace MCPForUnityTests.Editor.Services
             EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, _originalUseHttpTransport);
             EditorPrefs.SetBool(EditorPrefKeys.DebugLogs, _originalDebugLogs);
             EditorPrefs.SetString(EditorPrefKeys.UvxPathOverride, _originalUvxPath);
+            RestoreBool(_scopedUseHttpTransportKey, _hadScopedUseHttpTransport, _originalScopedUseHttpTransport);
+            RestoreString(_scopedHttpBaseUrlKey, _hadScopedHttpBaseUrl, _originalScopedHttpBaseUrl);
+            RestoreString(
+                _scopedHttpTransportScopeKey,
+                _hadScopedHttpTransportScope,
+                _originalScopedHttpTransportScope);
+            RestoreString(
+                _migrationOwnerKey,
+                _hadMigrationOwner,
+                _originalMigrationOwner);
 
-            // Refresh cache
-            EditorConfigurationCache.Instance.Refresh();
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
         }
 
         #region Singleton Tests
@@ -64,17 +104,17 @@ namespace MCPForUnityTests.Editor.Services
         #region Read Tests
 
         [Test]
-        public void UseHttpTransport_ReturnsEditorPrefsValue()
+        public void UseHttpTransport_ReturnsProjectScopedEditorPrefsValue()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            ProjectScopedEditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
             EditorConfigurationCache.Instance.Refresh();
 
             // Assert
             Assert.IsTrue(EditorConfigurationCache.Instance.UseHttpTransport);
 
             // Arrange - change value
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            ProjectScopedEditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
             EditorConfigurationCache.Instance.Refresh();
 
             // Assert
@@ -114,6 +154,7 @@ namespace MCPForUnityTests.Editor.Services
             // Arrange
             bool initialValue = EditorConfigurationCache.Instance.UseHttpTransport;
             bool newValue = !initialValue;
+            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, initialValue);
 
             // Act
             EditorConfigurationCache.Instance.SetUseHttpTransport(newValue);
@@ -121,8 +162,264 @@ namespace MCPForUnityTests.Editor.Services
             // Assert - cache is updated
             Assert.AreEqual(newValue, EditorConfigurationCache.Instance.UseHttpTransport);
 
-            // Assert - EditorPrefs is updated
-            Assert.AreEqual(newValue, EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, !newValue));
+            // Assert - only the current project's EditorPrefs value is updated
+            Assert.AreEqual(newValue, EditorPrefs.GetBool(_scopedUseHttpTransportKey, !newValue));
+            Assert.AreEqual(initialValue, EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, !initialValue));
+        }
+
+        [Test]
+        public void ProjectScopedKeys_DifferByProjectHash()
+        {
+            string first = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpBaseUrl, "project-a");
+            string second = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpBaseUrl, "project-b");
+
+            Assert.AreNotEqual(first, second);
+        }
+
+        [Test]
+        public void LegacyPreference_ClaimedByOneProjectOnly()
+        {
+            const string baseKey = EditorPrefKeys.HttpBaseUrl;
+            string firstProject = $"test-project-a-{Guid.NewGuid():N}";
+            string secondProject = $"test-project-b-{Guid.NewGuid():N}";
+            string firstKey = ProjectScopedEditorPrefs.GetKey(baseKey, firstProject);
+            string secondKey = ProjectScopedEditorPrefs.GetKey(baseKey, secondProject);
+            string ownerKey = ProjectScopedEditorPrefs.GetMigrationOwnerKey();
+            bool hadLegacy = EditorPrefs.HasKey(baseKey);
+            string originalLegacy = EditorPrefs.GetString(baseKey, string.Empty);
+            bool hadFirst = EditorPrefs.HasKey(firstKey);
+            string originalFirst = EditorPrefs.GetString(firstKey, string.Empty);
+            bool hadSecond = EditorPrefs.HasKey(secondKey);
+            string originalSecond = EditorPrefs.GetString(secondKey, string.Empty);
+            bool hadOwner = EditorPrefs.HasKey(ownerKey);
+            string originalOwner = EditorPrefs.GetString(ownerKey, string.Empty);
+
+            try
+            {
+                EditorPrefs.SetString(baseKey, "legacy");
+                EditorPrefs.DeleteKey(firstKey);
+                EditorPrefs.DeleteKey(secondKey);
+                EditorPrefs.DeleteKey(ownerKey);
+
+                Assert.AreEqual("legacy", ProjectScopedEditorPrefs.GetString(baseKey, "default", firstProject));
+                Assert.AreEqual("legacy", EditorPrefs.GetString(firstKey, "default"));
+                Assert.AreEqual("default", ProjectScopedEditorPrefs.GetString(baseKey, "default", secondProject));
+            }
+            finally
+            {
+                RestoreString(baseKey, hadLegacy, originalLegacy);
+                RestoreString(firstKey, hadFirst, originalFirst);
+                RestoreString(secondKey, hadSecond, originalSecond);
+                RestoreString(ownerKey, hadOwner, originalOwner);
+            }
+        }
+
+        [Test]
+        public void LegacyPreferenceBundle_ClaimedAtomicallyByOneProject()
+        {
+            const string firstBaseKey = EditorPrefKeys.HttpBaseUrl;
+            const string secondBaseKey = EditorPrefKeys.HttpTransportScope;
+            string firstProject = $"test-project-a-{Guid.NewGuid():N}";
+            string secondProject = $"test-project-b-{Guid.NewGuid():N}";
+            string firstProjectFirstKey = ProjectScopedEditorPrefs.GetKey(firstBaseKey, firstProject);
+            string firstProjectSecondKey = ProjectScopedEditorPrefs.GetKey(secondBaseKey, firstProject);
+            string secondProjectSecondKey = ProjectScopedEditorPrefs.GetKey(secondBaseKey, secondProject);
+            string ownerKey = ProjectScopedEditorPrefs.GetMigrationOwnerKey();
+            bool hadFirstLegacy = EditorPrefs.HasKey(firstBaseKey);
+            string originalFirstLegacy = EditorPrefs.GetString(firstBaseKey, string.Empty);
+            bool hadSecondLegacy = EditorPrefs.HasKey(secondBaseKey);
+            string originalSecondLegacy = EditorPrefs.GetString(secondBaseKey, string.Empty);
+            bool hadFirstProjectFirst = EditorPrefs.HasKey(firstProjectFirstKey);
+            string originalFirstProjectFirst = EditorPrefs.GetString(firstProjectFirstKey, string.Empty);
+            bool hadFirstProjectSecond = EditorPrefs.HasKey(firstProjectSecondKey);
+            string originalFirstProjectSecond = EditorPrefs.GetString(firstProjectSecondKey, string.Empty);
+            bool hadSecondProjectSecond = EditorPrefs.HasKey(secondProjectSecondKey);
+            string originalSecondProjectSecond = EditorPrefs.GetString(secondProjectSecondKey, string.Empty);
+            bool hadOwner = EditorPrefs.HasKey(ownerKey);
+            string originalOwner = EditorPrefs.GetString(ownerKey, string.Empty);
+
+            try
+            {
+                EditorPrefs.SetString(firstBaseKey, "first-legacy");
+                EditorPrefs.SetString(secondBaseKey, "second-legacy");
+                EditorPrefs.DeleteKey(firstProjectFirstKey);
+                EditorPrefs.DeleteKey(firstProjectSecondKey);
+                EditorPrefs.DeleteKey(secondProjectSecondKey);
+                EditorPrefs.DeleteKey(ownerKey);
+
+                Assert.AreEqual(
+                    "first-legacy",
+                    ProjectScopedEditorPrefs.GetString(firstBaseKey, "default", firstProject));
+                Assert.AreEqual(
+                    "default",
+                    ProjectScopedEditorPrefs.GetString(secondBaseKey, "default", secondProject));
+                Assert.AreEqual(
+                    "second-legacy",
+                    ProjectScopedEditorPrefs.GetString(secondBaseKey, "default", firstProject));
+            }
+            finally
+            {
+                RestoreString(firstBaseKey, hadFirstLegacy, originalFirstLegacy);
+                RestoreString(secondBaseKey, hadSecondLegacy, originalSecondLegacy);
+                RestoreString(firstProjectFirstKey, hadFirstProjectFirst, originalFirstProjectFirst);
+                RestoreString(firstProjectSecondKey, hadFirstProjectSecond, originalFirstProjectSecond);
+                RestoreString(secondProjectSecondKey, hadSecondProjectSecond, originalSecondProjectSecond);
+                RestoreString(ownerKey, hadOwner, originalOwner);
+            }
+        }
+
+        [Test]
+        public void SetUseHttpTransport_SameValuePersistsMissingScopedPreference()
+        {
+            bool currentValue = EditorConfigurationCache.Instance.UseHttpTransport;
+            EditorPrefs.DeleteKey(_scopedUseHttpTransportKey);
+
+            EditorConfigurationCache.Instance.SetUseHttpTransport(currentValue);
+
+            Assert.IsTrue(EditorPrefs.HasKey(_scopedUseHttpTransportKey));
+            Assert.AreEqual(currentValue, EditorPrefs.GetBool(_scopedUseHttpTransportKey, !currentValue));
+        }
+
+        [Test]
+        public void Refresh_LegacyFallbackDisabled_DoesNotMigrateOrClaimOwner()
+        {
+            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            EditorPrefs.DeleteKey(_scopedUseHttpTransportKey);
+            EditorPrefs.DeleteKey(_migrationOwnerKey);
+
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
+
+            Assert.IsTrue(EditorConfigurationCache.Instance.UseHttpTransport);
+            Assert.IsFalse(EditorPrefs.HasKey(_scopedUseHttpTransportKey));
+            Assert.IsFalse(EditorPrefs.HasKey(_migrationOwnerKey));
+        }
+
+        [Test]
+        public void ResolveStorageKey_UsesProjectScopeOnlyForKnownScopedPreferences()
+        {
+            const string unscopedKey = "MCPForUnity.Tests.UnscopedPreference";
+
+            Assert.AreEqual(
+                ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpBaseUrl),
+                ProjectScopedEditorPrefs.ResolveStorageKey(EditorPrefKeys.HttpBaseUrl));
+            Assert.AreEqual(
+                EditorPrefKeys.DebugLogs,
+                ProjectScopedEditorPrefs.ResolveStorageKey(EditorPrefKeys.DebugLogs));
+            Assert.AreEqual(
+                unscopedKey,
+                ProjectScopedEditorPrefs.ResolveStorageKey(unscopedKey));
+
+            try
+            {
+                ProjectScopedEditorPrefs.SetString(unscopedKey, "value");
+                Assert.AreEqual("value", EditorPrefs.GetString(unscopedKey, string.Empty));
+                Assert.IsFalse(EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(unscopedKey)));
+            }
+            finally
+            {
+                ProjectScopedEditorPrefs.DeleteKey(unscopedKey);
+                EditorPrefs.DeleteKey(ProjectScopedEditorPrefs.GetKey(unscopedKey));
+            }
+        }
+
+        [Test]
+        public void LocalHttpUrl_ProcessEnvironmentOverrideTakesPriority()
+        {
+            string originalEnvironment = Environment.GetEnvironmentVariable("UNITY_MCP_HTTP_URL");
+            string scopeKey = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpTransportScope);
+            bool hadScope = EditorPrefs.HasKey(scopeKey);
+            string originalScope = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpTransportScope,
+                "local",
+                allowLegacyFallback: false);
+            try
+            {
+                HttpEndpointUtility.SaveLocalBaseUrl("http://127.0.0.1:59991");
+                EditorConfigurationCache.Instance.SetHttpTransportScope("remote");
+                Environment.SetEnvironmentVariable("UNITY_MCP_HTTP_URL", "http://127.0.0.1:59992/mcp");
+
+                Assert.AreEqual("http://127.0.0.1:59992", HttpEndpointUtility.GetLocalBaseUrl());
+                Assert.AreEqual("http://127.0.0.1:59992", HttpEndpointUtility.GetBaseUrl());
+                Assert.IsFalse(HttpEndpointUtility.IsRemoteScope());
+                Assert.AreEqual(
+                    "http://127.0.0.1:59991",
+                    EditorPrefs.GetString(_scopedHttpBaseUrlKey, string.Empty));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("UNITY_MCP_HTTP_URL", originalEnvironment);
+                if (hadScope)
+                    EditorConfigurationCache.Instance.SetHttpTransportScope(originalScope);
+                else
+                    ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpTransportScope);
+                EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
+            }
+        }
+
+        [Test]
+        public void LocalHttpUrl_InvalidEnvironmentOverrideDoesNotBypassRemotePolicy()
+        {
+            string originalEnvironment = Environment.GetEnvironmentVariable("UNITY_MCP_HTTP_URL");
+            string scopeKey = ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpTransportScope);
+            bool hadScope = EditorPrefs.HasKey(scopeKey);
+            string originalScope = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpTransportScope,
+                "local",
+                allowLegacyFallback: false);
+            bool hadRemote = EditorPrefs.HasKey(EditorPrefKeys.HttpRemoteBaseUrl);
+            string originalRemote = EditorPrefs.GetString(
+                EditorPrefKeys.HttpRemoteBaseUrl,
+                string.Empty);
+
+            try
+            {
+                EditorConfigurationCache.Instance.SetHttpTransportScope("remote");
+                HttpEndpointUtility.SaveRemoteBaseUrl("https://configured.example");
+
+                Environment.SetEnvironmentVariable(
+                    "UNITY_MCP_HTTP_URL",
+                    "https://external.example");
+                Assert.IsTrue(HttpEndpointUtility.IsRemoteScope());
+                Assert.AreEqual("https://configured.example", HttpEndpointUtility.GetBaseUrl());
+
+                Environment.SetEnvironmentVariable(
+                    "UNITY_MCP_HTTP_URL",
+                    "ftp://127.0.0.1:59992");
+                Assert.IsTrue(HttpEndpointUtility.IsRemoteScope());
+                Assert.AreEqual("https://configured.example", HttpEndpointUtility.GetBaseUrl());
+                Assert.IsFalse(
+                    HttpEndpointUtility.IsHttpLocalUrlAllowedForLaunch(
+                        "ftp://127.0.0.1:59992",
+                        out _));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("UNITY_MCP_HTTP_URL", originalEnvironment);
+                if (hadScope)
+                    EditorConfigurationCache.Instance.SetHttpTransportScope(originalScope);
+                else
+                    ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpTransportScope);
+
+                if (hadRemote)
+                    EditorPrefs.SetString(EditorPrefKeys.HttpRemoteBaseUrl, originalRemote);
+                else
+                    EditorPrefs.DeleteKey(EditorPrefKeys.HttpRemoteBaseUrl);
+
+                EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
+            }
+        }
+
+        [Test]
+        public void LocalHttpUrl_ProcessEnvironmentOverrideMatchesExpectedValue()
+        {
+            string expected = Environment.GetEnvironmentVariable("UNITY_MCP_EXPECTED_HTTP_URL");
+            if (string.IsNullOrWhiteSpace(expected))
+            {
+                Assert.Ignore("Only used by the isolated multi-Editor endpoint stress route.");
+            }
+
+            Assert.AreEqual(expected, HttpEndpointUtility.GetLocalBaseUrl());
+            Assert.AreEqual(expected, HttpEndpointUtility.GetBaseUrl());
         }
 
         [Test]
@@ -246,7 +543,7 @@ namespace MCPForUnityTests.Editor.Services
         public void Refresh_UpdatesAllCachedValues()
         {
             // Arrange - directly set EditorPrefs
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            ProjectScopedEditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
             EditorPrefs.SetBool(EditorPrefKeys.DebugLogs, true);
             EditorPrefs.SetString(EditorPrefKeys.UvxPathOverride, "/refreshed/path");
 
@@ -260,5 +557,29 @@ namespace MCPForUnityTests.Editor.Services
         }
 
         #endregion
+
+        private static void RestoreBool(string key, bool hadValue, bool value)
+        {
+            if (hadValue)
+            {
+                EditorPrefs.SetBool(key, value);
+            }
+            else
+            {
+                EditorPrefs.DeleteKey(key);
+            }
+        }
+
+        private static void RestoreString(string key, bool hadValue, string value)
+        {
+            if (hadValue)
+            {
+                EditorPrefs.SetString(key, value);
+            }
+            else
+            {
+                EditorPrefs.DeleteKey(key);
+            }
+        }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/HttpAutoStartHandlerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/HttpAutoStartHandlerTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Services;
 using MCPForUnity.Editor.Services.Transport;
+using MCPForUnity.Editor.Helpers;
 using UnityEditor;
 
 namespace MCPForUnityTests.Editor.Services
@@ -23,6 +24,7 @@ namespace MCPForUnityTests.Editor.Services
         private bool _savedResumeFlag;
         private bool _savedAutoStart;
         private bool _savedUseHttpTransport;
+        private bool _hadUseHttpTransport;
 
         [SetUp]
         public void SetUp()
@@ -31,14 +33,18 @@ namespace MCPForUnityTests.Editor.Services
             _savedConnectPending = SessionState.GetBool(HttpAutoStartHandler.ConnectPendingKey, false);
             _savedResumeFlag = SessionState.GetBool(HttpBridgeReloadHandler.ResumeSessionKey, false);
             _savedAutoStart = EditorPrefs.GetBool(EditorPrefKeys.AutoStartOnLoad, false);
-            _savedUseHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
+            _hadUseHttpTransport = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.UseHttpTransport));
+            _savedUseHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                EditorPrefKeys.UseHttpTransport,
+                true,
+                allowLegacyFallback: false);
             _savedManager = MCPServiceLocator.TransportManager;
 
             SessionState.EraseBool(HttpAutoStartHandler.SessionInitKey);
             SessionState.EraseBool(HttpAutoStartHandler.ConnectPendingKey);
             SessionState.EraseBool(HttpBridgeReloadHandler.ResumeSessionKey);
             EditorPrefs.SetBool(EditorPrefKeys.AutoStartOnLoad, false);
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
             EditorConfigurationCache.Instance.Refresh();
 
             _fakeClient = new FakeTransportClient();
@@ -55,8 +61,11 @@ namespace MCPForUnityTests.Editor.Services
             SessionState.SetBool(HttpAutoStartHandler.ConnectPendingKey, _savedConnectPending);
             SessionState.SetBool(HttpBridgeReloadHandler.ResumeSessionKey, _savedResumeFlag);
             EditorPrefs.SetBool(EditorPrefKeys.AutoStartOnLoad, _savedAutoStart);
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, _savedUseHttpTransport);
-            EditorConfigurationCache.Instance.Refresh();
+            if (_hadUseHttpTransport)
+                EditorConfigurationCache.Instance.SetUseHttpTransport(_savedUseHttpTransport);
+            else
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.UseHttpTransport);
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
             MCPServiceLocator.Register(_savedManager);
         }
 
@@ -170,7 +179,7 @@ namespace MCPForUnityTests.Editor.Services
         public void TryBeginReconnect_StdioSelected_DropsPendingReconnect()
         {
             EditorPrefs.SetBool(EditorPrefKeys.AutoStartOnLoad, true);
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
             EditorConfigurationCache.Instance.Refresh();
             SessionState.SetBool(HttpAutoStartHandler.ConnectPendingKey, true);
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/HttpBridgeReloadHandlerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/HttpBridgeReloadHandlerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Services;
 using MCPForUnity.Editor.Services.Transport;
 using UnityEditor;
@@ -26,12 +27,17 @@ namespace MCPForUnityTests.Editor.Services
         private TransportManager _savedManager;
         private bool _savedResumeFlag;
         private bool _savedUseHttpTransport;
+        private bool _hadUseHttpTransport;
 
         [SetUp]
         public void SetUp()
         {
             _savedResumeFlag = SessionState.GetBool(HttpBridgeReloadHandler.ResumeSessionKey, false);
-            _savedUseHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
+            _hadUseHttpTransport = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.UseHttpTransport));
+            _savedUseHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                EditorPrefKeys.UseHttpTransport,
+                true,
+                allowLegacyFallback: false);
             _savedManager = MCPServiceLocator.TransportManager;
 
             SessionState.EraseBool(HttpBridgeReloadHandler.ResumeSessionKey);
@@ -41,7 +47,7 @@ namespace MCPForUnityTests.Editor.Services
             _manager.Configure(() => _fakeClient, () => _fakeClient);
             MCPServiceLocator.Register(_manager);
 
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
             EditorConfigurationCache.Instance.Refresh();
         }
 
@@ -50,8 +56,11 @@ namespace MCPForUnityTests.Editor.Services
         {
             // Stored-false and absent are indistinguishable: every read uses GetBool(key, false).
             SessionState.SetBool(HttpBridgeReloadHandler.ResumeSessionKey, _savedResumeFlag);
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, _savedUseHttpTransport);
-            EditorConfigurationCache.Instance.Refresh();
+            if (_hadUseHttpTransport)
+                EditorConfigurationCache.Instance.SetUseHttpTransport(_savedUseHttpTransport);
+            else
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.UseHttpTransport);
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
             MCPServiceLocator.Register(_savedManager);
         }
 
@@ -105,8 +114,7 @@ namespace MCPForUnityTests.Editor.Services
         public void AfterReloadCore_FlagSetStdioSelected_ClearsFlagAndSkips()
         {
             SessionState.SetBool(HttpBridgeReloadHandler.ResumeSessionKey, true);
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
-            EditorConfigurationCache.Instance.Refresh();
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
 
             Assert.IsFalse(HttpBridgeReloadHandler.OnAfterAssemblyReloadCore());
             Assert.IsFalse(ResumeFlagSet, "switching transports cancels the pending resume");

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/PidFileManagerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/PidFileManagerTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using MCPForUnity.Editor.Services.Server;
 using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
 using UnityEditor;
 using UnityEngine;
 
@@ -13,15 +15,30 @@ namespace MCPForUnityTests.Editor.Services.Server
     [TestFixture]
     public class PidFileManagerTests
     {
+        private static readonly string[] IntPreferenceKeys =
+        {
+            EditorPrefKeys.LastLocalHttpServerPid,
+            EditorPrefKeys.LastLocalHttpServerPort,
+        };
+
+        private static readonly string[] StringPreferenceKeys =
+        {
+            EditorPrefKeys.LastLocalHttpServerStartedUtc,
+            EditorPrefKeys.LastLocalHttpServerPidArgsHash,
+            EditorPrefKeys.LastLocalHttpServerPidFilePath,
+            EditorPrefKeys.LastLocalHttpServerInstanceToken,
+        };
+
         private PidFileManager _manager;
         private string _testPidFilePath;
+        private readonly Dictionary<string, int> _savedIntPreferences = new Dictionary<string, int>();
+        private readonly Dictionary<string, string> _savedStringPreferences = new Dictionary<string, string>();
 
         [SetUp]
         public void SetUp()
         {
             _manager = new PidFileManager();
-            // Clear any test state
-            ClearTestEditorPrefs();
+            SnapshotAndClearTestEditorPrefs();
         }
 
         [TearDown]
@@ -32,18 +49,60 @@ namespace MCPForUnityTests.Editor.Services.Server
             {
                 try { File.Delete(_testPidFilePath); } catch { }
             }
-            // Clear test state
+            ClearTestEditorPrefs();
+            RestoreTestEditorPrefs();
+        }
+
+        private void SnapshotAndClearTestEditorPrefs()
+        {
+            _savedIntPreferences.Clear();
+            _savedStringPreferences.Clear();
+
+            foreach (string baseKey in IntPreferenceKeys)
+            {
+                string key = ProjectScopedEditorPrefs.GetKey(baseKey);
+                if (EditorPrefs.HasKey(key))
+                {
+                    _savedIntPreferences[key] = EditorPrefs.GetInt(key, 0);
+                }
+            }
+
+            foreach (string baseKey in StringPreferenceKeys)
+            {
+                string key = ProjectScopedEditorPrefs.GetKey(baseKey);
+                if (EditorPrefs.HasKey(key))
+                {
+                    _savedStringPreferences[key] = EditorPrefs.GetString(key, string.Empty);
+                }
+            }
+
             ClearTestEditorPrefs();
         }
 
-        private void ClearTestEditorPrefs()
+        private static void ClearTestEditorPrefs()
         {
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPid); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPort); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerStartedUtc); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidArgsHash); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerPidFilePath); } catch { }
-            try { EditorPrefs.DeleteKey(EditorPrefKeys.LastLocalHttpServerInstanceToken); } catch { }
+            foreach (string baseKey in IntPreferenceKeys)
+            {
+                EditorPrefs.DeleteKey(ProjectScopedEditorPrefs.GetKey(baseKey));
+            }
+
+            foreach (string baseKey in StringPreferenceKeys)
+            {
+                EditorPrefs.DeleteKey(ProjectScopedEditorPrefs.GetKey(baseKey));
+            }
+        }
+
+        private void RestoreTestEditorPrefs()
+        {
+            foreach (KeyValuePair<string, int> preference in _savedIntPreferences)
+            {
+                EditorPrefs.SetInt(preference.Key, preference.Value);
+            }
+
+            foreach (KeyValuePair<string, string> preference in _savedStringPreferences)
+            {
+                EditorPrefs.SetString(preference.Key, preference.Value);
+            }
         }
 
         #region GetPidFilePath Tests
@@ -271,6 +330,46 @@ namespace MCPForUnityTests.Editor.Services.Server
         }
 
         [Test]
+        public void StoreHandshake_DoesNotOverwriteLegacyGlobalKeys()
+        {
+            const string legacyPath = "/another/project/mcp_http_8082.pid";
+            const string legacyToken = "another-project-token";
+            bool hadLegacyPath = EditorPrefs.HasKey(EditorPrefKeys.LastLocalHttpServerPidFilePath);
+            bool hadLegacyToken = EditorPrefs.HasKey(EditorPrefKeys.LastLocalHttpServerInstanceToken);
+            string originalLegacyPath = EditorPrefs.GetString(
+                EditorPrefKeys.LastLocalHttpServerPidFilePath,
+                string.Empty);
+            string originalLegacyToken = EditorPrefs.GetString(
+                EditorPrefKeys.LastLocalHttpServerInstanceToken,
+                string.Empty);
+            EditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerPidFilePath, legacyPath);
+            EditorPrefs.SetString(EditorPrefKeys.LastLocalHttpServerInstanceToken, legacyToken);
+
+            try
+            {
+                _manager.StoreHandshake("/this/project/mcp_http_8083.pid", "this-project-token");
+
+                Assert.AreEqual(
+                    legacyPath,
+                    EditorPrefs.GetString(EditorPrefKeys.LastLocalHttpServerPidFilePath, string.Empty));
+                Assert.AreEqual(
+                    legacyToken,
+                    EditorPrefs.GetString(EditorPrefKeys.LastLocalHttpServerInstanceToken, string.Empty));
+            }
+            finally
+            {
+                RestoreString(
+                    EditorPrefKeys.LastLocalHttpServerPidFilePath,
+                    hadLegacyPath,
+                    originalLegacyPath);
+                RestoreString(
+                    EditorPrefKeys.LastLocalHttpServerInstanceToken,
+                    hadLegacyToken,
+                    originalLegacyToken);
+            }
+        }
+
+        [Test]
         public void TryGetHandshake_NoHandshake_ReturnsFalse()
         {
             // Act
@@ -490,5 +589,17 @@ namespace MCPForUnityTests.Editor.Services.Server
         }
 
         #endregion
+
+        private static void RestoreString(string key, bool hadValue, string value)
+        {
+            if (hadValue)
+            {
+                EditorPrefs.SetString(key, value);
+            }
+            else
+            {
+                EditorPrefs.DeleteKey(key);
+            }
+        }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/ServerCommandBuilderTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/ServerCommandBuilderTests.cs
@@ -1,7 +1,9 @@
+using System;
 using NUnit.Framework;
 using MCPForUnity.Editor.Services;
 using MCPForUnity.Editor.Services.Server;
 using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
 using UnityEditor;
 
 namespace MCPForUnityTests.Editor.Services.Server
@@ -14,32 +16,49 @@ namespace MCPForUnityTests.Editor.Services.Server
     {
         private ServerCommandBuilder _builder;
         private bool _savedUseHttpTransport;
+        private bool _hadUseHttpTransport;
         private string _savedHttpUrl;
+        private bool _hadHttpUrl;
+        private string _savedHttpUrlEnvironment;
 
         [SetUp]
         public void SetUp()
         {
             _builder = new ServerCommandBuilder();
             // Save current settings
-            _savedUseHttpTransport = EditorPrefs.GetBool(EditorPrefKeys.UseHttpTransport, true);
-            _savedHttpUrl = EditorPrefs.GetString(EditorPrefKeys.HttpBaseUrl, string.Empty);
+            _savedHttpUrlEnvironment = Environment.GetEnvironmentVariable("UNITY_MCP_HTTP_URL");
+            Environment.SetEnvironmentVariable("UNITY_MCP_HTTP_URL", null);
+            _hadUseHttpTransport = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.UseHttpTransport));
+            _savedUseHttpTransport = ProjectScopedEditorPrefs.GetBool(
+                EditorPrefKeys.UseHttpTransport,
+                true,
+                allowLegacyFallback: false);
+            _hadHttpUrl = EditorPrefs.HasKey(ProjectScopedEditorPrefs.GetKey(EditorPrefKeys.HttpBaseUrl));
+            _savedHttpUrl = ProjectScopedEditorPrefs.GetString(
+                EditorPrefKeys.HttpBaseUrl,
+                string.Empty,
+                allowLegacyFallback: false);
         }
 
         [TearDown]
         public void TearDown()
         {
             // Restore settings
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, _savedUseHttpTransport);
-            if (!string.IsNullOrEmpty(_savedHttpUrl))
+            if (_hadUseHttpTransport)
+                EditorConfigurationCache.Instance.SetUseHttpTransport(_savedUseHttpTransport);
+            else
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.UseHttpTransport);
+            if (_hadHttpUrl)
             {
-                EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, _savedHttpUrl);
+                EditorConfigurationCache.Instance.SetHttpBaseUrl( _savedHttpUrl);
             }
             else
             {
-                EditorPrefs.DeleteKey(EditorPrefKeys.HttpBaseUrl);
+                ProjectScopedEditorPrefs.DeleteKey(EditorPrefKeys.HttpBaseUrl);
             }
-            // Refresh cache to reflect restored values
-            EditorConfigurationCache.Instance.Refresh();
+            Environment.SetEnvironmentVariable("UNITY_MCP_HTTP_URL", _savedHttpUrlEnvironment);
+            // Refresh without recreating originally absent scoped keys from legacy prefs.
+            EditorConfigurationCache.Instance.Refresh(allowLegacyFallback: false);
         }
 
         #region QuoteIfNeeded Tests
@@ -222,8 +241,8 @@ namespace MCPForUnityTests.Editor.Services.Server
         public void TryBuildCommand_HttpDisabled_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, false);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(false);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:8080");
             EditorConfigurationCache.Instance.Refresh();
 
             // Act
@@ -242,8 +261,8 @@ namespace MCPForUnityTests.Editor.Services.Server
         public void TryBuildCommand_RemoteUrl_ReturnsFalse()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://remote.server.com:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://remote.server.com:8080");
             EditorConfigurationCache.Instance.Refresh();
 
             // Act
@@ -259,8 +278,8 @@ namespace MCPForUnityTests.Editor.Services.Server
         public void TryBuildCommand_LocalUrl_ReturnsCommandOrError()
         {
             // Arrange
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, "http://localhost:8080");
+            EditorConfigurationCache.Instance.SetUseHttpTransport(true);
+            EditorConfigurationCache.Instance.SetHttpBaseUrl("http://localhost:8080");
             EditorConfigurationCache.Instance.Refresh();
 
             // Act


### PR DESCRIPTION
## Description

Fix machine-global `EditorPrefs` cross-contamination that can make one Unity project inherit another project's local HTTP endpoint or server ownership metadata.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Scope local endpoint, transport selection, PID, port, PID-file path, and instance token by project hash.
- Let `UNITY_MCP_HTTP_URL` override only the current Unity process and reject non-local or unsupported schemes.
- Migrate the legacy endpoint/transport bundle atomically to at most one project under a cross-process mutex.
- Keep known global preferences global and use one storage-key resolver for all scoped accessors and diagnostics.
- Display/search the resolved project key in the EditorPrefs diagnostics window.
- Preserve pre-existing scoped endpoint/PID state in test fixtures and disable migration side effects during snapshot and teardown refreshes.

## Compatibility / Package Source

- Unity version(s) tested: 2022.3.62f3
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): branch derived directly from official `beta` (`bd72241ab91c664176091789c9408d676783abec`); local `file:` source for validation only
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): N/A

Single-project defaults remain unchanged. Configuration remains machine-local and is not written into the Unity project.

## Testing/Screenshots/Recordings

- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

Unity 2022.3.62f3 targeted suite: 155 total, 154 passed, 0 failed, 1 intentional stress-only skip. Two isolated Unity processes also validated independent endpoints and project-scoped PID tracking.

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

## Related Issues

Relates to #1164.

## Additional Notes

A rebuilt stable branch containing this PR plus #1286 and #1287 passed 162 targeted EditMode tests: 161 passed, 0 failed, 1 intentional stress-only skip. `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the local HTTP endpoint through the `UNITY_MCP_HTTP_URL` environment variable.
  * HTTP endpoint validation now accepts only HTTP and HTTPS schemes.

* **Improvements**
  * Transport settings and server tracking data are now isolated per project, reducing cross-project preference conflicts.
  * Existing settings are migrated safely when applicable.

* **Tests**
  * Expanded coverage for project-scoped settings, environment overrides, transport configuration, and legacy preference compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->