### PR TITLE
fix(server): address resources by URI in agent-facing prose

### DIFF
--- a/MCPForUnity/Editor/Tools/RefreshUnity.cs
+++ b/MCPForUnity/Editor/Tools/RefreshUnity.cs
@@ -120,7 +120,7 @@ namespace MCPForUnity.Editor.Tools
                 resulting_state = resultingState,
                 hint = shouldWaitForReady
                     ? "Unity refresh completed; editor should be ready."
-                    : "If Unity enters compilation/domain reload, poll editor_state until ready_for_tools is true."
+                    : "If Unity enters compilation/domain reload, poll the mcpforunity://editor/state resource until data.advice.ready_for_tools is true."
             });
         }
 

--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -311,19 +311,19 @@ Targeting Unity instances:
 Important Workflows:
 
 Resources vs Tools:
-- Use RESOURCES to read editor state (editor_state, project_info, project_tags, tests, etc)
+- Use RESOURCES to read editor state (mcpforunity://editor/state, mcpforunity://project/info, mcpforunity://project/tags, mcpforunity://tests, etc)
 - Use TOOLS to perform actions and mutations (manage_editor for play mode control, tag/layer management, etc)
 - Always check related resources before modifying the engine state with tools
 
 Reading resources (read this before using ANY resource named below):
 - Resources are addressed by URI, never by name. A resource's name and URI are NOT interchangeable: names use underscores (e.g. editor_state) while URIs use slashes (e.g. mcpforunity://editor/state). Do NOT build a URI by swapping separators in the name — you will 404.
-- Always read the exact URI from your MCP client's resource listing (resources/list). Where these instructions mention a resource by name, look up its URI in that listing rather than guessing it.
+- These instructions always spell resources as full mcpforunity:// URIs — read one exactly as written. If you only have a name (from resources/list or another tool's output), look its URI up in resources/list rather than guessing it.
 - Resource payloads are wrapped: the content lives under a top-level `data` object, so field paths are `data.<section>.<field>` (e.g. `data.advice.ready_for_tools`), not bare top-level fields.
 
 Script Management:
 - After creating or modifying scripts (by your own tools or the `manage_script` tool) use `read_console` to check for compilation errors before proceeding
 - Only after successful compilation can new components/types be used
-- You can poll the `editor_state` resource's `isCompiling` field to check if the domain reload is complete
+- You can poll mcpforunity://editor/state and read `data.compilation.is_compiling` to check if the domain reload is complete, or `data.advice.ready_for_tools` for overall readiness
 
 Scene Setup:
 - Always include a Camera and main Light (Directional Light) in new scenes
@@ -339,7 +339,7 @@ Console Monitoring:
 - Filter by log type (Error, Warning, Log) to focus on specific issues
 
 Menu Items:
-- Use `execute_menu_item` when you have read the menu items resource
+- Use `execute_menu_item` when you have read the mcpforunity://menu-items resource
 - This lets you interact with Unity's menu system and third-party tools
 
 Unity API Verification (requires 'docs' tool group):

--- a/Server/src/services/tools/refresh_unity.py
+++ b/Server/src/services/tools/refresh_unity.py
@@ -180,7 +180,7 @@ async def refresh_unity(
     compile: Annotated[Literal["none", "request"],
                        "Whether to request compilation"] = "none",
     wait_for_ready: Annotated[bool,
-                              "If true, wait until editor_state.advice.ready_for_tools is true"] = True,
+                              "If true, wait until mcpforunity://editor/state reports data.advice.ready_for_tools true"] = True,
 ) -> MCPResponse | dict[str, Any]:
     unity_instance = await get_unity_instance_from_context(ctx)
 

