### PR TITLE
fix: deduplicate CodeDom assembly references

### DIFF
--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -30,11 +30,13 @@ namespace MCPForUnity.Editor.Tools
 
         private static readonly List<HistoryEntry> _history = new List<HistoryEntry>();
         private static string[] _cachedAssemblyPaths;
+        private static string[] _cachedCodeDomAssemblyPaths;
 
         [UnityEditor.InitializeOnLoadMethod]
         private static void OnDomainReload()
         {
             _cachedAssemblyPaths = null;
+            _cachedCodeDomAssemblyPaths = null;
             RoslynCompiler.ResetCache();
         }
 
@@ -342,6 +344,10 @@ namespace MCPForUnity.Editor.Tools
 
         internal static string[] FilterAssemblyPathsForCodeDom(string[] allPaths)
         {
+            var useCache = ReferenceEquals(allPaths, _cachedAssemblyPaths);
+            if (useCache && _cachedCodeDomAssemblyPaths != null)
+                return _cachedCodeDomAssemblyPaths;
+
             var hasNetstandard = allPaths.Any(p =>
                 string.Equals(Path.GetFileNameWithoutExtension(p), "netstandard", StringComparison.OrdinalIgnoreCase));
 
@@ -350,7 +356,10 @@ namespace MCPForUnity.Editor.Tools
                     !_codedomDuplicateAssemblies.Contains(Path.GetFileNameWithoutExtension(p))).ToArray()
                 : allPaths;
 
-            return DeduplicateAssemblyPathsForCodeDom(filtered);
+            var result = DeduplicateAssemblyPathsForCodeDom(filtered);
+            if (useCache)
+                _cachedCodeDomAssemblyPaths = result;
+            return result;
         }
 
         private static string[] DeduplicateAssemblyPathsForCodeDom(string[] paths)

--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -340,16 +340,103 @@ namespace MCPForUnity.Editor.Tools
             "System.Collections",
         };
 
-        private static string[] FilterAssemblyPathsForCodeDom(string[] allPaths)
+        internal static string[] FilterAssemblyPathsForCodeDom(string[] allPaths)
         {
-            bool hasNetstandard = allPaths.Any(p =>
+            var hasNetstandard = allPaths.Any(p =>
                 string.Equals(Path.GetFileNameWithoutExtension(p), "netstandard", StringComparison.OrdinalIgnoreCase));
 
-            if (!hasNetstandard)
-                return allPaths;
+            var filtered = hasNetstandard
+                ? allPaths.Where(p =>
+                    !_codedomDuplicateAssemblies.Contains(Path.GetFileNameWithoutExtension(p))).ToArray()
+                : allPaths;
 
-            return allPaths.Where(p =>
-                !_codedomDuplicateAssemblies.Contains(Path.GetFileNameWithoutExtension(p))).ToArray();
+            return DeduplicateAssemblyPathsForCodeDom(filtered);
+        }
+
+        private static string[] DeduplicateAssemblyPathsForCodeDom(string[] paths)
+        {
+            var candidates = new List<CodeDomAssemblyCandidate>();
+            var unresolvedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var path in paths)
+            {
+                try
+                {
+                    candidates.Add(new CodeDomAssemblyCandidate(path, AssemblyName.GetAssemblyName(path)));
+                }
+                catch
+                {
+                    unresolvedPaths.Add(path);
+                }
+            }
+
+            var groups = candidates
+                .GroupBy(candidate => candidate.AssemblyName.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (groups.All(group => group.Count() == 1))
+                return paths;
+
+            var referenceCounts = GetLoadedAssemblyReferenceCounts();
+            var selectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var group in groups)
+            {
+                var selected = group
+                    .OrderByDescending(candidate => GetReferenceCount(referenceCounts, candidate.AssemblyName.FullName))
+                    .ThenByDescending(candidate => candidate.AssemblyName.Version)
+                    .ThenBy(candidate => candidate.Path, StringComparer.OrdinalIgnoreCase)
+                    .First();
+                selectedPaths.Add(selected.Path);
+            }
+
+            return paths.Where(path => unresolvedPaths.Contains(path) || selectedPaths.Contains(path)).ToArray();
+        }
+
+        private static Dictionary<string, int> GetLoadedAssemblyReferenceCounts()
+        {
+            var referenceCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var assembly in UnityAssembliesCompat.GetLoadedAssemblies())
+            {
+                if (assembly.IsDynamic) continue;
+
+                AssemblyName[] referencedAssemblies;
+                try
+                {
+                    referencedAssemblies = assembly.GetReferencedAssemblies();
+                }
+                catch (NotSupportedException)
+                {
+                    continue;
+                }
+
+                foreach (var referencedAssembly in referencedAssemblies)
+                {
+                    var fullName = referencedAssembly.FullName;
+                    referenceCounts.TryGetValue(fullName, out var count);
+                    referenceCounts[fullName] = count + 1;
+                }
+            }
+
+            return referenceCounts;
+        }
+
+        private static int GetReferenceCount(Dictionary<string, int> referenceCounts, string fullName)
+        {
+            return referenceCounts.TryGetValue(fullName, out var count) ? count : 0;
+        }
+
+        private sealed class CodeDomAssemblyCandidate
+        {
+            public CodeDomAssemblyCandidate(string path, AssemblyName assemblyName)
+            {
+                Path = path;
+                AssemblyName = assemblyName;
+            }
+
+            public string Path { get; }
+            public AssemblyName AssemblyName { get; }
         }
 
         // ──────────────────── Shared helpers ────────────────────

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.CodeDom.Compiler;
+using System.IO;
+using System.Linq;
+using Microsoft.CSharp;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using MCPForUnity.Editor.Tools;
@@ -367,7 +372,122 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.IsNotNull(result["data"]["result"]);
         }
 
