### PR TITLE
fix: restore HTTP transport for Codex (#1193)

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/CodexConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/CodexConfigurator.cs
@@ -12,8 +12,7 @@ namespace MCPForUnity.Editor.Clients.Configurators
             name = "Codex",
             windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "config.toml"),
             macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "config.toml"),
-            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "config.toml"),
-            SupportsHttpTransport = false
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex", "config.toml")
         })
         { }
 
@@ -31,8 +30,5 @@ namespace MCPForUnity.Editor.Clients.Configurators
             "Paste the configuration TOML",
             "Save and restart Codex"
         };
-
-        private static readonly ConfiguredTransport[] StdioOnly = { ConfiguredTransport.Stdio };
-        public override IReadOnlyList<ConfiguredTransport> SupportedTransports => StdioOnly;
     }
 }

--- a/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
+++ b/MCPForUnity/Editor/Clients/McpClientConfiguratorBase.cs
@@ -599,26 +599,7 @@ namespace MCPForUnity.Editor.Clients
             try
             {
                 string uvx = GetUvxPathOrError();
-
-                // BuildCodexServerBlock reads the global transport pref directly. Configure() gets
-                // that pref coerced for it by ClientConfigurationService.ConfigureWithTransportCoercion,
-                // but the snippet path does not, so a stdio-only client would otherwise render an
-                // HTTP block that connects and then exposes no tools (#1193).
-                bool original = EditorConfigurationCache.Instance.UseHttpTransport;
-                if (!original || Client.SupportsHttpTransport)
-                {
-                    return CodexConfigHelper.BuildCodexServerBlock(uvx);
-                }
-
-                try
-                {
-                    EditorConfigurationCache.Instance.SetUseHttpTransport(false);
-                    return CodexConfigHelper.BuildCodexServerBlock(uvx);
-                }
-                finally
-                {
-                    EditorConfigurationCache.Instance.SetUseHttpTransport(original);
-                }
+                return CodexConfigHelper.BuildCodexServerBlock(uvx);
             }
             catch (Exception ex)
             {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Clients/SupportedTransportsTests.cs
@@ -26,23 +26,21 @@ namespace MCPForUnityTests.Editor.Clients
         }
 
         [Test]
-        public void Codex_SupportsStdioOnly()
+        public void Codex_SupportsBothTransports()
         {
-            // Regression guard for #1193: Codex does not expose tools over the HTTP block, so it
-            // must advertise stdio only and let CoerceTransportFor pick stdio before Configure().
+            // Verified against Codex CLI 0.47.0: a bare `[mcp_servers.x] url = "..."` entry reports
+            // `transport: streamable_http` from `codex mcp get` and completes a full MCP handshake
+            // against a live server, with no feature flag set. #1193 was not Codex lacking HTTP.
             var codex = new CodexConfigurator();
-            CollectionAssert.AreEqual(
-                new[] { ConfiguredTransport.Stdio },
-                codex.SupportedTransports.ToList(),
-                "Codex must advertise stdio and nothing else");
-            Assert.IsFalse(codex.Client.SupportsHttpTransport, "Codex must not be treated as HTTP-capable");
+            var list = codex.SupportedTransports.ToList();
+            CollectionAssert.Contains(list, ConfiguredTransport.Stdio);
+            CollectionAssert.Contains(list, ConfiguredTransport.Http);
+            Assert.IsTrue(codex.Client.SupportsHttpTransport, "Codex is HTTP-capable");
         }
 
         [Test]
