### PR TITLE
fix: trust the pipeline flag when a domain reload is deferred (#1276)

### DIFF
--- a/MCPForUnity/Editor/Services/EditorStateCache.cs
+++ b/MCPForUnity/Editor/Services/EditorStateCache.cs
@@ -260,8 +260,8 @@ namespace MCPForUnity.Editor.Services
                 EditorApplication.playModeStateChanged += _ => ForceUpdate("playmode");
 
                 // Tracks whether an assembly compilation is actually running, for
-                // GetActualIsCompiling's Play-mode check. Statics reset on domain reload
-                // and this [InitializeOnLoad] ctor re-subscribes, so the flag is per-domain.
+                // GetActualIsCompiling. Statics reset on domain reload and this
+                // [InitializeOnLoad] ctor re-subscribes, so the flag is per-domain.
                 UnityEditor.Compilation.CompilationPipeline.compilationStarted += _ => _pipelineCompilationRunning = true;
                 UnityEditor.Compilation.CompilationPipeline.compilationFinished += _ => _pipelineCompilationRunning = false;
 
@@ -288,7 +288,7 @@ namespace MCPForUnity.Editor.Services
         {
             // Throttle to reduce overhead while keeping the snapshot fresh enough for polling clients.
             double now = EditorApplication.timeSinceStartup;
-            // Use GetActualIsCompiling() to avoid Play mode false positives (issue #582)
+            // Use GetActualIsCompiling() to avoid isCompiling false positives (issues #549, #1276)
             bool isCompiling = GetActualIsCompiling();
 
             // Check for compilation edge transitions (always update on these)
@@ -543,10 +543,12 @@ namespace MCPForUnity.Editor.Services
         private static bool _pipelineCompilationRunning;
 
         /// <summary>
-        /// Returns the actual compilation state, working around a known Unity quirk where
-        /// EditorApplication.isCompiling can return false positives in Play mode (e.g. a
-        /// recompile deferred by Recompile-After-Finished-Playing keeps it true for the
-        /// whole play session). See: https://github.com/CoplayDev/unity-mcp/issues/549
+        /// Returns the actual compilation state, working around known Unity quirks where
+        /// EditorApplication.isCompiling reports false positives while no compilation is
+        /// running: a recompile deferred by Recompile-After-Finished-Playing keeps it true
+        /// for the whole play session (issue #549), and a project holding
+        /// EditorApplication.LockReloadAssemblies keeps it true until the lock is released
+        /// (issue #1276). In both cases the event-tracked pipeline flag is authoritative.
         /// </summary>
         internal static bool GetActualIsCompiling()
         {
@@ -556,16 +558,9 @@ namespace MCPForUnity.Editor.Services
                 return false;
             }
 
-            // In Play mode, trust the event-tracked pipeline state instead: a deferred
-            // recompile keeps EditorApplication.isCompiling true without any compilation
-            // actually running.
-            if (EditorApplication.isPlaying)
-            {
-                return _pipelineCompilationRunning;
-            }
-
-            // Outside Play mode the raw signal is reliable.
-            return true;
+            // Otherwise trust the event-tracked pipeline state: isCompiling stays true for as
+            // long as an assembly reload is deferred, with no compilation actually running.
+            return _pipelineCompilationRunning;
         }
     }
 }

--- a/MCPForUnity/Editor/Services/StdioBridgeReloadHandler.cs
+++ b/MCPForUnity/Editor/Services/StdioBridgeReloadHandler.cs
@@ -114,14 +114,8 @@ namespace MCPForUnity.Editor.Services
             }
 
             // If the editor is not compiling, attempt an immediate restart without relying on editor focus.
