### PR TITLE
Close WebSocket cleanly before domain reload

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/WebSocketTransportClient.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/WebSocketTransportClient.cs
@@ -170,8 +170,8 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
 
         /// <summary>
         /// Synchronous teardown for use in beforeAssemblyReload where async is not possible.
-        /// Skips the graceful WebSocket close handshake and just disposes resources immediately.
-        /// The server handles ungraceful disconnects via its ping timeout.
+        /// Sends a bounded close-output frame when possible, then disposes immediately so
+        /// domain reload cannot leave an unfinished close handshake behind.
         /// </summary>
         public void ForceStop()
         {
@@ -180,7 +180,16 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
 
             if (_socket != null)
             {
-                try { _socket.Abort(); } catch { }
+                if (_sendLock.Wait(0))
+                {
+                    try { CloseForDomainReload(_socket, TimeSpan.FromMilliseconds(100)); }
+                    finally { _sendLock.Release(); }
+                }
+                else
+                {
+                    try { _socket.Abort(); } catch { }
+                }
+
                 try { _socket.Dispose(); } catch { }
                 _socket = null;
             }
@@ -195,6 +204,37 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
 
             try { _lifecycleCts?.Dispose(); } catch { }
             _lifecycleCts = null;
+        }
+
+        internal static void CloseForDomainReload(WebSocket socket, TimeSpan timeout)
+        {
+            if (socket == null)
+            {
+                return;
+            }
+
+            try
+            {
+                WebSocketState state = socket.State;
+                if (state == WebSocketState.Open || state == WebSocketState.CloseReceived)
+                {
+                    using var closeCts = new CancellationTokenSource(timeout);
+                    socket.CloseOutputAsync(
+                        WebSocketCloseStatus.EndpointUnavailable,
+                        "Domain reload",
+                        closeCts.Token).GetAwaiter().GetResult();
+                    return;
+                }
+
+                if (state != WebSocketState.Closed && state != WebSocketState.Aborted)
+                {
+                    socket.Abort();
+                }
+            }
+            catch
+            {
+                try { socket.Abort(); } catch { }
+            }
         }
 
         public async Task<bool> VerifyAsync()

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/WebSocketTransportClientTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/WebSocketTransportClientTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.WebSockets;
 using System.Reflection;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using MCPForUnity.Editor.Services.Transport.Transports;
 using NUnit.Framework;
 
@@ -80,6 +83,75 @@ namespace MCPForUnityTests.Editor.Services
                 Assert.AreEqual("/custom/path", candidate.AbsolutePath);
                 Assert.AreEqual("?mode=test", candidate.Query);
             }
+        }
+
+        [Test]
+        public void CloseForDomainReload_OpenSocket_SendsBoundedCloseOutput()
+        {
+            var socket = new RecordingWebSocket();
+
+            WebSocketTransportClient.CloseForDomainReload(socket, TimeSpan.FromSeconds(1));
+
+            Assert.IsTrue(socket.CloseOutputCalled);
+            Assert.AreEqual(WebSocketCloseStatus.EndpointUnavailable, socket.RequestedCloseStatus);
+            Assert.AreEqual("Domain reload", socket.RequestedCloseDescription);
+            Assert.IsFalse(socket.AbortCalled);
+        }
+
+        [Test]
+        public void CloseForDomainReload_CloseFailure_AbortsSocket()
+        {
+            var socket = new RecordingWebSocket { ThrowOnCloseOutput = true };
+
+            WebSocketTransportClient.CloseForDomainReload(socket, TimeSpan.FromSeconds(1));
+
+            Assert.IsTrue(socket.CloseOutputCalled);
+            Assert.IsTrue(socket.AbortCalled);
+        }
+
+        [Test]
+        public void CloseForDomainReload_CloseReceived_CompletesCloseOutput()
+        {
+            var socket = new RecordingWebSocket { SocketState = WebSocketState.CloseReceived };
+
+            WebSocketTransportClient.CloseForDomainReload(socket, TimeSpan.FromSeconds(1));
+
+            Assert.IsTrue(socket.CloseOutputCalled);
+            Assert.IsFalse(socket.AbortCalled);
+        }
+
+        [Test]
+        public void CloseForDomainReload_CloseTimeout_AbortsSocket()
+        {
+            var socket = new RecordingWebSocket { WaitForCancellation = true };
+
+            WebSocketTransportClient.CloseForDomainReload(socket, TimeSpan.FromMilliseconds(10));
+
+            Assert.IsTrue(socket.CloseOutputCalled);
+            Assert.IsTrue(socket.AbortCalled);
+        }
+
+        [Test]
+        public void CloseForDomainReload_ConnectingSocket_AbortsImmediately()
+        {
+            var socket = new RecordingWebSocket { SocketState = WebSocketState.Connecting };
+
+            WebSocketTransportClient.CloseForDomainReload(socket, TimeSpan.FromSeconds(1));
+
+            Assert.IsFalse(socket.CloseOutputCalled);
+            Assert.IsTrue(socket.AbortCalled);
+        }
+
+        [TestCase(WebSocketState.Closed)]
+        [TestCase(WebSocketState.Aborted)]
+        public void CloseForDomainReload_TerminalSocket_DoesNothing(WebSocketState state)
+        {
+            var socket = new RecordingWebSocket { SocketState = state };
+
+            WebSocketTransportClient.CloseForDomainReload(socket, TimeSpan.FromSeconds(1));
+
+            Assert.IsFalse(socket.CloseOutputCalled);
+            Assert.IsFalse(socket.AbortCalled);
         }
 
         private static List<Uri> InvokeBuildConnectionCandidateUris(Uri endpoint)