-        public void Codex_ManualSnippet_IsStdio_EvenWhenHttpPreferred()
+        public void Codex_ManualSnippet_RendersUrl_WhenHttpPreferred()
         {
-            // The snippet path does not go through ConfigureWithTransportCoercion, so with the
-            // global HTTP pref on it used to render a url block for a client that cannot use one.
             var cache = EditorConfigurationCache.Instance;
             bool original = cache.UseHttpTransport;
             try
@@ -50,9 +48,27 @@ namespace MCPForUnityTests.Editor.Clients
                 cache.SetUseHttpTransport(true);
                 string snippet = new CodexConfigurator().GetManualSnippet();
 
-                StringAssert.Contains("command", snippet, "Codex snippet must configure stdio");
-                Assert.IsFalse(snippet.Contains("url ="), "Codex snippet must not configure an HTTP url");
+                StringAssert.Contains("url =", snippet, "Codex snippet must configure the HTTP url");
                 Assert.IsTrue(cache.UseHttpTransport, "The global transport pref must be restored");
+            }
+            finally
+            {
+                cache.SetUseHttpTransport(original);
+            }
+        }
+
+        [Test]
+        public void Codex_ManualSnippet_RendersCommand_WhenStdioPreferred()
+        {
+            var cache = EditorConfigurationCache.Instance;
+            bool original = cache.UseHttpTransport;
+            try
+            {
+                cache.SetUseHttpTransport(false);
+                string snippet = new CodexConfigurator().GetManualSnippet();
+
+                StringAssert.Contains("command", snippet, "Codex snippet must configure stdio");
+                Assert.IsFalse(snippet.Contains("url ="), "Stdio snippet must not carry an HTTP url");
             }
             finally
             {


### PR DESCRIPTION
Re: #1193. **This partially reverts #1292**, which I merged yesterday.

## What #1292 got wrong

It set `SupportsHttpTransport = false` and `SupportedTransports => { Stdio }` on `CodexConfigurator`, on the theory that Codex cannot expose tools over an HTTP block. Tested against **Codex CLI 0.47.0**, that is not true — and the change removed a working capability for every Codex user.

## Evidence

All tests used an isolated `CODEX_HOME`; no real config was touched.

**Config parsing** (`codex mcp list` / `codex mcp get`) — all identical, `enabled`, `transport: streamable_http`:

| Config | Result |
|---|---|
| `url` only, no flag | works |
| `url` + `[features] rmcp_client = true` | identical |
| `url` + root `experimental_use_rmcp_client = true` | identical |
| both | identical |
| a deliberately bogus feature key | identical — unknown feature keys are silently ignored |

**End-to-end** against a live `mcp-for-unity --transport http` server, using the exact TOML `BuildCodexServerBlock` emits:

```
Created new transport with session ID: f62f8533b4514e16bb86008dc0040b47
POST /mcp  200 OK       (initialize)
POST /mcp  202 Accepted (notifications/initialized)
GET  /mcp  200 OK       (SSE stream)
POST /mcp  200 OK       (tools/list)
```

Full handshake. The run then failed on the *model* (`gpt-5.1-codex` unavailable on that account), which is downstream of MCP and unrelated.

So on current Codex, HTTP works with a bare `url` and **no feature flag at all**.

## Changes

- `CodexConfigurator.cs` — drop `SupportsHttpTransport = false` (the `McpClient` default is already `true`) and delete the `SupportedTransports` override, since the base default is already `{ Stdio, Http }`
- `McpClientConfiguratorBase.cs` — delete the `GetManualSnippet` stdio coercion #1292 added. `CodexConfigurator` is the only subclass of `CodexMcpConfigurator`, so once Codex is HTTP-capable that branch is unreachable
- Tests assert both transports and cover the snippet in both directions

`[features] rmcp_client = true` is left alone: it is the current key name (the root `experimental_use_rmcp_client` form is deprecated per openai/codex#6995), it is harmless, and it enables the RMCP client OAuth needs. Deliberately **not** adding the deprecated key — it does nothing on current Codex and would linger in users' configs.

## Caveat for review

Verified against the Codex **CLI**. #1193 was reported against Codex **Desktop** on Windows 11, which I have not tested. #1292's remedy was too broad — that does not mean the reporter was wrong. Worth asking for their version and CLI-vs-Desktop. If Desktop genuinely cannot do HTTP, that belongs in Desktop-specific handling rather than a blanket capability removal.

Compiles clean on Unity 2021.3.45f2. Python untouched (`1340 passed, 3 skipped`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex integrations now support both HTTP and stdio connection methods.
  * Generated setup snippets use the preferred transport, providing either a URL or command-based configuration.
* **Bug Fixes**
  * Improved manual configuration snippets so they accurately reflect the selected connection method.
* **Tests**
  * Added coverage for HTTP-preferred and stdio-preferred Codex configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->