### PR TITLE
Fix duplicate-signature false positives on calls at class-member depth

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageScript.cs
+++ b/MCPForUnity/Editor/Tools/ManageScript.cs
@@ -2758,6 +2758,14 @@ namespace MCPForUnity.Editor.Tools
                 string returnType = sm.Groups[1].Value;
                 string methodName = sm.Groups[2].Value;
                 if (string.Equals(returnType, "new", StringComparison.Ordinal)) continue; // constructor invocation, not a method declaration
+                // A punctuation "return type" means this match is a CALL, not a declaration:
+                // the opening brace of a method body ("{ Foo();") or an expression-bodied
+                // member ("=> Foo();"). Both sit at class-member depth, so the brace-depth
+                // guard below cannot reject them.
+                if (returnType.Length == 0) continue;
+                char returnTypeStart = returnType[0];
+                if (!char.IsLetter(returnTypeStart) && returnTypeStart != '_'
+                    && returnTypeStart != '@' && returnTypeStart != '(') continue;
                 if (IsCSharpKeyword(methodName)) continue;
                 int paramCount = CountTopLevelParams(sm.Groups[3].Value);
                 string paramTypes = ExtractParamTypes(sm.Groups[3].Value);

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageScriptValidationTests.cs
@@ -227,6 +227,55 @@ public class Foo : MonoBehaviour
                 "Overloads with different param types but same count should not be flagged");
         }
 
+        [Test]
+        public void DuplicateDetection_ExplicitInterfaceImplementation_NotFlagged()
+        {
+            string code = @"using UnityEngine;
+public interface IThing { void Notify(); }
+public class Foo : MonoBehaviour, IThing
+{
+    void IThing.Notify()
+    {
+        Ping();
+    }
+
+    private void Ping() { }
+}";
+            var errors = CallValidateScriptSyntaxUnity(code);
+            Assert.IsFalse(HasDuplicateMethodError(errors),
+                "A call as the first statement of an explicit interface implementation is not a declaration");
+        }
+
+        [Test]
+        public void DuplicateDetection_ExpressionBodiedCall_NotFlagged()
+        {
+            string code = @"using UnityEngine;
+public class Foo : MonoBehaviour
+{
+    public int Total => Count();
+
+    private int Count() => 0;
+}";
+            var errors = CallValidateScriptSyntaxUnity(code);
+            Assert.IsFalse(HasDuplicateMethodError(errors),
+                "A call inside an expression-bodied member is not a declaration");
+        }
+
+        [Test]
+        public void DuplicateDetection_FieldInitializerCall_NotFlagged()
+        {
+            string code = @"using UnityEngine;
+public class Foo : MonoBehaviour
+{
+    private static bool _enabled = ReadPref();
+
+    private static bool ReadPref() { return false; }
+}";
+            var errors = CallValidateScriptSyntaxUnity(code);
+            Assert.IsFalse(HasDuplicateMethodError(errors),
+                "A call in a field initializer is not a declaration");
+        }
+
         // --- Duplicate method detection: true positive tests ---
 
         [Test]


### PR DESCRIPTION
## Why

`CheckDuplicateMethodSignatures` reports duplicate-signature **errors** on valid, compiling C#. `validate_script` returns `success: false`, which also masks any genuine validation error in the same file.

The signature regex matches call sites as readily as declarations — `(\S+)` will capture punctuation as a "return type". That is normally harmless, because matches are non-overlapping: an ordinary declaration consumes its own opening brace, so a call inside the body has no preceding token left to match against.

**Any call sitting at class-member depth escapes that**, because there is no enclosing declaration match to consume the token in front of it:

- **Field initializers** — `static bool X = ReadPref();` captures `=`
- **Expression-bodied members** — `int Total => Count();` captures `=>`; `Current => _current ??= Build();` captures `??=`
- **The first statement of a body whose declaration the regex could not match at all** — an explicit interface implementation, since `(\w+)` cannot span the dot in `IThing.Notify`. The body's opening brace is captured instead.

All sit at class-member depth, so the brace-depth guard from *"Prevent validator false positives from method-body calls"* cannot reject them. Zero-argument methods are what bite in practice, since the key includes parameter types and an empty list always matches.

**This repository's own sources contain four instances**, all ordinary idiomatic C#:

| File | Shape |
|---|---|
| `Editor/Helpers/McpLog.cs` | `= ReadDebugPreference();` field initializer |
| `Editor/Services/Transport/Transports/StdioBridgeHost.cs` | `= ResolveFrameIOTimeoutMs();` field initializer |
| `Editor/Services/BridgeControlService.cs` | `=> ResolvePreferredMode();` expression-bodied property |
| `Editor/Security/SecureKeyStore/SecureKeyStore.cs` | `=> _current ??= Build();` expression-bodied property |

## Approach

This is the third report of one underlying pattern — after #1044 (`new Type(...)` constructor invocations) and the method-body-call fix. Rather than a third targeted skip, this rejects the class: **a captured return type that is punctuation is never a declaration.** `(` is kept so tuple returns still validate.

## Verification

Against the patched `ManageScript.cs` running in a real Unity project (v10.0.0, Unity 6000.3.8f1):

- All four instances above, plus four in a production project (a 5,600-line controller with explicit interface implementations, and one with an expression-bodied property), validate clean.
- A genuine duplicate — `Initialize(string name)` / `Initialize(string label)`, the corruption pattern from `DuplicateDetection_SameTypeDifferentParamName_Flagged` — is still flagged.
- All 14 existing duplicate-detection tests behave exactly as their assertions expect, before and after.
- Tuple, generic, array, nullable, `global::`-qualified, `async Task<T>`, `@`-verbatim and leading-underscore return types all still detect genuine duplicates.

The three added tests fail without the guard and pass with it.

## Checklist

- [x] Branched off `beta`
- [x] New tests (three, in the existing false-positive section)
- [x] No commented-out code or leftover markers
- [x] Description explains the why

## Not covered

Two adjacent issues this deliberately does not touch:

- A *genuine* duplicate explicit interface implementation (`void IThing.Notify()` twice) is still not detected, since `(\w+)` cannot match the dotted name.
- `#if` / `#else` pairs that declare the same method in both branches are flagged as duplicates — the code-only pass strips comments and strings but not preprocessor directives. Five files here hit this, including `ManageScript.cs` itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-method detection to avoid incorrectly flagging method calls as duplicate declarations in explicit interface implementations, expression-bodied members, and field initializers.

* **Tests**
  * Added coverage for these scenarios to help prevent future false-positive validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->