### PR TITLE
test: report unavailable-pipeline graphics tests as Skipped, not Inconclusive

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageGraphicsTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageGraphicsTests.cs
@@ -106,15 +106,18 @@ namespace MCPForUnityTests.Editor.Tools
         // Volume Actions
         // =====================================================================
 
-        private void AssumeVolumeSystem()
+        // Assert.Ignore, not Assume.That: Assume yields Inconclusive, which the Test Runner
+        // window renders as a failure and which leaves the run's resultState non-Passed.
+        private void RequireVolumeSystem()
         {
-            Assume.That(_hasVolumeSystem, "Volume system not available — skipping.");
+            if (!_hasVolumeSystem)
+                Assert.Ignore("Volume system not available — skipping.");
         }
 
         [Test]
         public void VolumeCreate_Global_CreatesVolume()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
             {
                 ["action"] = "volume_create",
@@ -130,7 +133,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeCreate_WithEffects_AddsEffects()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
             {
                 ["action"] = "volume_create",
@@ -150,7 +153,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeCreate_Local_CreatesNonGlobal()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
             {
                 ["action"] = "volume_create",
@@ -164,7 +167,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeAddEffect_AddsEffect()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_AddFx");
 
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
@@ -181,7 +184,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeAddEffect_Duplicate_ReturnsError()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_DupFx");
             ManageGraphics.HandleCommand(new JObject
             {
@@ -203,7 +206,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeAddEffect_InvalidEffect_ReturnsError()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_BadFx");
 
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
@@ -219,7 +222,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeSetEffect_SetsParameters()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_SetFx");
             ManageGraphics.HandleCommand(new JObject
             {
@@ -245,7 +248,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeSetEffect_InvalidParam_ReportsFailed()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_BadParam");
             ManageGraphics.HandleCommand(new JObject
             {
@@ -270,7 +273,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeRemoveEffect_RemovesEffect()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_RmFx");
             ManageGraphics.HandleCommand(new JObject
             {
@@ -301,7 +304,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeRemoveEffect_NonExistent_ReturnsError()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_RmMissing");
 
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
@@ -317,7 +320,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeGetInfo_ReturnsEffectList()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_Info");
             ManageGraphics.HandleCommand(new JObject
             {
@@ -343,7 +346,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeGetInfo_NonExistentTarget_ReturnsError()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
             {
                 ["action"] = "volume_get_info",
@@ -355,7 +358,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeSetProperties_UpdatesWeightAndPriority()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             CreateTestVolume("GfxTest_Props");
 
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
@@ -383,7 +386,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeListEffects_ReturnsAvailableTypes()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             var result = ToJObject(ManageGraphics.HandleCommand(
                 new JObject { ["action"] = "volume_list_effects" }));
             Assert.IsTrue(result.Value<bool>("success"), result.ToString());
@@ -396,7 +399,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void VolumeCreateProfile_CreatesAsset()
         {
-            AssumeVolumeSystem();
+            RequireVolumeSystem();
             string path = $"{TempRoot}/TestProfile";
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
             {
@@ -626,7 +629,8 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void PipelineGetSettings_ReturnsSettings()
         {
-            Assume.That(_hasURP || _hasHDRP, "Built-in pipeline has no settings asset — skipping.");
+            if (!_hasURP && !_hasHDRP)
+                Assert.Ignore("Built-in pipeline has no settings asset — skipping.");
             var result = ToJObject(ManageGraphics.HandleCommand(
                 new JObject { ["action"] = "pipeline_get_settings" }));
             Assert.IsTrue(result.Value<bool>("success"), result.ToString());
@@ -651,15 +655,16 @@ namespace MCPForUnityTests.Editor.Tools
         // Renderer Feature Actions (URP only)
         // =====================================================================
 
-        private void AssumeURP()
+        private void RequireURP()
         {
-            Assume.That(_hasURP, "URP not available — skipping.");
+            if (!_hasURP)
+                Assert.Ignore("URP not available — skipping.");
         }
 
         [Test]
         public void FeatureList_ReturnsFeatures()
         {
-            AssumeURP();
+            RequireURP();
             var result = ToJObject(ManageGraphics.HandleCommand(
                 new JObject { ["action"] = "feature_list" }));
             Assert.IsTrue(result.Value<bool>("success"), result.ToString());
@@ -670,7 +675,7 @@ namespace MCPForUnityTests.Editor.Tools
         [Test]
         public void FeatureAdd_InvalidType_ReturnsError()
         {
-            AssumeURP();
+            RequireURP();
             var result = ToJObject(ManageGraphics.HandleCommand(new JObject
             {
                 ["action"] = "feature_add",


### PR DESCRIPTION
## The problem

`ManageGraphicsTests` guards 18 environment-dependent tests with `Assume.That`, which yields **Inconclusive**. Three consumers disagree about what Inconclusive means:

| Consumer | Interpretation |
|---|---|
| Test Runner window | renders it with a **failure** icon |
| `run_tests` summary | **excludes** it from `summary.total` |
| `run_tests` progress | **includes** it in `progress.total` |
| `failures_so_far` | ignores it entirely |

So a completely clean suite reports `progress.total 1168` against `summary.total 1150`, and anyone reading the Test Runner window concludes 18 tests are broken. That is exactly what happened, and it cost real triage time.

`TestProjects/UnityMCPTests` runs the Built-in pipeline with no render-pipelines-core, so `manage_graphics` `ping` returns `hasVolumeSystem`/`hasURP`/`hasHDRP` all false and all 18 guards trip. This reproduces on a pristine `beta` checkout.

## The fix

`Assert.Ignore` behind an explicit condition — NUnit has no condition-taking overload, hence the `if`. That buckets them as `Skipped:Ignored`, which every consumer already agrees on, and drops the misleading `Expected: True / But was: False` text from the message.

This matches the convention already used elsewhere in the suite for exactly this "environment not available" pattern: `WriteToConfigTests.cs:44`, `StdioBridgeReconnectTests.cs:30`, `ManageSceneMultiSceneTests.cs:28`.

The two helpers are renamed `AssumeVolumeSystem` → `RequireVolumeSystem` and `AssumeURP` → `RequireURP`, since `Assume*` named the very NUnit API being dropped. That accounts for the 17 otherwise-mechanical call-site lines in the diff.

## Result

Full EditMode suite on **2021.3.45f2**:

| | before | after |
|---|---|---|
| `progress.total` | 1168 | 1168 |
| `summary.total` | 1150 | **1168** |
| passed | 1094 | 1094 |
| failed | 0 | 0 |
| skipped | 56 | **74** |

`passed` is unchanged, and the two totals now reconcile.

## Scope note

This does **not** change the run's top-level `resultState`, which stays `"Skipped:Ignored"` — roughly 56 legitimately-skipped tests already force that on a pristine `beta`. Flagging it because it matters for any future CI gate: `"Skipped:Ignored"` is not `"Passed"`, so a gate keyed on `resultState` would report false red on a clean suite. That is a separate problem from this PR.

Four `Assert.Inconclusive` calls elsewhere (`MCPToolParameterTests.cs:200`, `UIDocumentSerializationTests.cs:105/136/232`) are left alone — they currently pass, and changing the failure mode of passing tests would be speculative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved handling of unavailable rendering systems during graphics tests.
  * Tests now skip cleanly when required volume, URP, or HDRP functionality is not available.
  * Updated pipeline settings coverage to avoid inconclusive results when supported pipelines are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->