@@ -181,6 +253,75 @@ namespace MCPForUnityTests.Editor.Services
             }
 
             return host.Trim('[', ']');
+        }
+
+        private sealed class RecordingWebSocket : WebSocket
+        {
+            public bool ThrowOnCloseOutput { get; set; }
+            public bool WaitForCancellation { get; set; }
+            public WebSocketState SocketState { get; set; } = WebSocketState.Open;
+            public bool CloseOutputCalled { get; private set; }
+            public bool AbortCalled { get; private set; }
+            public WebSocketCloseStatus RequestedCloseStatus { get; private set; }
+            public string RequestedCloseDescription { get; private set; }
+
+            public override WebSocketCloseStatus? CloseStatus => null;
+            public override string CloseStatusDescription => null;
+            public override WebSocketState State => SocketState;
+            public override string SubProtocol => null;
+
+            public override void Abort()
+            {
+                AbortCalled = true;
+            }
+
+            public override Task CloseAsync(
+                WebSocketCloseStatus closeStatus,
+                string statusDescription,
+                CancellationToken cancellationToken)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override Task CloseOutputAsync(
+                WebSocketCloseStatus closeStatus,
+                string statusDescription,
+                CancellationToken cancellationToken)
+            {
+                CloseOutputCalled = true;
+                RequestedCloseStatus = closeStatus;
+                RequestedCloseDescription = statusDescription;
+                if (ThrowOnCloseOutput)
+                {
+                    throw new InvalidOperationException("close failed");
+                }
+                if (WaitForCancellation)
+                {
+                    return Task.Delay(Timeout.Infinite, cancellationToken);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            public override void Dispose()
+            {
+            }
+
+            public override Task<WebSocketReceiveResult> ReceiveAsync(
+                ArraySegment<byte> buffer,
+                CancellationToken cancellationToken)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override Task SendAsync(
+                ArraySegment<byte> buffer,
+                WebSocketMessageType messageType,
+                bool endOfMessage,
+                CancellationToken cancellationToken)
+            {
+                throw new NotSupportedException();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Replace immediate WebSocket abort during Unity domain reload with a bounded close-output attempt that is serialized against normal sends and falls back to abort without blocking the Editor.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Send `EndpointUnavailable` close output for `Open` and `CloseReceived` sockets with a 100 ms budget.
- Acquire the normal WebSocket send lock non-blockingly before the close output; abort immediately if a send is already active.
- Abort on timeout, exception, or unfinished states such as `Connecting` and `CloseSent`.
- Leave `Closed` and `Aborted` sockets untouched.

## Compatibility / Package Source

- Unity version(s) tested: 2022.3.62f3
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): branch derived directly from official `beta` (`bd72241ab91c664176091789c9408d676783abec`); local `file:` source for validation only
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): N/A

The 100 ms close budget is bounded; all failure paths retain the previous abort behavior.

## Testing/Screenshots/Recordings

- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

Unity 2022.3.62f3 targeted reload suite: 21 passed, 0 failed. Tests cover close output, `CloseReceived`, timeout, exception, unfinished states, and terminal states; the send-lock serialization path is compiled and source-reviewed.

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

## Related Issues

Relates to #1207.

## Additional Notes

A rebuilt stable branch containing this PR plus #1285 and #1286 passed 162 targeted EditMode tests: 161 passed, 0 failed, 1 intentional stress-only skip. `git diff --check` passes.