-            bool isCompiling = EditorApplication.isCompiling;
-            try
-            {
-                var pipeline = Type.GetType("UnityEditor.Compilation.CompilationPipeline, UnityEditor");
-                var prop = pipeline?.GetProperty("isCompiling", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-                if (prop != null) isCompiling |= (bool)prop.GetValue(null);
-            }
-            catch { }
+            // Routed through EditorStateCache so a deferred reload (issue #1276) does not block resume.
+            bool isCompiling = EditorStateCache.GetActualIsCompiling();
 
             if (!isCompiling)
             {

--- a/MCPForUnity/Editor/Services/TestJobManager.cs
+++ b/MCPForUnity/Editor/Services/TestJobManager.cs
@@ -502,7 +502,7 @@ namespace MCPForUnity.Editor.Services
                 {
                     long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                     long initTimeout = job.InitTimeoutMs > 0 ? job.InitTimeoutMs : DefaultInitializationTimeoutMs;
-                    if (!EditorApplication.isCompiling && !EditorApplication.isUpdating && now - job.StartedUnixMs > initTimeout)
+                    if (!EditorStateCache.GetActualIsCompiling() && !EditorApplication.isUpdating && now - job.StartedUnixMs > initTimeout)
                     {
                         McpLog.Warn($"[TestJobManager] Job {jobId} failed to initialize within {initTimeout}ms, auto-failing");
                         job.Status = TestJobStatus.Failed;
@@ -589,7 +589,7 @@ namespace MCPForUnity.Editor.Services
                 return "editor_unfocused";
             }
 
-            if (EditorApplication.isCompiling)
+            if (EditorStateCache.GetActualIsCompiling())
             {
                 return "compiling";
             }

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -237,24 +237,10 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
             }
         }
 
-        private static bool IsCompiling()
-        {
-            if (EditorApplication.isCompiling)
-            {
-                return true;
-            }
-            try
-            {
-                Type pipeline = Type.GetType("UnityEditor.Compilation.CompilationPipeline, UnityEditor");
-                var prop = pipeline?.GetProperty("isCompiling", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-                if (prop != null)
-                {
-                    return (bool)prop.GetValue(null);
-                }
-            }
-            catch { }
-            return false;
-        }
+        // Routed through EditorStateCache so a deferred domain reload (issue #1276) does not
+        // pin the bridge off: raw EditorApplication.isCompiling stays true for as long as the
+        // reload is held, and this gates bridge startup.
+        private static bool IsCompiling() => EditorStateCache.GetActualIsCompiling();
 
         public static void Start()
         {

--- a/MCPForUnity/Editor/Tools/ManageScriptableObject.cs
+++ b/MCPForUnity/Editor/Tools/ManageScriptableObject.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Services;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -44,7 +45,7 @@ namespace MCPForUnity.Editor.Tools
                 return new ErrorResponse(CodeInvalidParams);
             }
 
-            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            if (EditorStateCache.GetActualIsCompiling() || EditorApplication.isUpdating)
             {
                 // Unity is transient; treat as retryable on the client side.
                 return new ErrorResponse(CodeCompilingOrReloading, new { hint = "retry" });

--- a/MCPForUnity/Editor/Tools/RefreshUnity.cs
+++ b/MCPForUnity/Editor/Tools/RefreshUnity.cs
@@ -109,7 +109,7 @@ namespace MCPForUnity.Editor.Tools
                 }
             }
 
-            string resultingState = EditorApplication.isCompiling
+            string resultingState = EditorStateCache.GetActualIsCompiling()
                 ? "compiling"
                 : (EditorApplication.isUpdating ? "asset_import" : "idle");
 
@@ -146,7 +146,7 @@ namespace MCPForUnity.Editor.Tools
                         return;
                     }
 
