### PR TITLE
fix: make stdio bridge command timeout configurable (default 5m)

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -58,10 +58,32 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         private static int currentUnityPort = 6400;
         private static bool isAutoConnectMode = false;
         private const ulong MaxFrameBytes = 64UL * 1024 * 1024;
-        private const int FrameIOTimeoutMs = 30000;
+        // Command/frame I/O timeout for the stdio bridge TCP hop. Previously a
+        // hardcoded 30s const, which cut off long-running tool calls mid-execution
+        // (the client would then reconnect and re-send, causing the bridge to
+        // restart on a new port). Now defaults to 5 minutes and is overridable via
+        // the UNITY_MCP_STDIO_COMMAND_TIMEOUT_MS environment variable.
+        private const int DefaultFrameIOTimeoutMs = 300000;
+        private static readonly int FrameIOTimeoutMs = ResolveFrameIOTimeoutMs();
         private static readonly Stopwatch _uptime = Stopwatch.StartNew();
         private static volatile int _consecutiveTimeouts = 0;
         private static bool _processCommandsHooked = false;
+
+        private static int ResolveFrameIOTimeoutMs()
+        {
+            try
+            {
+                string raw = Environment.GetEnvironmentVariable("UNITY_MCP_STDIO_COMMAND_TIMEOUT_MS");
+                if (!string.IsNullOrWhiteSpace(raw)
+                    && int.TryParse(raw.Trim(), out int ms)
+                    && ms > 0)
+                {
+                    return ms;
+                }
+            }
+            catch { /* fall through to default */ }
+            return DefaultFrameIOTimeoutMs;
+        }
 
         private static void IoInfo(string s) { McpLog.Info(s, always: false); }
 
@@ -465,7 +487,9 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                         true
                     );
 
-                    client.ReceiveTimeout = 60000;
+                    // Keep the socket receive timeout at least as long as the command
+                    // timeout so it never fires before a long-running tool call completes.
+                    client.ReceiveTimeout = Math.Max(60000, FrameIOTimeoutMs);
 
                     _ = Task.Run(() => HandleClientAsync(client, token), token);
                 }
@@ -825,7 +849,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
 
                     // Evict commands stuck with IsExecuting=true for too long (e.g. from pre-reload state).
                     long nowMs = _uptime.ElapsedMilliseconds;