--- a/Server/tests/test_resource_uri_references.py
+++ b/Server/tests/test_resource_uri_references.py
@@ -1,0 +1,143 @@
+"""Agent-facing prose must address resources by URI, never by bare name.
+
+A resource's name and its URI are deliberately different (`editor_state` vs
+`mcpforunity://editor/state`), and the URI scheme is not derivable from the
+name. Any instruction, description or tool-result hint that mentions a resource
+by name alone sends the reader to build `mcpforunity://<name>`, which 404s.
+"""
+import os
+import re
+import typing
+from pathlib import Path
+
+import pytest
+
+import services.resources as resources_pkg
+import services.tools as tools_pkg
+from services.registry import get_registered_resources, get_registered_tools
+from utils.module_discovery import discover_modules
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UNITY_EDITOR_DIR = REPO_ROOT / "MCPForUnity" / "Editor"
+
+# C# string literal, honouring backslash escapes.
+CSHARP_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+@pytest.fixture(scope="module")
+def build_instructions():
+    """Import `main` without leaking the env vars it sets at import time."""
+    before = dict(os.environ)
+    from main import _build_instructions
+    os.environ.clear()
+    os.environ.update(before)
+    return _build_instructions
+
+
+@pytest.fixture(scope="module")
+def resource_uris_by_name() -> dict[str, str]:
+    """Registered resources whose name is an unambiguous snake_case identifier.
+
+    Single-word names (`tests`, `cameras`, `volumes`) are ordinary English and
+    would match prose that is not referring to the resource at all.
+    """
+    list(discover_modules(Path(resources_pkg.__file__).parent,
+                          resources_pkg.__package__))
+    registered = get_registered_resources()
+    assert registered, "no resources registered — discovery failed"
+    return {r["name"]: r["uri"] for r in registered if "_" in r["name"]}
+
+
+def _offenders(text: str | None, where: str, uris_by_name: dict[str, str]) -> list[str]:
+    """Lines that name a resource without also giving that resource's URI."""
+    if not text:
+        return []
+    found = []
+    for line in str(text).splitlines():
+        for name, uri in uris_by_name.items():
+            if re.search(rf"\b{re.escape(name)}\b", line) and uri not in line:
+                found.append(f"{where}: '{name}' without '{uri}' in: {line.strip()}")
+    return found
+
+
+@pytest.mark.parametrize("project_scoped_tools", [True, False])
+def test_server_instructions_reference_resources_by_uri(
+    project_scoped_tools: bool, build_instructions, resource_uris_by_name: dict[str, str]
+):
+    offenders = _offenders(
+        build_instructions(project_scoped_tools),
+        f"instructions(project_scoped_tools={project_scoped_tools})",
+        resource_uris_by_name,
+    )
+    assert not offenders, "\n".join(offenders)
+
+
+def test_resource_descriptions_reference_resources_by_uri(
+    resource_uris_by_name: dict[str, str]
+):
+    offenders = []
+    for resource in get_registered_resources():
+        offenders += _offenders(
+            resource.get("description"),
+            f"resource '{resource['name']}' description",
+            resource_uris_by_name,
+        )
+    assert not offenders, "\n".join(offenders)
+
+
+def test_tool_descriptions_reference_resources_by_uri(
+    resource_uris_by_name: dict[str, str]
+):
+    list(discover_modules(Path(tools_pkg.__file__).parent, tools_pkg.__package__))
+    registered = get_registered_tools()
+    assert registered, "no tools registered — discovery failed"
+
+    offenders = []
+    for tool in registered:
+        name = tool["name"]
+        func = tool["func"]
+        offenders += _offenders(
+            tool.get("kwargs", {}).get("description"),
+            f"tool '{name}' description",
+            resource_uris_by_name,
+        )
+        offenders += _offenders(
+            func.__doc__, f"tool '{name}' docstring", resource_uris_by_name)
+
+        try:
+            hints = typing.get_type_hints(func, include_extras=True)
+        except Exception:
+            continue
+        for param, hint in hints.items():
+            for meta in getattr(hint, "__metadata__", ()):
+                if isinstance(meta, str):
+                    offenders += _offenders(
+                        meta, f"tool '{name}' parameter '{param}'", resource_uris_by_name)
+
+    assert not offenders, "\n".join(offenders)
+
+
+def test_unity_tool_result_strings_reference_resources_by_uri(
+    resource_uris_by_name: dict[str, str]
+):
+    """Hints Unity returns in tool payloads are read by the same agents.
+
+    Only multi-word literals are checked: a bare token such as "get_tests" is a
+    command name, not prose telling the reader to go read a resource.
+    """
+    assert UNITY_EDITOR_DIR.is_dir(), f"{UNITY_EDITOR_DIR} not found"
+
+    offenders = []
+    for source in sorted(UNITY_EDITOR_DIR.rglob("*.cs")):
+        text = source.read_text(encoding="utf-8", errors="replace")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            for match in CSHARP_STRING.finditer(line):
+                literal = match.group(1)
+                if " " not in literal.strip():
+                    continue
+                offenders += _offenders(
+                    literal,
+                    f"{source.relative_to(REPO_ROOT).as_posix()}:{line_no}",
+                    resource_uris_by_name,
+                )
+    assert not offenders, "\n".join(offenders)

