### PR TITLE
docs: fix broken star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Branch off `beta`, not `main`. The full 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CoplayDev/unity-mcp&type=Date)](https://www.star-history.com/#CoplayDev/unity-mcp&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CoplayDev/unity-mcp&type=Date)](https://star-history.dera.page/#CoplayDev/unity-mcp&Date)
 
 ## Citation
 

--- a/docs/i18n/README-zh.md
+++ b/docs/i18n/README-zh.md
@@ -182,7 +182,7 @@ MCP for Unity 支持同时开多个 Unity 编辑器实例。想把操作定向�
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CoplayDev/unity-mcp&type=Date)](https://www.star-history.com/#CoplayDev/unity-mcp&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CoplayDev/unity-mcp&type=Date)](https://star-history.dera.page/#CoplayDev/unity-mcp&Date)
 
 <details>
 <summary><strong>论文引用</strong></summary>


### PR DESCRIPTION
The star history charts in the READMEs are currently broken because the GitHub stargazer API they depend on no longer allows unauthenticated access. This swaps them over to star-history.dera.page, which serves the same charts from an alternative data source that requires no API token and uses the same domain for both the image and the link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart and link to use the new service address.
  * Applied the update to both English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->