### PR TITLE
fix(screenshot): avoid re-entering PlayerLoop in play mode

### DIFF
--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -302,7 +302,18 @@ namespace MCPForUnity.Editor.Tools
                 throw new InvalidOperationException($"Handler for '{commandName}' does not provide a synchronous implementation");
             }
 
-            return handlerInfo.SyncHandler(@params);
+            object result = handlerInfo.SyncHandler(@params);
+            if (result is Task<object> returnedTask)
+            {
+                ExecuteAsyncHandler(
+                    new HandlerInfo(commandName, null, _ => returnedTask),
+                    @params,
+                    commandName,
+                    tcs);
+                return null;
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -332,6 +343,11 @@ namespace MCPForUnity.Editor.Tools
             }
 
             object result = handlerInfo.SyncHandler(payload);
+            if (result is Task<object> returnedTask)
+            {
+                return returnedTask;
+            }
+
             return Task.FromResult(result);
         }
 

--- a/MCPForUnity/Editor/Tools/ManageScene.cs
+++ b/MCPForUnity/Editor/Tools/ManageScene.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using MCPForUnity.Editor.Helpers; // For Response class
 using MCPForUnity.Runtime.Helpers; // For ScreenshotUtility
 using Newtonsoft.Json.Linq;
@@ -613,18 +614,7 @@ namespace MCPForUnity.Editor.Tools
                 if (includeImage && Application.isPlaying)
                 {
                     if (!Application.isBatchMode) EnsureGameView();
-
-                    string folderOverride = ScreenshotPreferences.Resolve(cmd.outputFolder);
-                    ScreenshotCaptureResult result = ScreenshotUtility.CaptureComposited(
-                        fileName, resolvedSuperSize, ensureUniqueFileName: true,
-                        includeImage: true, maxResolution: maxResolution,
-                        folderOverride: folderOverride);
-
-                    if (ScreenshotUtility.IsUnderAssets(result.ProjectRelativePath))
-                        AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
-                    string cameraName = Camera.main != null ? Camera.main.name : "composited";
-                    string message = $"Screenshot captured to '{result.ProjectRelativePath}' (camera: {cameraName}).";
-                    return new SuccessResponse(message, BuildScreenshotResponseData(result, cameraName, includeImage: true));
+                    return CaptureCompositedScreenshotAsync(cmd, fileName, resolvedSuperSize, maxResolution);
                 }
 
                 if (includeImage)
@@ -754,6 +744,38 @@ namespace MCPForUnity.Editor.Tools
             }
 
             return data;