-                    if (!EditorApplication.isCompiling
+                    if (!EditorStateCache.GetActualIsCompiling()
                         && !EditorApplication.isUpdating
                         && !TestRunStatus.IsRunning
                         && !EditorApplication.isPlayingOrWillChangePlaymode)

--- a/MCPForUnity/Editor/Tools/UnityReflect.cs
+++ b/MCPForUnity/Editor/Tools/UnityReflect.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Services;
 using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
@@ -99,7 +100,7 @@ namespace MCPForUnity.Editor.Tools
 
         public static object HandleCommand(JObject @params)
         {
-            if (EditorApplication.isCompiling)
+            if (EditorStateCache.GetActualIsCompiling())
                 return new ErrorResponse("Cannot reflect while Unity is compiling. Wait for domain reload to complete.");
 
             if (@params == null)


### PR DESCRIPTION
Fixes #1276.

## The bug

`EditorApplication.isCompiling` conflates three distinct states:

1. actually compiling
2. compilation queued
3. compilation finished, but the assembly reload is deferred

A project holding `EditorApplication.LockReloadAssemblies` sits in state 3 for as long as the lock is held. No compilation is running, but `isCompiling` stays `true` the entire time — and any code gated on it refuses work indefinitely.

Eight call sites read the raw flag:

| Site | Symptom while a reload is held |
|---|---|
| `StdioBridgeHost.IsCompiling` | bridge never starts — the headline symptom |
| `StdioBridgeReloadHandler` | resume deferred to `delayCall` instead of running immediately |
| `TestJobManager` (init timeout) | timeout mis-attributed to compilation |
| `TestJobManager` (blocked reason) | reports a bogus `"compiling"` block |
| `ManageScriptableObject` | rejects every call |
| `UnityReflect` | "Cannot reflect while Unity is compiling" |
| `RefreshUnity` (wait tick) | `wait_for_ready` never completes |
| `RefreshUnity` (resulting state) | reports `"compiling"` when idle |

## The fix

Route all eight through `EditorStateCache.GetActualIsCompiling()`, which short-circuits to `false` when `isCompiling` is `false` and otherwise trusts the event-tracked `CompilationPipeline` flag.

Also drops the `isPlaying` gate that previously limited this workaround to play mode — the same false positive occurs outside play mode, which is exactly what #1276 reports. The existing #549 (Recompile-After-Finished-Playing) case is unaffected and still covered.

Two dead reflection probes that could never be reached are deleted rather than left in place, per the repo's delete-don't-deprecate policy.

## The load-bearing assumption, verified

The fix only works if `CompilationPipeline.compilationFinished` actually fires while `LockReloadAssemblies` is held. It does. Reproduced live in the Editor:

```
LockReloadAssemblies() -> RequestScriptCompilation() -> read state

EditorApplication.isCompiling      = True
_pipelineCompilationRunning        = False
GetActualIsCompiling()             = False   <- fixed
(previous behaviour would return    True)
```

Then confirmed end-to-end per call site: with a reload held, `unity_reflect` previously returned "Cannot reflect while Unity is compiling" and now reaches parameter validation (`'class_name' parameter is required`), and `refresh_unity` previously reported `resulting_state: "compiling"` and now reports `idle`.

An earlier draft of this fix added a separate `_pipelineCompilationFinished` flag. That turned out to be unnecessary given the above, and would have left the flag set after a failed compile — dropped.

## Tests

Full EditMode suite on **2021.3.45f2**: `1168 total / 1094 passed / 0 failed / 74 skipped`.

## Known remaining sites, deliberately not touched

Three display-only reads still use the raw flag and are cosmetic rather than functional: `McpConnectionSection.cs:382`, `McpConnectionSection.cs:640`, `ManagePackages.cs:603`.

The EditMode harness itself is also affected — `TestUtilities.cs:65` spins on `while (EditorApplication.isCompiling || EditorApplication.isUpdating)`, so a held reload makes every `SetUp` burn its 180s timeout. That is a test-infrastructure change and belongs in its own PR rather than riding along here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Unity’s compilation state across editor operations.
  * Reduced false positives and timing issues during script compilation and assembly reloads.
  * Improved reliability of command retries, readiness checks, test jobs, reflection, and automatic connection recovery while Unity is compiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->