--- a/Server/tests/test_resource_uri_references.py
+++ b/Server/tests/test_resource_uri_references.py
@@ -104,10 +104,7 @@ def test_tool_descriptions_reference_resources_by_uri(
         offenders += _offenders(
             func.__doc__, f"tool '{name}' docstring", resource_uris_by_name)
 
-        try:
-            hints = typing.get_type_hints(func, include_extras=True)
-        except Exception:
-            continue
+        hints = typing.get_type_hints(func, include_extras=True)
         for param, hint in hints.items():
             for meta in getattr(hint, "__metadata__", ()):
                 if isinstance(meta, str):
@@ -140,4 +137,34 @@ def test_unity_tool_result_strings_reference_resources_by_uri(
                     f"{source.relative_to(REPO_ROOT).as_posix()}:{line_no}",
                     resource_uris_by_name,
                 )
+    assert not offenders, "\n".join(offenders)
+
+
+def test_agent_facing_markdown_references_resources_by_uri(
+    resource_uris_by_name: dict[str, str]
+):
+    """Docs that tell a reader to go read a resource must give its URI.
+
+    Scoped to the surfaces that issue that instruction: the skill agents load,
+    and the per-tool reference pages. Excluded deliberately —
+    `website/docs/reference/resources/` is a generated catalog that puts each
+    name in a heading and its URI on the following line, and the guides and
+    getting-started pages name resources as subjects of a sentence rather than
+    telling anyone to construct a URI.
+    """
+    targets = [REPO_ROOT / "unity-mcp-skill" / "SKILL.md"]
+    targets += sorted((REPO_ROOT / "website" / "docs" /
+                       "reference" / "tools").rglob("*.md"))
+    assert len(targets) > 1, "expected the skill and the tool reference pages"
+
+    offenders = []
+    for doc in targets:
+        assert doc.is_file(), f"{doc} not found"
+        text = doc.read_text(encoding="utf-8", errors="replace")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            offenders += _offenders(
+                line,
+                f"{doc.relative_to(REPO_ROOT).as_posix()}:{line_no}",
+                resource_uris_by_name,
+            )
     assert not offenders, "\n".join(offenders)

--- a/unity-mcp-skill/SKILL.md
+++ b/unity-mcp-skill/SKILL.md
@@ -129,7 +129,7 @@ read_console(
 )
 ```
 
-### 5. Always Check `editor_state` Before Complex Operations
+### 5. Always Check `mcpforunity://editor/state` Before Complex Operations
 
 ```python
 # Read mcpforunity://editor/state to check:
@@ -268,7 +268,7 @@ set_active_instance(instance="MyProject@abc123")
 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
-| Tools return "busy" | Compilation in progress | Wait, check `editor_state` |
+| Tools return "busy" | Compilation in progress | Wait, check `mcpforunity://editor/state` |
 | "stale_file" error | File changed since SHA | Re-fetch SHA with `get_sha`, retry |
 | Connection lost | Domain reload | Wait ~5s, reconnect |
 | Commands fail silently | Wrong instance | Check `set_active_instance` |

--- a/website/docs/reference/tools/core/manage_script.md
+++ b/website/docs/reference/tools/core/manage_script.md
@@ -84,6 +84,6 @@ Returns the full file. For just a SHA (to detect drift between reads and writes)
 
 ### After every create / delete
 
-Unity needs a domain reload to compile the new file (or notice the old one is gone). Poll the `editor_state` resource's `isCompiling` field until it flips back to `false`, then run [`read_console`](./read_console) to catch any compile errors before relying on the new types.
+Unity needs a domain reload to compile the new file (or notice the old one is gone). Poll the `mcpforunity://editor/state` resource until `data.compilation.is_compiling` flips back to `false`, then run [`read_console`](./read_console) to catch any compile errors before relying on the new types.
 <!-- examples:end -->
 

--- a/website/docs/reference/tools/core/refresh_unity.md
+++ b/website/docs/reference/tools/core/refresh_unity.md
@@ -21,7 +21,7 @@ Request a Unity asset database refresh and optionally a script compilation. Can 
 | `mode` | `Literal['if_dirty', 'force']` | — | Refresh mode |
 | `scope` | `Literal['assets', 'scripts', 'all']` | — | Refresh scope |
 | `compile` | `Literal['none', 'request']` | — | Whether to request compilation |
-| `wait_for_ready` | `bool` | — | If true, wait until editor_state.advice.ready_for_tools is true |
+| `wait_for_ready` | `bool` | — | If true, wait until mcpforunity://editor/state reports data.advice.ready_for_tools true |
 
 ## Returns
 

--- a/website/docs/reference/tools/core/script_apply_edits.md
+++ b/website/docs/reference/tools/core/script_apply_edits.md
@@ -181,6 +181,6 @@ Anchor ops are great for adding instrumentation near stable comment markers with
 
 ### After every edit
 
-Poll `editor_state.isCompiling` until it flips back to `false`, then run [`read_console`](./read_console) to catch any compile errors before relying on the new types.
+Poll the `mcpforunity://editor/state` resource until `data.compilation.is_compiling` flips back to `false`, then run [`read_console`](./read_console) to catch any compile errors before relying on the new types.
 <!-- examples:end -->
 


### PR DESCRIPTION
## Description

Fixes the recurring 404 where an agent turns a resource name into a URI:

1. `resources/list` returns `{"name":"editor_state","uri":"mcpforunity://editor/state", ...}`.
2. The server instructions say: *"You can poll the `editor_state` resource's `isCompiling` field to check if the domain reload is complete"*.
3. `refresh_unity` returns this hint in its result payload: *"If Unity enters compilation/domain reload, poll editor_state until ready_for_tools is true."*
4. Following (2) or (3) literally reads `mcpforunity://editor_state` → `Unknown resource`.

There's no pattern to infer instead. Most URIs are `category/thing` (`mcpforunity://editor/state`, `mcpforunity://project/info`, `mcpforunity://scene/cameras`) but several are flat (`mcpforunity://instances`, `mcpforunity://custom-tools`, `mcpforunity://menu-items`, `mcpforunity://tests`, `mcpforunity://tool-groups`). Neither "use the name" nor "guess the path" works.

#1244 added a warning to the instructions that names and URIs aren't interchangeable. That warning is correct and still there, but the strings that trigger the mistake were left naming resources bare — so the agent reads an instruction that contradicts the warning three lines above it. This changes every agent-facing reference to a full URI.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made

- `Server/src/main.py` — resource lists, the domain-reload polling instruction, and the menu-items line now use full URIs. Also corrects the field path: the instruction said `isCompiling`, which isn't a field of the payload — payloads are wrapped and snake_case, so it's `data.compilation.is_compiling`.
- `Server/src/services/tools/refresh_unity.py` — `wait_for_ready` description referred to `editor_state.advice.ready_for_tools`.
- `MCPForUnity/Editor/Tools/RefreshUnity.cs` — the hint returned in the `refresh_unity` result payload.
- `unity-mcp-skill/SKILL.md`, `website/docs/reference/**` — the same bare-name references in docs example blocks.
- New `Server/tests/test_resource_uri_references.py`.

### The test

Asserts no agent-facing prose mentions a resource by its snake_case name without also giving that resource's URI on the same line. Covers server instructions (both `project_scoped_tools` values), resource descriptions, tool descriptions and docstrings, `Annotated` parameter descriptions, and multi-word string literals under `MCPForUnity/Editor` — which is what catches the C# hint.

Two deliberate narrowings, documented in the test: single-word names (`tests`, `cameras`, `volumes`) are ordinary English and would match prose not referring to the resource at all; single-token C# literals are command names (`get_tests`), not instructions to go read something.

On the unfixed code the test fails 4/5, naming each offending string.

## Compatibility / Package Source
- Unity version(s) tested: n/a — the C# change is one string literal in a result payload
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `file:`

## Testing/Screenshots/Recordings
- [x] Python tests (`cd Server && uv run pytest tests/ -v`) — `1341 passed, 3 skipped` (1336 before, +5 new)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [ ] Package import/compile check
- [x] Not applicable (explain why in Additional Notes)

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [x] Regenerated `/website/docs/reference/` via `tools/generate_docs_reference.py`

## Related Issues

Relates to #1244 (added the names-vs-URIs warning; this fixes the strings that trigger the mistake).

## Additional Notes

No tool or resource behavior changes — descriptions, instructions and one result hint only, plus the test. The `refresh_unity` C# change is a string literal in the returned payload, so the Unity test legs have nothing to exercise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Unity Editor guidance to use canonical `mcpforunity://` resource URIs.
  * Clarified how to check editor readiness and compilation status through wrapped `data` fields.
  * Updated menu-item and post-operation instructions for more consistent resource access.

* **Bug Fixes**
  * Improved readiness polling guidance for Unity refresh operations.

* **Tests**
  * Added automated checks to ensure agent-facing references use registered resource URIs consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->