### PR TITLE
ci: retire safe-to-test gate, make skipped Unity checks visible

### DIFF
--- a/.github/workflows/e2e-bridge.yml
+++ b/.github/workflows/e2e-bridge.yml
@@ -45,7 +45,17 @@ jobs:
             echo "unity_ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "unity_ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Unity license secrets absent; E2E bridge smoke will be skipped (not failed)."
+            echo "::warning::E2E bridge smoke SKIPPED - no license secrets in scope (normal for fork PRs). This check is NOT a pass: nothing was booted or exercised."
+            # Every step below is gated on unity_ok, so the job reports a green check
+            # having run nothing at all. Say so plainly on the run page.
+            {
+              echo "## :warning: E2E bridge smoke was SKIPPED"
+              echo
+              echo "No Unity license secrets were in scope, so **no Editor was booted and no tool call was exercised**."
+              echo "The green check means the job exited cleanly - **not** that the bridge works."
+              echo
+              echo "GitHub withholds repository secrets from workflow runs triggered by a fork's pull request."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - uses: actions/checkout@v4

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -25,9 +25,14 @@ on:
   # Same-repo PRs get a unity-tests status check on every open / push via this trigger
   # (mirrors python-tests.yml). Fork PRs ALSO fire this trigger but run in the fork's
   # context without secrets — the detect step downstream writes unity_ok=false and the
-  # job exits clean with a "missing license secrets" notice so the status check still
-  # appears. Maintainers apply 'safe-to-test' to invoke pull_request_target below for
-  # a real fork-PR test run.
+  # job reports a green check having compiled and tested nothing. That skip is stated
+  # loudly in the job's step summary so it is never mistaken for a pass.
+  #
+  # There is deliberately no pull_request_target trigger here. Running fork-authored
+  # C# through game-ci/unity-test-runner with UNITY_* secrets in scope is the classic
+  # "pwn request" shape — an [InitializeOnLoad] script in the PR is enough to read
+  # them. To test a fork PR, review the diff and push its branch into this repo; the
+  # push trigger above then runs the full suite in a genuinely trusted context.
   pull_request:
     branches: [main, beta]
     paths:
@@ -35,20 +40,8 @@ on:
       - MCPForUnity/Editor/**
       - MCPForUnity/Runtime/**
       - .github/workflows/unity-tests.yml
-  # Fork PRs: maintainer applies the 'safe-to-test' label after reviewing
-  # the diff. The workflow runs with UNITY_LICENSE in scope against the
-  # PR's head SHA. Re-pushed commits do NOT auto-trigger — maintainer must
-  # remove and re-apply the label to re-run after additional review.
-  pull_request_target:
-    types: [labeled]
-    branches: [main, beta]
-    paths:
-      - TestProjects/UnityMCPTests/**
-      - MCPForUnity/Editor/**
-      - MCPForUnity/Runtime/**
-      - .github/workflows/unity-tests.yml
 
-# Dedup runs for the same branch across push / pull_request / pull_request_target / workflow_call.
+# Dedup runs for the same branch across push / pull_request / workflow_call.
 # Same-repo PRs would otherwise fire both push (on the branch SHA) AND pull_request (on the PR);
 # concurrency keeps only the newer in-flight run per branch.
 concurrency:
@@ -61,23 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Gate (mirrored by testAllModes below):
-    #   - Always run for non-PR triggers (push / workflow_call / workflow_dispatch).
-    #   - Fork PRs: require 'safe-to-test' to be applied (existing secret-safety gate);
-    #     'full-matrix' may be added on top to opt into the full 4-version matrix.
-    #   - In-repo PRs: only re-run via pull_request_target when 'full-matrix' is the
-    #     label that just fired (the push-event run already covered the default leg).
-    if: >
-      github.event_name != 'pull_request_target' ||
-      (
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
-        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'full-matrix')
-      ) ||
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.label.name == 'full-matrix'
-      )
     outputs:
       versions: ${{ steps.set.outputs.versions }}
     steps:
@@ -97,12 +73,13 @@ jobs:
         run: |
           set -euo pipefail
           # Full matrix on: beta push, workflow_call (release pipelines), workflow_dispatch,
-          # or any PR (pull_request OR pull_request_target) labeled with 'full-matrix'.
+          # or a PR carrying the 'full-matrix' label. Note the label is only read when the
+          # workflow fires, so applying it to an open PR takes effect on the next push.
           # Default (single defaultVersion from tools/unity-versions.json) otherwise — fast PR feedback.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]] || \
              [[ "$EVENT_NAME" == "workflow_call" ]] || \
              { [[ "$EVENT_NAME" == "push" ]] && [[ "$GH_REF" == "refs/heads/beta" ]]; } || \
-             { { [[ "$EVENT_NAME" == "pull_request" ]] || [[ "$EVENT_NAME" == "pull_request_target" ]]; } && [[ "$FULL_MATRIX_LABEL" == "true" ]]; }; then
+             { [[ "$EVENT_NAME" == "pull_request" ]] && [[ "$FULL_MATRIX_LABEL" == "true" ]]; }; then
             versions=$(jq -c '[.versions[].id]' tools/unity-versions.json)
             echo "Trigger '$EVENT_NAME' on ref '$GH_REF' (full_matrix_label=$FULL_MATRIX_LABEL) → full matrix: $versions"
           else
@@ -117,17 +94,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: >
-      github.event_name != 'pull_request_target' ||
-      (
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
-        (github.event.label.name == 'safe-to-test' || github.event.label.name == 'full-matrix')
-      ) ||
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.label.name == 'full-matrix'
-      )
     strategy:
       fail-fast: false
       matrix:
@@ -159,10 +125,23 @@ jobs:
             echo "unity_ok=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # A skipped run and a real pass both report a green check, because step-level
+      # `if:` conditions produce step-conclusion `skipped`, which contributes nothing
+      # to the job conclusion. Make the difference unmissable on the run page so a
+      # reviewer never reads this green check as "the code compiled".
       - name: Skip Unity tests (missing license secrets)
         if: steps.detect.outputs.unity_ok != 'true'
         run: |
-          echo "Unity license secrets missing; skipping Unity tests."
+          echo "::warning::Unity tests SKIPPED - no license secrets in scope (normal for fork PRs). This check is NOT a pass: nothing was compiled or tested."
+          {
+            echo "## :warning: Unity tests were SKIPPED"
+            echo
+            echo "No Unity license secrets were in scope for this run, so **no C# was compiled and no test was executed**."
+            echo "The green check means the job exited cleanly - **not** that this code works."
+            echo
+            echo "GitHub withholds repository secrets from workflow runs triggered by a fork's pull request."
+            echo "To get real signal, a maintainer must run the suite against this code from a trusted context."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/cache@v4
         with:
@@ -218,8 +197,8 @@ jobs:
           fi
           python3 - "$RESULTS_XML" <<'PY'
           import sys, xml.etree.ElementTree as ET
-          # Escape workflow-command payloads so test-controlled XML (under pull_request_target this
-          # is fork-supplied) can't break annotation rendering or inject extra workflow commands.
+          # Escape workflow-command payloads so test-controlled XML can't break annotation
+          # rendering or inject extra workflow commands.
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
           def esc_data(s):
               return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")


### PR DESCRIPTION
## Problem

Fork PRs touching `MCPForUnity/**` get **green Unity checks that verified nothing.**

Observed on #1250 (a one-file C# change). Three green checks totalling 22 seconds, none of which compiled a line of the changed code:

```
3. Detect Unity license secrets -> success
4. Skip Unity tests (missing license secrets) -> success
6. Run domain reload tests -> skipped
7. Run tests -> skipped
8. Check test results -> skipped
```

Mechanism: GitHub withholds repository secrets from `pull_request` runs originating in a fork, so `Detect Unity license secrets` writes `unity_ok=false` and every real step is gated off. Step-level `if:` produces a *step* conclusion of `skipped`, which contributes nothing to the **job** conclusion — the job reports `success` having done nothing. There is no path to failure, because the only step that can `exit 1` (`Check test results`) is itself gated.

`e2e-bridge` is worse: even the checkout is gated, so it concludes green in ~4s having run exactly one step.

A reviewer reading `gh pr checks` sees green and reasonably assumes the code compiled. It did not.

## The `safe-to-test` escape hatch is broken

`unity-tests.yml` had a `pull_request_target: types: [labeled]` trigger so a maintainer could apply `safe-to-test` and get a real run. Applying it now fails:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. […] To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

Nothing in this repo changed. `actions/checkout@v4` is a floating tag that has since rolled forward to **v4.4.0**, which added this guardrail. Both checkouts pass `github.event.pull_request.head.sha`, so both are blocked.

## What this PR does

**1. Makes the skip unmissable.** Both workflows now emit `::warning::` plus a `$GITHUB_STEP_SUMMARY` block stating plainly that no C# was compiled and no test ran, and that the green check is not a pass. `unity-tests` previously logged only a plain `echo`; `e2e-bridge` had a warning but nothing on the run page.

**2. Retires `safe-to-test` rather than repairing it.** Repairing means `allow-unsafe-pr-checkout: true`, and the warning is accurate for this workflow specifically: after checkout, the job runs `game-ci/unity-test-runner`, which executes **arbitrary fork-authored C#** — any `[InitializeOnLoad]` editor script is enough — in a process with `UNITY_LICENSE`, `UNITY_EMAIL`, `UNITY_PASSWORD` and `UNITY_SERIAL` in its environment. `persist-credentials: false` and `permissions: contents: read` already limit `GITHUB_TOKEN` exposure, so the prize for an attacker is the Unity credentials, and a label was the only thing in the way. The gate was never used in practice.

Removing the trigger makes both job-level `if:` gates dead code — each began with `github.event_name != 'pull_request_target' ||`, unconditionally true once the trigger is gone — so they go too. Net **+39 / −50**.

To test a fork PR going forward: review the diff, then push its branch into this repo. The existing `push` trigger (`branches-ignore: [beta, main]`) runs the full licensed suite in a genuinely trusted context, against a repo-owned ref, with no opt-in flag.

## Known tradeoff

The `full-matrix` label used to re-trigger a run when applied to an open PR — that was `types: [labeled]` doing the work. It now takes effect on the **next push** instead. The label logic itself is unchanged and still works. If on-demand re-runs are wanted back, adding `labeled` to the `pull_request` trigger's `types` gets it safely (no secrets for forks, secrets for same-repo) and is a one-line follow-up.

## Deliberately not included

- **No SHA pinning.** There is no `.github/dependabot.yml`, so a lone pinned SHA would go stale with no update path while every other action stayed floating. `v4` resolves to `v4.4.0` today, so pinning to it changes nothing functionally.
- **No license-free compile job.** That is the actual fix for "fork PRs get no signal", and it deserves its own PR. Sketch: extract `UnityEngine.*`/`UnityEditor.*` DLLs at CI time from the public `unityci/editor` image (the pull needs no Unity credentials), cache the ~100 MB subset populated from a `beta` push, compile Runtime then Editor with `csc`. Fork PRs can read base-branch caches but not write them. Cost is real — the Editor asmdef resolves to 219 references and 110 `DefineConstants`, and that define list must be captured from a licensed run and re-captured when `defaultVersion` bumps.

**This PR does not give fork PRs real signal. It stops the absence of signal from looking like success.**

## Verification

Both workflows parse (`yaml.safe_load`). `unity-tests.yml` triggers are now `workflow_dispatch, workflow_call, push, pull_request`; jobs `matrix` and `testAllModes` are unchanged apart from the removed dead gates. The only surviving mention of `pull_request_target` is the comment explaining why there deliberately isn't one.

Since this PR modifies `.github/workflows/unity-tests.yml`, it matches that workflow's own paths filter — so its checks should exercise the new skip messaging directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear workflow warnings and summaries when Unity credentials are unavailable or tests are skipped.
  - Fork pull requests now run safely without secrets and explicitly report skipped Unity tests.
  - Full test-matrix selection is supported for labeled pull requests.

- **Documentation**
  - Improved workflow messages to clarify that skipped checks do not validate the E2E bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->