+        }
+
+        private static async Task<object> CaptureCompositedScreenshotAsync(
+            SceneCommand cmd,
+            string fileName,
+            int resolvedSuperSize,
+            int maxResolution)
+        {
+            string folderOverride = ScreenshotPreferences.Resolve(cmd.outputFolder);
+            ScreenshotCaptureResult result;
+            try
+            {
+                result = await ScreenshotUtility.CaptureCompositedAsync(
+                    fileName, resolvedSuperSize, ensureUniqueFileName: true,
+                    includeImage: true, maxResolution: maxResolution,
+                    folderOverride: folderOverride).ConfigureAwait(true);
+            }
+            catch (TimeoutException ex)
+            {
+                return new ErrorResponse(ex.Message);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return new ErrorResponse(ex.Message);
+            }
+
+            if (ScreenshotUtility.IsUnderAssets(result.ProjectRelativePath))
+                AssetDatabase.ImportAsset(result.ProjectRelativePath, ImportAssetOptions.ForceSynchronousImport);
+
+            string cameraName = Camera.main != null ? Camera.main.name : "composited";
+            string message = $"Screenshot captured to '{result.ProjectRelativePath}' (camera: {cameraName}).";
+            return new SuccessResponse(message, BuildScreenshotResponseData(result, cameraName, includeImage: true));
         }
 
         private static object CaptureSceneViewScreenshot(

--- a/MCPForUnity/Editor/Tools/ManageUI.cs
+++ b/MCPForUnity/Editor/Tools/ManageUI.cs
@@ -866,6 +866,14 @@ namespace MCPForUnity.Editor.Tools
                 playFullPath = EnsureUniqueFilePath(playFullPath);
                 string playProjectRelPath = ScreenshotUtility.ToProjectRelativePath(playFullPath);
 
+                if (s_pendingCaptureDone && s_pendingCaptureTex == null)
+                {
+                    s_pendingCaptureDone = false;
+                    s_pendingCaptureStarted = false;
+                    return new ErrorResponse(
+                        "Play-mode screenshot timed out or captured nothing. Keep the Game view visible and the editor unpaused.");
+                }
+
                 // ── Case 1: capture is ready ──────────────────────────────────────
                 if (s_pendingCaptureDone && s_pendingCaptureTex != null)
                 {

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -220,7 +220,13 @@ namespace MCPForUnity.Runtime.Helpers
             int maxResolution = 0,
             string folderOverride = null)
         {
-            await CompositedCaptureGate.WaitAsync().ConfigureAwait(true);
+            if (!await CompositedCaptureGate
+                    .WaitAsync(TimeSpan.FromSeconds(ScreenshotCapturer.DefaultTimeoutSeconds * 4))
+                    .ConfigureAwait(true))
+            {
+                throw new TimeoutException(
+                    "Another composited screenshot capture is still in progress. Retry shortly.");
+            }
             try
             {
                 return await CaptureCompositedAsyncUngated(
@@ -242,7 +248,8 @@ namespace MCPForUnity.Runtime.Helpers
             string folderOverride)
         {
             var prepared = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride: folderOverride, isAsync: false);
-            var tcs = new TaskCompletionSource<ScreenshotCaptureResult>();
+            var tcs = new TaskCompletionSource<ScreenshotCaptureResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
 
             ScreenshotCapturer.Begin(prepared.SuperSize, (tex, timedOut) =>
             {

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace MCPForUnity.Runtime.Helpers
@@ -50,6 +52,7 @@ namespace MCPForUnity.Runtime.Helpers
         /// or globally via <c>ScreenshotPreferences</c> in the Editor assembly.
         /// </summary>
         public const string DefaultFolder = "Assets/Screenshots";
+        private static readonly SemaphoreSlim CompositedCaptureGate = new SemaphoreSlim(1, 1);
 
         private static Camera FindAvailableCamera()
         {
@@ -182,62 +185,155 @@ namespace MCPForUnity.Runtime.Helpers
             ScreenshotCaptureResult result = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride: folderOverride, isAsync: false);
             Texture2D tex = null;
             Texture2D downscaled = null;
-            string imageBase64 = null;
-            int imgW = 0, imgH = 0;
             try
             {
-                // Commands execute through UnitySynchronizationContext while the PlayerLoop is
-                // already active. Capture the current frame directly; driving
-                // EditorApplication.Step here would re-enter that loop.
+                // Direct capture is safe in edit mode. Play-mode MCP callers must use
+                // CaptureCompositedAsync so WaitForEndOfFrame can run without
+                // EditorApplication.Step re-entering the PlayerLoop.
                 tex = ScreenCapture.CaptureScreenshotAsTexture(result.SuperSize);
                 if (tex == null)
                 {
-                    // Fallback to camera-based if ScreenCapture fails
-                    var cam = FindAvailableCamera();
-                    if (cam != null)
-                        return CaptureFromCameraToProjectFolder(cam, fileName, superSize, ensureUniqueFileName,
-                            includeImage, maxResolution, folderOverride: folderOverride);
-                    throw new InvalidOperationException("ScreenCapture.CaptureScreenshotAsTexture returned null and no fallback camera available.");
+                    return CaptureCompositedOrCameraFallback(
+                        fileName, superSize, ensureUniqueFileName, includeImage, maxResolution, folderOverride);
                 }
 
-                int width = tex.width;
-                int height = tex.height;
-
-                byte[] png = tex.EncodeToPNG();
-                File.WriteAllBytes(result.FullPath, png);
-
-                if (includeImage)
-                {
-                    int targetMax = maxResolution > 0 ? maxResolution : 640;
-                    if (width > targetMax || height > targetMax)
-                    {
-                        downscaled = DownscaleTexture(tex, targetMax);
-                        byte[] smallPng = downscaled.EncodeToPNG();
-                        imageBase64 = System.Convert.ToBase64String(smallPng);
-                        imgW = downscaled.width;
-                        imgH = downscaled.height;
-                    }
-                    else
-                    {
-                        imageBase64 = System.Convert.ToBase64String(png);
-                        imgW = width;
-                        imgH = height;
-                    }
-                }
+                return EncodeAndSaveComposited(tex, result, includeImage, maxResolution, ref downscaled);
             }
             finally
             {
                 DestroyTexture(tex);
                 DestroyTexture(downscaled);
             }
+        }
 
-            if (includeImage && imageBase64 != null)
+        /// <summary>
+        /// Play-mode composited capture that waits for end-of-frame without pumping
+        /// <c>EditorApplication.Step</c>. MCP commands run inside
+        /// <c>UnitySynchronizationContext.ExecuteTasks</c>, so a synchronous Step()
+        /// re-enters the PlayerLoop and can flood Editor.log until the Editor dies.
+        /// </summary>
+        public static async Task<ScreenshotCaptureResult> CaptureCompositedAsync(
+            string fileName = null,
+            int superSize = 1,
+            bool ensureUniqueFileName = true,
+            bool includeImage = false,
+            int maxResolution = 0,
+            string folderOverride = null)
+        {
+            await CompositedCaptureGate.WaitAsync().ConfigureAwait(true);
+            try
             {
-                return new ScreenshotCaptureResult(
-                    result.FullPath, result.ProjectRelativePath, result.SuperSize, false,
-                    imageBase64, imgW, imgH);
+                return await CaptureCompositedAsyncUngated(
+                    fileName, superSize, ensureUniqueFileName, includeImage, maxResolution, folderOverride)
+                    .ConfigureAwait(true);
             }
-            return result;
+            finally
+            {
+                CompositedCaptureGate.Release();
+            }
+        }
+
+        private static Task<ScreenshotCaptureResult> CaptureCompositedAsyncUngated(
+            string fileName,
+            int superSize,
+            bool ensureUniqueFileName,
+            bool includeImage,
+            int maxResolution,
+            string folderOverride)
+        {
+            var prepared = PrepareCaptureResult(fileName, superSize, ensureUniqueFileName, folderOverride: folderOverride, isAsync: false);
+            var tcs = new TaskCompletionSource<ScreenshotCaptureResult>();
+
+            ScreenshotCapturer.Begin(prepared.SuperSize, (tex, timedOut) =>
+            {
+                Texture2D downscaled = null;
+                try
+                {
+                    if (timedOut)
+                    {
+                        tcs.TrySetException(new TimeoutException(
+                            "Play-mode screenshot timed out waiting for end of frame. Keep the Game view visible and the editor unpaused."));
+                        return;
+                    }
+
+                    if (tex == null)
+                    {
+                        tcs.TrySetResult(CaptureCompositedOrCameraFallback(
+                            fileName, superSize, ensureUniqueFileName, includeImage, maxResolution, folderOverride));
+                        return;
+                    }
+
+                    tcs.TrySetResult(EncodeAndSaveComposited(tex, prepared, includeImage, maxResolution, ref downscaled));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+                finally
+                {
+                    DestroyTexture(tex);
+                    DestroyTexture(downscaled);
+                }
+            });
+
+            return tcs.Task;
+        }
+
+        private static ScreenshotCaptureResult CaptureCompositedOrCameraFallback(
+            string fileName,
+            int superSize,
+            bool ensureUniqueFileName,
+            bool includeImage,
+            int maxResolution,
+            string folderOverride)
+        {
+            var cam = FindAvailableCamera();
+            if (cam != null)
+            {
+                return CaptureFromCameraToProjectFolder(cam, fileName, superSize, ensureUniqueFileName,
+                    includeImage, maxResolution, folderOverride: folderOverride);
+            }
+
+            throw new InvalidOperationException(
+                "ScreenCapture.CaptureScreenshotAsTexture returned null and no fallback camera available.");
+        }
+
+        private static ScreenshotCaptureResult EncodeAndSaveComposited(
+            Texture2D tex,
+            ScreenshotCaptureResult prepared,
+            bool includeImage,
+            int maxResolution,
+            ref Texture2D downscaled)
+        {
+            int width = tex.width;
+            int height = tex.height;
+            byte[] png = tex.EncodeToPNG();
+            File.WriteAllBytes(prepared.FullPath, png);
+
+            if (!includeImage)
+                return prepared;
+
+            int targetMax = maxResolution > 0 ? maxResolution : 640;
+            string imageBase64;
+            int imgW;
+            int imgH;
+            if (width > targetMax || height > targetMax)
+            {
+                downscaled = DownscaleTexture(tex, targetMax);
+                imageBase64 = Convert.ToBase64String(downscaled.EncodeToPNG());
+                imgW = downscaled.width;
+                imgH = downscaled.height;
+            }
+            else
+            {
+                imageBase64 = Convert.ToBase64String(png);
+                imgW = width;
+                imgH = height;
+            }
+
+            return new ScreenshotCaptureResult(
+                prepared.FullPath, prepared.ProjectRelativePath, prepared.SuperSize, false,
+                imageBase64, imgW, imgH);
         }
 
         /// <summary>
@@ -709,29 +805,120 @@ namespace MCPForUnity.Runtime.Helpers
     /// <summary>
     /// Transient MonoBehaviour that yields WaitForEndOfFrame, calls
     /// ScreenCapture.CaptureScreenshotAsTexture, invokes the callback, and self-destructs.
+    /// Times out via the editor update loop so a paused or unfocused PlayerLoop cannot leak
+    /// hidden capturer objects for the rest of the session.
     /// </summary>
     public sealed class ScreenshotCapturer : MonoBehaviour
     {
+        public const float DefaultTimeoutSeconds = 2f;
+
         private int _superSize = 1;
-        private Action<Texture2D> _onComplete;
+        private Action<Texture2D, bool> _onComplete;
+        private float _timeoutSeconds = DefaultTimeoutSeconds;
+        private float _startedAt;
+        private bool _finished;
+        private bool _destroying;
 
         /// <summary>Spawns a hidden GameObject, attaches a capturer, returns immediately.</summary>
-        public static void Begin(int superSize, Action<Texture2D> onComplete)
+        public static ScreenshotCapturer Begin(int superSize, Action<Texture2D> onComplete, float timeoutSeconds = DefaultTimeoutSeconds)
+        {
+            return Begin(superSize, (tex, _) => onComplete?.Invoke(tex), timeoutSeconds);
+        }
+
+        /// <summary>Spawns a hidden GameObject, attaches a capturer, returns immediately.</summary>
+        public static ScreenshotCapturer Begin(int superSize, Action<Texture2D, bool> onComplete, float timeoutSeconds = DefaultTimeoutSeconds)
         {
             var go = new GameObject("__MCP_ScreenshotCapturer__") { hideFlags = HideFlags.HideAndDontSave };
             var c = go.AddComponent<ScreenshotCapturer>();
             c._superSize = Mathf.Max(1, superSize);
             c._onComplete = onComplete;
+            c._timeoutSeconds = Mathf.Max(0.05f, timeoutSeconds);
+            c._startedAt = Time.realtimeSinceStartup;
+            c.ArmTimeout();
+            return c;
         }
+
+        private void ArmTimeout()
+        {
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.update += TickTimeout;
+#else
+            StartCoroutine(TimeoutWatch());
+#endif
+        }
+
+        private void OnDestroy()
+        {
+            _destroying = true;
+            DisarmTimeout();
+            if (!_finished)
+                Complete(null, timedOut: true);
+        }
+
+        private void DisarmTimeout()
+        {
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.update -= TickTimeout;
+#endif
+        }
+
+#if UNITY_EDITOR
+        private void TickTimeout()
+        {
+            if (_finished) return;
+            if (Time.realtimeSinceStartup - _startedAt < _timeoutSeconds) return;
+            Complete(null, timedOut: true);
+        }
+#else
+        private System.Collections.IEnumerator TimeoutWatch()
+        {
+            yield return new WaitForSecondsRealtime(_timeoutSeconds);
+            if (!_finished)
+                Complete(null, timedOut: true);
+        }
+#endif
 
         private System.Collections.IEnumerator Start()
         {
             yield return new WaitForEndOfFrame();
+            if (_finished) yield break;
+
             Texture2D tex = null;
             try { tex = ScreenCapture.CaptureScreenshotAsTexture(_superSize); }
             catch (Exception ex) { Debug.LogError($"[MCP for Unity] CaptureScreenshotAsTexture failed: {ex.Message}"); }
-            _onComplete?.Invoke(tex);
-            Destroy(gameObject);
+            Complete(tex, timedOut: false);
+        }
+
+        private void Complete(Texture2D tex, bool timedOut)
+        {
+            if (_finished)
+            {
+                if (tex != null)
+                {
+                    if (Application.isPlaying)
+                        Destroy(tex);
+                    else
+                        DestroyImmediate(tex);
+                }
+                return;
+            }
+            _finished = true;
+            DisarmTimeout();
+            try
+            {
+                _onComplete?.Invoke(tex, timedOut);
+            }
+            finally
+            {
+                if (!_destroying)
+                {
+#if UNITY_EDITOR
+                    DestroyImmediate(gameObject);
+#else
+                    Destroy(gameObject);
+#endif
+                }
+            }
         }
     }
 }

--- a/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
+++ b/MCPForUnity/Runtime/Helpers/ScreenshotUtility.cs
@@ -166,46 +166,6 @@ namespace MCPForUnity.Runtime.Helpers
             return result;
         }
 
-#if UNITY_EDITOR
-        // Synchronously drive a WaitForEndOfFrame ScreenshotCapturer by pumping the editor's
-        // player loop. Play-mode only; EditorApplication.Step is a no-op in edit mode.
-        private static Texture2D CaptureCompositedAfterFrame(int superSize, int timeoutSteps = 5)
-        {
-            Texture2D result = null;
-            bool done = false;
-            bool callerReturned = false;
-            ScreenshotCapturer.Begin(superSize, tex =>
-            {
-                // Late completion after the spin loop timed out: caller will never consume
-                // the texture, so destroy it here to avoid leaking a Unity object.
-                if (callerReturned)
-                {
-                    if (tex != null) DestroyTexture(tex);
-                    return;
-                }
-                result = tex;
-                done = true;
-            });
-            // Step() pauses play mode as a side effect; restore the prior state so a screenshot
-            // doesn't leave a running game paused (an already-paused game stays paused).
-            bool wasPaused = UnityEditor.EditorApplication.isPaused;
-            try
-            {
-                for (int i = 0; i < timeoutSteps && !done; i++)
-                {
-                    UnityEditor.EditorApplication.Step();
-                }
-            }
-            finally
-            {
-                if (!wasPaused)
-                    UnityEditor.EditorApplication.isPaused = false;
-            }
-            callerReturned = true;
-            return result;
-        }
-#endif
-
         /// <summary>
         /// Captures a screenshot using ScreenCapture.CaptureScreenshotAsTexture, which captures the
         /// final composited frame including UI Toolkit overlays, post-processing, etc.
@@ -226,15 +186,10 @@ namespace MCPForUnity.Runtime.Helpers
             int imgW = 0, imgH = 0;
             try
             {
-#if UNITY_EDITOR
-                // In play mode, inline ScreenCapture reads a backbuffer before UITK has
-                // composited; route through WaitForEndOfFrame instead.
-                tex = Application.isPlaying
-                    ? CaptureCompositedAfterFrame(result.SuperSize)
-                    : ScreenCapture.CaptureScreenshotAsTexture(result.SuperSize);
-#else
+                // Commands execute through UnitySynchronizationContext while the PlayerLoop is
+                // already active. Capture the current frame directly; driving
+                // EditorApplication.Step here would re-enter that loop.
                 tex = ScreenCapture.CaptureScreenshotAsTexture(result.SuperSize);
-#endif
                 if (tex == null)
                 {
                     // Fallback to camera-based if ScreenCapture fails

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ScreenshotCapturerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ScreenshotCapturerTests.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using MCPForUnity.Runtime.Helpers;
+
+namespace MCPForUnityTests.Editor.Helpers
+{
+    public class ScreenshotCapturerTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var capturer in Resources.FindObjectsOfTypeAll<ScreenshotCapturer>())
+            {
+                if (capturer != null)
+                    Object.DestroyImmediate(capturer.gameObject);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Begin_DoesNotLeakCapturerWhenFrameNeverCompletes()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            bool called = false;
+            var capturer = ScreenshotCapturer.Begin(1, _ => called = true, timeoutSeconds: 0.15f);
+            Assert.IsNotNull(capturer, "Begin should return the live capturer.");
+
+            float deadline = Time.realtimeSinceStartup + 2f;
+            while (!called && Time.realtimeSinceStartup < deadline)
+                yield return null;
+
+            Assert.IsTrue(called, "Capturer must complete even if WaitForEndOfFrame never resumes.");
+            yield return null;
+
+            Assert.IsTrue(capturer == null, "Hidden __MCP_ScreenshotCapturer__ must destroy itself after completion.");
+            Assert.AreEqual(0, Resources.FindObjectsOfTypeAll<ScreenshotCapturer>().Length);
+        }
+
+        [Test]
+        public void Destroy_CompletesPendingCallback()
+        {
+            bool called = false;
+            Texture2D received = null;
+
+            var capturer = ScreenshotCapturer.Begin(1, tex =>
+            {
+                received = tex;
+                called = true;
+            }, timeoutSeconds: 5f);
+
+            Assert.IsNotNull(capturer);
+            Object.DestroyImmediate(capturer.gameObject);
+
+            Assert.IsTrue(called, "Destroying the capturer must complete the waiter so MCP commands cannot hang.");
+            Assert.IsNull(received);
+            Assert.AreEqual(0, Resources.FindObjectsOfTypeAll<ScreenshotCapturer>().Length);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ScreenshotCapturerTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ScreenshotCapturerTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ScreenshotCapturerTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Helpers/ScreenshotCapturerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8e4c91a2d7f4a3e9c5b1f0e8d7a6c5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageSceneHierarchyPagingTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageSceneHierarchyPagingTests.cs
@@ -169,6 +169,19 @@ namespace MCPForUnityTests.Editor.Tools
         }
 
         [Test]
+        public void Screenshot_CompositedCaptureDoesNotExposePlayerLoopPump()
+        {
+            var utilityType = typeof(MCPForUnity.Runtime.Helpers.ScreenshotUtility);
+            var pumpMethod = utilityType.GetMethod(
+                "CaptureCompositedAfterFrame",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.IsNull(
+                pumpMethod,
+                "Play-mode screenshots must not synchronously pump Unity's PlayerLoop; commands run from UnitySynchronizationContext.ExecuteTasks, which is already inside that loop.");
+        }
+
+        [Test]
         public void Screenshot_ViewTargetAcceptedForGameView()
         {
             // view_target should be accepted for game_view (positioned capture path).

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageSceneHierarchyPagingTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageSceneHierarchyPagingTests.cs
@@ -169,19 +169,6 @@ namespace MCPForUnityTests.Editor.Tools
         }
 
         [Test]
-        public void Screenshot_CompositedCaptureDoesNotExposePlayerLoopPump()
-        {
-            var utilityType = typeof(MCPForUnity.Runtime.Helpers.ScreenshotUtility);
-            var pumpMethod = utilityType.GetMethod(
-                "CaptureCompositedAfterFrame",
-                BindingFlags.NonPublic | BindingFlags.Static);
-
-            Assert.IsNull(
-                pumpMethod,
-                "Play-mode screenshots must not synchronously pump Unity's PlayerLoop; commands run from UnitySynchronizationContext.ExecuteTasks, which is already inside that loop.");
-        }
-
-        [Test]
         public void Screenshot_ViewTargetAcceptedForGameView()
         {
             // view_target should be accepted for game_view (positioned capture path).


### PR DESCRIPTION
## Description

Play-mode `include_image` screenshots were pumping `EditorApplication.Step()` from inside `UnitySynchronizationContext.ExecuteTasks`, which re-enters the PlayerLoop. Unity then floods `Editor.log` with `Access version should be odd when acquiring lock` until the Editor dies.

I changed that path to wait for `WaitForEndOfFrame` and complete the MCP command afterward, so the current PlayerLoop can finish instead of being driven from inside itself.

Fixes #1289

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- `ScreenshotUtility.CaptureCompositedAsync` waits for end of frame without `EditorApplication.Step()`
- `ScreenshotCapturer` now times out and destroys itself if that frame never arrives
- timeout is returned as an error instead of a blank/partial texture
- `CommandRegistry` completes the original command once the capture task finishes
- EditMode tests cover capturer timeout cleanup and destroy-to-complete so the waiter cannot hang

## Compatibility / Package Source
- Unity version(s) tested:
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `#beta`
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL):

## Testing/Screenshots/Recordings
- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [ ] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

## Related Issues

Fixes #1289

## Additional Notes

If the Game view is not rendering, the command now errors on timeout instead of hanging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous composited screenshot capture with configurable resolution, output location, unique filenames, and optional image data.
  * Added capture timeouts and completion callbacks for more reliable screenshot workflows.

* **Bug Fixes**
  * Improved cleanup when captures time out, fail, or are interrupted.
  * Added clear errors for empty or incomplete Play Mode captures.
  * Fixed asynchronous command handling for screenshot operations.

* **Tests**
  * Added coverage for capture timeouts, cleanup, interrupted frame capture, and destroyed capture objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->