### PR TITLE
fix: redirect stdin from NUL when launching the server on Windows (#1279)

### DIFF
--- a/MCPForUnity/Editor/Services/Server/TerminalLauncher.cs
+++ b/MCPForUnity/Editor/Services/Server/TerminalLauncher.cs
@@ -42,10 +42,13 @@ namespace MCPForUnity.Editor.Services.Server
             }
 
 #if UNITY_EDITOR_WIN
-            // cmd.exe /c "<command> >> "<log>" 2>&1"
+            // cmd.exe /c "<command> < NUL >> "<log>" 2>&1"
             // The whole payload after /c is wrapped in one outer pair of quotes; cmd strips the
             // outermost quotes, so inner quotes around the log path survive for paths with spaces.
-            string winRedirect = $"{command} >> \"{logFilePath}\" 2>&1";
+            // stdin is redirected from NUL because the Editor is a console-less GUI process: with
+            // CreateNoWindow and no console handle, uvx.exe would inherit an invalid stdin and die
+            // with "The handle is invalid. (os error 6)" before launching the server.
+            string winRedirect = $"{command} < NUL >> \"{logFilePath}\" 2>&1";
             return new System.Diagnostics.ProcessStartInfo
             {
                 FileName = "cmd.exe",

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/TerminalLauncherTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/Server/TerminalLauncherTests.cs
@@ -212,6 +212,19 @@ namespace MCPForUnityTests.Editor.Services.Server
             StringAssert.Contains(">>", startInfo.Arguments, "output should be appended to the log via >>");
         }
 
+#if UNITY_EDITOR_WIN
+        [Test]
+        public void CreateHeadlessProcessStartInfo_RedirectsStdinFromNul()
+        {
+            // Regression guard for #1279: the Editor is a console-less GUI process, so a child
+            // launched with CreateNoWindow inherits an invalid stdin and uvx.exe fails with
+            // "The handle is invalid. (os error 6)". stdin must come from NUL instead.
+            var startInfo = _launcher.CreateHeadlessProcessStartInfo("uvx run-server", LogPath());
+
+            StringAssert.Contains("< NUL", startInfo.Arguments, "stdin should be redirected from NUL");
+        }
+#endif
+
         [Test]
         public void CreateHeadlessProcessStartInfo_LogPathWithSpaces_IsQuoted()
         {


### PR DESCRIPTION
Fixes #1279.

## The bug

Windows headless server launch is broken in the shipped **v10.1.0**. `TerminalLauncher` spawns `cmd.exe` with `UseShellExecute=false` and `CreateNoWindow=true` but never redirects stdin. The Unity Editor is a console-less GUI process, so the child inherits an invalid stdin handle and `uvx.exe` dies with:

```
The handle is invalid. (os error 6)
```

before the server ever starts. Regression from #1201.

## The fix

Redirect stdin from `NUL` inside the `cmd.exe` payload:

```
cmd.exe /c "<command> < NUL >> "<log>" 2>&1"
```

The whole payload after `/c` stays wrapped in one outer pair of quotes, so `cmd` strips the outermost pair and the inner quotes around the log path still survive for paths containing spaces.

## What is and isn't verified

Please read this part before approving.

**Verified:** the new form is byte-for-byte equivalent to the old one on a working setup. Old and new both produced identical 4768-character output through a full `uvx --from <local Server> mcp-for-unity --help` run. This proves **no regression** and that `< NUL` parses correctly in `cmd.exe`.

**Not verified:** the fix's actual benefit. Hub-launched Unity on my machine has a valid redirected stdin (`Console.IsInputRedirected = True`, `OpenStandardInput()` returns a readable `FileStream`), so the invalid-handle precondition never holds locally and the failure cannot be reproduced. Forging an invalid handle from managed code needs `STARTUPINFO`/P-Invoke, which is out of reach here.

Confirming this needs either the reporter's environment or a Unity launched without a valid stdin (e.g. straight from Explorer rather than Hub). **A maintainer on the reporting configuration should sanity-check before this ships.**

## Tests

Adds `CreateHeadlessProcessStartInfo_RedirectsStdinFromNul`, guarded by `#if UNITY_EDITOR_WIN`, asserting the argument string contains `< NUL`.

Full EditMode suite on **2021.3.45f2**: `1150 total / 1094 passed / 0 failed / 56 skipped`.

## Suggested handling

This is a regression in a tagged release that breaks Windows launch outright. It is deliberately scoped to two files so it can be merged and cherry-picked to `main` for 10.1.1 without waiting on anything else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless launches on Windows by redirecting standard input from `NUL`, helping prevent GUI editor processes from terminating unexpectedly.
* **Tests**
  * Added Windows-specific coverage to verify correct standard input redirection during headless launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->