-                    const long staleThresholdMs = 2L * FrameIOTimeoutMs; // 60s
+                    long staleThresholdMs = 2L * FrameIOTimeoutMs; // 2x the command timeout
                     List<string> staleIds = null;
                     foreach (var kvp in commandQueue)
                     {

--- a/Server/src/core/config.py
+++ b/Server/src/core/config.py
@@ -3,7 +3,25 @@ Configuration settings for the MCP for Unity Server.
 This file contains all configurable parameters for the server.
 """
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
+
+
+def _env_float(name: str, default: float) -> float:
+    """Read a positive float from an environment variable, falling back to default.
+
+    Invalid or non-positive values are ignored so a bad override can't disable
+    the timeout entirely.
+    """
+    raw = os.environ.get(name)
+    if raw:
+        try:
+            value = float(raw.strip())
+            if value > 0:
+                return value
+        except (TypeError, ValueError):
+            pass
+    return default
 
 
 @dataclass
@@ -31,9 +49,19 @@ class ServerConfig:
     api_key_service_token: str | None = None         # The token value
 
     # Connection settings
-    connection_timeout: float = 30.0
+    # Socket receive timeout for a single Unity command (seconds). Raised from the
+    # historical 30s so long-running tools (e.g. imports, test runs, batched edits)
+    # aren't cut off mid-execution, which previously forced a reconnect + re-send and
+    # made the Unity stdio bridge restart. Override via UNITY_MCP_CONNECTION_TIMEOUT.
+    connection_timeout: float = field(
+        default_factory=lambda: _env_float("UNITY_MCP_CONNECTION_TIMEOUT", 300.0)
+    )
     # Hard ceiling on a command's total time across all retries (wedged-socket guard).
-    command_total_timeout: float = 90.0
+    # Kept above connection_timeout so a single slow-but-progressing command still fits.
+    # Override via UNITY_MCP_COMMAND_TOTAL_TIMEOUT.
+    command_total_timeout: float = field(
+        default_factory=lambda: _env_float("UNITY_MCP_COMMAND_TOTAL_TIMEOUT", 600.0)
+    )
     buffer_size: int = 16 * 1024 * 1024  # 16MB buffer
 
     # STDIO framing behaviour

--- a/Server/src/core/config.py
+++ b/Server/src/core/config.py
@@ -3,21 +3,23 @@ Configuration settings for the MCP for Unity Server.
 This file contains all configurable parameters for the server.
 """
 
+import math
 import os
 from dataclasses import dataclass, field
 
 
 def _env_float(name: str, default: float) -> float:
-    """Read a positive float from an environment variable, falling back to default.
+    """Read a positive, finite float from an environment variable.
 
-    Invalid or non-positive values are ignored so a bad override can't disable
-    the timeout entirely.
+    Invalid, non-positive, or non-finite values (e.g. "inf", "1e309", "nan")
+    are ignored so a bad override can't disable the timeout or produce unusable
+    socket/timeout behaviour.
     """
     raw = os.environ.get(name)
     if raw:
         try:
             value = float(raw.strip())
-            if value > 0:
+            if math.isfinite(value) and value > 0:
                 return value
         except (TypeError, ValueError):
             pass

--- a/Server/tests/test_core_infrastructure_characterization.py
+++ b/Server/tests/test_core_infrastructure_characterization.py
@@ -661,7 +661,8 @@ class TestServerConfigDefaults:
         assert config.unity_host == "127.0.0.1"
         assert config.unity_port == 6400
         assert config.mcp_port == 6500
-        assert config.connection_timeout == 30.0
+        assert config.connection_timeout == 300.0
+        assert config.command_total_timeout == 600.0
         assert config.buffer_size == 16 * 1024 * 1024
         assert config.require_framing is True
         assert config.handshake_timeout == 1.0

--- a/Server/tests/test_core_infrastructure_characterization.py
+++ b/Server/tests/test_core_infrastructure_characterization.py
@@ -654,8 +654,11 @@ class TestTelemetryDuration:
 class TestServerConfigDefaults:
     """Tests for ServerConfig default values."""
 
-    def test_config_default_values(self):
+    def test_config_default_values(self, monkeypatch):
         """Verify ServerConfig has expected default values."""
+        # Clear env overrides so the defaults aren't masked by the ambient env.
+        monkeypatch.delenv("UNITY_MCP_CONNECTION_TIMEOUT", raising=False)
+        monkeypatch.delenv("UNITY_MCP_COMMAND_TOTAL_TIMEOUT", raising=False)
         config = ServerConfig()
 
         assert config.unity_host == "127.0.0.1"
@@ -669,6 +672,25 @@ class TestServerConfigDefaults:
         assert config.framed_receive_timeout == 2.0
         assert config.max_heartbeat_frames == 16
         assert config.heartbeat_timeout == 2.0
+
+    def test_timeout_env_overrides_are_honored(self, monkeypatch):
+        """Valid env overrides for the stdio timeouts are applied."""
+        monkeypatch.setenv("UNITY_MCP_CONNECTION_TIMEOUT", "120.5")
+        monkeypatch.setenv("UNITY_MCP_COMMAND_TOTAL_TIMEOUT", "240")
+        config = ServerConfig()
+
+        assert config.connection_timeout == 120.5
+        assert config.command_total_timeout == 240.0
+
+    @pytest.mark.parametrize("bad_value", ["0", "-5", "abc", "", "inf", "Infinity", "1e309", "nan"])
+    def test_timeout_env_invalid_values_fall_back(self, monkeypatch, bad_value):
+        """Invalid, non-positive, or non-finite overrides preserve the defaults."""
+        monkeypatch.setenv("UNITY_MCP_CONNECTION_TIMEOUT", bad_value)
+        monkeypatch.setenv("UNITY_MCP_COMMAND_TOTAL_TIMEOUT", bad_value)
+        config = ServerConfig()
+
+        assert config.connection_timeout == 300.0
+        assert config.command_total_timeout == 600.0
 
     def test_config_logging_defaults(self):
         """Verify logging configuration defaults."""


### PR DESCRIPTION
## Problem

Long-running tool calls on the **stdio** transport (asset imports, `run_tests`, batched `manage_gameobject`/`execute_code`, etc.) are cut off ~30–90s into execution and can never finish. In the Unity console the bridge visibly restarts on alternating ports:

```
MCP-FOR-UNITY: StdioBridgeHost started on port 6400 ...
MCP-FOR-UNITY: StdioBridgeHost started on port 6402 ...
```

## Root cause

On the stdio path the timeout is hardcoded on **both** hops, with no way to raise it (unlike the WebSocket transport, where `WebSocketTransportClient` reads a per-call `timeout` off the wire at `WebSocketTransportClient.cs:605`):

| Hop | Value | Location |
|-----|-------|----------|
| Unity command execution + frame I/O | **30s** | `StdioBridgeHost.FrameIOTimeoutMs = 30000` (const) |
| Socket receive | 60s | `StdioBridgeHost` `client.ReceiveTimeout = 60000` |
| Stale-command eviction | 60s (`2×`) | `StdioBridgeHost` `staleThresholdMs` |
| Python socket recv (per attempt) | **30s** | `ServerConfig.connection_timeout = 30.0` |
| Python cross-retry ceiling | **90s** | `ServerConfig.command_total_timeout = 90.0` |

When the 30s/90s cap fires, the Python client closes the socket and re-sends the command on a fresh connection; the new connection makes Unity force-close the prior client and re-listen — the restart/port-churn seen above.

## Fix

Make all three configurable, defaulting to **5 minutes** (from the historical 30s), with env-var overrides. Invalid or non-positive values fall back to the default so a bad override can't disable the timeout.

**C# — `StdioBridgeHost.cs`**
- `FrameIOTimeoutMs`: `30000` → default `300000`, override `UNITY_MCP_STDIO_COMMAND_TIMEOUT_MS`. Changed from `const` to a `static readonly` resolved once at load.
- `client.ReceiveTimeout` now `Math.Max(60000, FrameIOTimeoutMs)` so it never fires before the command timeout.
- `staleThresholdMs` kept at `2× FrameIOTimeoutMs` (was a `const`, now a local since the operand is no longer compile-time constant).

**Python — `core/config.py`**
- `connection_timeout`: `30.0` → default `300.0`, override `UNITY_MCP_CONNECTION_TIMEOUT`.
- `command_total_timeout`: `90.0` → default `600.0` (kept above `connection_timeout`), override `UNITY_MCP_COMMAND_TOTAL_TIMEOUT`.
- Added a small `_env_float` helper that ignores invalid/non-positive values.

**Tests**
- Updated `test_core_infrastructure_characterization.py` to assert the new defaults (`connection_timeout == 300.0`, `command_total_timeout == 600.0`).

## Notes / testing

- Env-var parsing + fallback for `config.py` verified in isolation (defaults `300.0`/`600.0`; a valid override applies; a bad value falls back). The repo's pytest collection currently fails on an unrelated missing `tomli` import in `core/telemetry.py`, so the full suite wasn't run in this environment.
- C# is header/behaviour-only; no signature changes. Not compiled against Unity in this environment.
- Naming follows the existing `UNITY_MCP_*` env-var convention (`UNITY_MCP_TIMEOUT`, `UNITY_MCP_DISABLE_TELEMETRY`, `UNITY_MCP_ALLOW_BATCH`, …).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout settings through environment variables for bridge, connection, and command operations.
  * Increased default connection, command, and bridge timeouts to support longer-running operations.
  * Client receive and stale-command handling now adapt to the configured bridge timeout.
  * Invalid, missing, non-positive, or non-finite timeout values automatically fall back to safe defaults.

* **Tests**
  * Expanded coverage for default, valid override, and invalid timeout configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->