+        [Test]
+        public void FilterAssemblyPathsForCodeDom_WithNetstandard_PreservesSystemSecurity()
+        {
+            var tempRoot = CreateTempDirectory();
+            try
+            {
+                var netstandardPath = CompileVersionedAssembly(tempRoot, "netstandard", "2.0.0.0");
+                var securityFixturePath = CompileVersionedAssembly(tempRoot, "SystemSecurityFixture", "4.0.0.0");
+                var systemSecurityPath = Path.Combine(
+                    Path.GetDirectoryName(securityFixturePath),
+                    "System.Security.dll");
+                File.Copy(securityFixturePath, systemSecurityPath);
+
+                var filtered = ExecuteCode.FilterAssemblyPathsForCodeDom(new[]
+                {
+                    netstandardPath,
+                    systemSecurityPath,
+                });
+
+                CollectionAssert.Contains(filtered, systemSecurityPath);
+            }
+            finally
+            {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+
+        [Test]
+        public void FilterAssemblyPathsForCodeDom_DuplicateNames_PrefersReferencedVersion()
+        {
+            var tempRoot = CreateTempDirectory();
+            try
+            {
+                var assemblyName = "McpCodeDomDuplicate" + Guid.NewGuid().ToString("N");
+                var referencedPath = CompileVersionedAssembly(tempRoot, assemblyName, "1.0.0.0");
+                var newerPath = CompileVersionedAssembly(tempRoot, assemblyName, "2.0.0.0");
+                LoadAssemblyReferencing(referencedPath);
+
+                var filtered = ExecuteCode.FilterAssemblyPathsForCodeDom(new[]
+                {
+                    newerPath,
+                    referencedPath,
+                });
+
+                Assert.AreEqual(1, filtered.Length);
+                Assert.AreEqual(referencedPath, filtered[0]);
+            }
+            finally
+            {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+
         // ──────────────────── Helpers ────────────────────
+
+        private static string CreateTempDirectory()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "UnityMCPTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static string CompileVersionedAssembly(string tempRoot, string assemblyName, string version)
+        {
+            var outputDirectory = Path.Combine(tempRoot, version);
+            Directory.CreateDirectory(outputDirectory);
+            var outputPath = Path.Combine(outputDirectory, assemblyName + ".dll");
+            var source =
+                "using System.Reflection;\n" +
+                "[assembly: AssemblyVersion(\"" + version + "\")]\n" +
+                "public sealed class VersionMarker { }";
+
+            using (var provider = new CSharpCodeProvider())
+            {
+                var parameters = new CompilerParameters
+                {
+                    GenerateExecutable = false,
+                    GenerateInMemory = false,
+                    OutputAssembly = outputPath,
+                };
+                var results = provider.CompileAssemblyFromSource(parameters, source);
+                AssertCompilerSuccess(results);
+            }
+
+            return outputPath;
+        }
+
+        private static void LoadAssemblyReferencing(string referencedAssemblyPath)
+        {
+            using (var provider = new CSharpCodeProvider())
+            {
+                var parameters = new CompilerParameters
+                {
+                    GenerateExecutable = false,
+                    GenerateInMemory = true,
+                };
+                parameters.ReferencedAssemblies.Add(referencedAssemblyPath);
+
+                var results = provider.CompileAssemblyFromSource(
+                    parameters,
+                    "public static class ReferenceHolder { " +
+                    "public static System.Type Get() { return typeof(VersionMarker); } }");
+                AssertCompilerSuccess(results);
+                Assert.IsNotNull(results.CompiledAssembly);
+            }
+        }
+
+        private static void AssertCompilerSuccess(CompilerResults results)
+        {
+            var errors = results.Errors
+                .Cast<CompilerError>()
+                .Where(error => !error.IsWarning)
+                .Select(error => error.ToString())
+                .ToArray();
+            Assert.IsFalse(results.Errors.HasErrors, string.Join("\n", errors));
+        }
 
         private static JObject Execute(string code)
         {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.CSharp;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -421,6 +422,53 @@ namespace MCPForUnityTests.Editor.Tools
             }
             finally
             {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+
+        [Test]
+        public void FilterAssemblyPathsForCodeDom_CachedAssemblyPaths_ReusesResultUntilDomainReload()
+        {
+            var tempRoot = CreateTempDirectory();
+            var cachedAssemblyPathsField = typeof(ExecuteCode).GetField(
+                "_cachedAssemblyPaths",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var cachedCodeDomAssemblyPathsField = typeof(ExecuteCode).GetField(
+                "_cachedCodeDomAssemblyPaths",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var onDomainReload = typeof(ExecuteCode).GetMethod(
+                "OnDomainReload",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(cachedAssemblyPathsField);
+            Assert.IsNotNull(cachedCodeDomAssemblyPathsField);
+            Assert.IsNotNull(onDomainReload);
+
+            try
+            {
+                onDomainReload.Invoke(null, null);
+                var assemblyName = "McpCodeDomCache" + Guid.NewGuid().ToString("N");
+                var olderPath = CompileVersionedAssembly(tempRoot, assemblyName, "1.0.0.0");
+                var newerPath = CompileVersionedAssembly(tempRoot, assemblyName, "2.0.0.0");
+                var cachedAssemblyPaths = new[] { olderPath, newerPath };
+                cachedAssemblyPathsField.SetValue(null, cachedAssemblyPaths);
+
+                var first = ExecuteCode.FilterAssemblyPathsForCodeDom(cachedAssemblyPaths);
+                Assert.AreEqual(1, first.Length);
+
+                File.WriteAllText(olderPath, "invalidated");
+                File.WriteAllText(newerPath, "invalidated");
+                var second = ExecuteCode.FilterAssemblyPathsForCodeDom(cachedAssemblyPaths);
+                Assert.AreSame(first, second);
+
+                onDomainReload.Invoke(null, null);
+                cachedAssemblyPathsField.SetValue(null, cachedAssemblyPaths);
+                var afterReload = ExecuteCode.FilterAssemblyPathsForCodeDom(cachedAssemblyPaths);
+                Assert.AreNotSame(first, afterReload);
+                Assert.AreEqual(2, afterReload.Length);
+            }
+            finally
+            {
+                onDomainReload.Invoke(null, null);
                 Directory.Delete(tempRoot, true);
             }
         }


### PR DESCRIPTION
## Description

Fix CodeDom dynamic compilation failures when Unity has multiple loaded assemblies with the same simple name. The observed failure involved `System.Security` 2.0.0.0 and 4.0.0.0: excluding `System.Security` entirely avoided the duplicate-reference error but made types defined only in that assembly unavailable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Preserve the existing netstandard facade exclusions used by the CodeDom backend.
- Deduplicate remaining CodeDom references by managed assembly simple name.
- Prefer the exact assembly identity referenced by the most loaded assemblies, then the higher version, then a stable path tie-break.
- Preserve `System.Security` instead of removing it from CodeDom references.
- Add portable EditMode regression coverage using temporary generated assemblies, without project-specific DLL paths.

## Compatibility / Package Source

- Unity version(s) tested: Unity 2022.3.23f1 on Windows
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): local file checkout based on `CoplayDev/unity-mcp#beta` at `fc70dda7`
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): not applicable (`file:` checkout)

## Testing/Screenshots/Recordings

- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

Validation in the active Unity 2022.3 project:

- Package scripts compiled with no `ExecuteCode` or `error CS` Console entries.
- CodeDom selected `System.Security, Version=4.0.0.0` from simultaneous 2.0.0.0 and 4.0.0.0 inputs.
- CodeDom compiled and resolved `System.Security.Cryptography.ProtectedData` from `System.Security, Version=4.0.0.0`.
- Equivalent temporary-assembly checks preserved a file named `System.Security.dll` with `netstandard` present and selected referenced version 1.0.0.0 over unreferenced version 2.0.0.0.

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

No tool or resource surface changed.

## Related Issues

None.

## Additional Notes

The two Unity EditMode regression tests were added to `ExecuteCodeTests.cs`, but the standalone `UnityMCPTests` project was not opened or run locally. The active host project was used for package compilation and equivalent runtime checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CodeDom compilation reliability when projects include multiple versions of the same assembly.
  * Preserved required security assemblies during compilation with netstandard references.
  * Added smarter assembly selection to favor versions referenced by the running Unity environment.
  * Improved repeated compilation performance by reusing filtered assembly paths until the Unity domain reloads.

* **Tests**
  * Added regression coverage for assembly filtering, duplicate assembly resolution, security assemblies, and cache reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->