### PR TITLE
fix(animation): resolve the Animator on child objects, not just the exact target

### DIFF
--- a/MCPForUnity/Editor/Tools/Animation/AnimatorControl.cs
+++ b/MCPForUnity/Editor/Tools/Animation/AnimatorControl.cs
@@ -15,9 +15,9 @@ namespace MCPForUnity.Editor.Tools.Animation
             if (go == null)
                 return new { success = false, message = "Target GameObject not found" };
 
-            var animator = go.GetComponent<Animator>();
+            var animator = AnimatorResolver.Find(go, out var animatorCandidates);
             if (animator == null)
-                return new { success = false, message = $"No Animator component on '{go.name}'" };
+                return AnimatorResolver.NotResolvedError(go, animatorCandidates);
 
             string stateName = @params["stateName"]?.ToString();
             if (string.IsNullOrEmpty(stateName))
@@ -28,7 +28,7 @@ namespace MCPForUnity.Editor.Tools.Animation
             Undo.RecordObject(animator, "Play Animation State");
             animator.Play(stateName, layer);
 
-            return new { success = true, message = $"Playing state '{stateName}' on '{go.name}'" };
+            return new { success = true, message = $"Playing state '{stateName}' on {AnimatorResolver.Describe(go, animator)}" };
         }
 
         public static object Crossfade(JObject @params)
@@ -37,9 +37,9 @@ namespace MCPForUnity.Editor.Tools.Animation
             if (go == null)
                 return new { success = false, message = "Target GameObject not found" };
 
-            var animator = go.GetComponent<Animator>();
+            var animator = AnimatorResolver.Find(go, out var animatorCandidates);
             if (animator == null)
-                return new { success = false, message = $"No Animator component on '{go.name}'" };
+                return AnimatorResolver.NotResolvedError(go, animatorCandidates);
 
             string stateName = @params["stateName"]?.ToString();
             if (string.IsNullOrEmpty(stateName))
@@ -51,7 +51,7 @@ namespace MCPForUnity.Editor.Tools.Animation
             Undo.RecordObject(animator, "Crossfade Animation State");
             animator.CrossFade(stateName, duration, layer);
 
-            return new { success = true, message = $"Crossfading to '{stateName}' over {duration}s on '{go.name}'" };
+            return new { success = true, message = $"Crossfading to '{stateName}' over {duration}s on {AnimatorResolver.Describe(go, animator)}" };
         }
 
         public static object SetParameter(JObject @params)
@@ -60,9 +60,9 @@ namespace MCPForUnity.Editor.Tools.Animation
             if (go == null)
                 return new { success = false, message = "Target GameObject not found" };
 
-            var animator = go.GetComponent<Animator>();
+            var animator = AnimatorResolver.Find(go, out var animatorCandidates);
             if (animator == null)
-                return new { success = false, message = $"No Animator component on '{go.name}'" };
+                return AnimatorResolver.NotResolvedError(go, animatorCandidates);
 
             string paramName = @params["parameterName"]?.ToString();
             if (string.IsNullOrEmpty(paramName))
@@ -103,23 +103,23 @@ namespace MCPForUnity.Editor.Tools.Animation
                     case "float":
                         float fVal = valueToken?.ToObject<float>() ?? 0f;
                         animator.SetFloat(paramName, fVal);
-                        return new { success = true, message = $"Set float '{paramName}' = {fVal}" };
+                        return new { success = true, message = $"Set float '{paramName}' = {fVal}" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     case "int":
                     case "integer":
                         int iVal = valueToken?.ToObject<int>() ?? 0;
                         animator.SetInteger(paramName, iVal);
-                        return new { success = true, message = $"Set int '{paramName}' = {iVal}" };
+                        return new { success = true, message = $"Set int '{paramName}' = {iVal}" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     case "bool":
                     case "boolean":
                         bool bVal = valueToken?.ToObject<bool>() ?? false;
                         animator.SetBool(paramName, bVal);
-                        return new { success = true, message = $"Set bool '{paramName}' = {bVal}" };
+                        return new { success = true, message = $"Set bool '{paramName}' = {bVal}" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     case "trigger":
                         animator.SetTrigger(paramName);
-                        return new { success = true, message = $"Set trigger '{paramName}'" };
+                        return new { success = true, message = $"Set trigger '{paramName}'" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     default:
                         return new { success = false, message = $"Unknown parameter type: {paramType}. Valid: float, int, bool, trigger" };
@@ -130,7 +130,7 @@ namespace MCPForUnity.Editor.Tools.Animation
                 // Edit mode: modify the AnimatorController asset's default parameter values
                 var controller = animator.runtimeAnimatorController as AnimatorController;
                 if (controller == null)
-                    return new { success = false, message = $"No AnimatorController assigned to Animator on '{go.name}'. Cannot set parameter defaults in Edit mode." };
+                    return new { success = false, message = $"No AnimatorController assigned to the Animator on {AnimatorResolver.Describe(go, animator)}. Cannot set parameter defaults in Edit mode." };
 
                 var allParams = controller.parameters;
                 int paramIndex = -1;
@@ -156,7 +156,7 @@ namespace MCPForUnity.Editor.Tools.Animation
                         controller.parameters = allParams;
                         EditorUtility.SetDirty(controller);
                         AssetDatabase.SaveAssets();
-                        return new { success = true, message = $"Set float '{paramName}' = {fVal} (default value, Edit mode)" };
+                        return new { success = true, message = $"Set float '{paramName}' = {fVal} (default value, Edit mode)" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     case "int":
                     case "integer":
@@ -165,7 +165,7 @@ namespace MCPForUnity.Editor.Tools.Animation
                         controller.parameters = allParams;
                         EditorUtility.SetDirty(controller);
                         AssetDatabase.SaveAssets();
-                        return new { success = true, message = $"Set int '{paramName}' = {iVal} (default value, Edit mode)" };
+                        return new { success = true, message = $"Set int '{paramName}' = {iVal} (default value, Edit mode)" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     case "bool":
                     case "boolean":
@@ -174,10 +174,10 @@ namespace MCPForUnity.Editor.Tools.Animation
                         controller.parameters = allParams;
                         EditorUtility.SetDirty(controller);
                         AssetDatabase.SaveAssets();
-                        return new { success = true, message = $"Set bool '{paramName}' = {bVal} (default value, Edit mode)" };
+                        return new { success = true, message = $"Set bool '{paramName}' = {bVal} (default value, Edit mode)" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     case "trigger":
-                        return new { success = true, message = $"Trigger '{paramName}' noted (triggers are runtime-only, no default to set)" };
+                        return new { success = true, message = $"Trigger '{paramName}' noted (triggers are runtime-only, no default to set)" + AnimatorResolver.ResolvedSuffix(go, animator) };
 
                     default:
                         return new { success = false, message = $"Unknown parameter type: {paramType}. Valid: float, int, bool, trigger" };
@@ -191,16 +191,16 @@ namespace MCPForUnity.Editor.Tools.Animation
             if (go == null)
                 return new { success = false, message = "Target GameObject not found" };
 
-            var animator = go.GetComponent<Animator>();
+            var animator = AnimatorResolver.Find(go, out var animatorCandidates);
             if (animator == null)
-                return new { success = false, message = $"No Animator component on '{go.name}'" };
+                return AnimatorResolver.NotResolvedError(go, animatorCandidates);
 
             float speed = @params["speed"]?.ToObject<float>() ?? 1f;
 
             Undo.RecordObject(animator, "Set Animator Speed");
             animator.speed = speed;
 
-            return new { success = true, message = $"Set animator speed to {speed} on '{go.name}'" };
+            return new { success = true, message = $"Set animator speed to {speed} on {AnimatorResolver.Describe(go, animator)}" };
         }
 
         public static object SetEnabled(JObject @params)
@@ -209,16 +209,16 @@ namespace MCPForUnity.Editor.Tools.Animation
             if (go == null)
                 return new { success = false, message = "Target GameObject not found" };
 
-            var animator = go.GetComponent<Animator>();
+            var animator = AnimatorResolver.Find(go, out var animatorCandidates);
             if (animator == null)
-                return new { success = false, message = $"No Animator component on '{go.name}'" };
+                return AnimatorResolver.NotResolvedError(go, animatorCandidates);
 
             bool enabled = @params["enabled"]?.ToObject<bool>() ?? true;
 
             Undo.RecordObject(animator, "Set Animator Enabled");
             animator.enabled = enabled;
 
-            return new { success = true, message = $"Animator {(enabled ? "enabled" : "disabled")} on '{go.name}'" };
+            return new { success = true, message = $"Animator {(enabled ? "enabled" : "disabled")} on {AnimatorResolver.Describe(go, animator)}" };
         }
     }
 }

--- a/MCPForUnity/Editor/Tools/Animation/AnimatorRead.cs
+++ b/MCPForUnity/Editor/Tools/Animation/AnimatorRead.cs
@@ -14,9 +14,9 @@ namespace MCPForUnity.Editor.Tools.Animation
             if (go == null)
                 return new { success = false, message = "Target GameObject not found" };
 
-            var animator = go.GetComponent<Animator>();
+            var animator = AnimatorResolver.Find(go, out var animatorCandidates);
             if (animator == null)
-                return new { success = false, message = $"No Animator component on '{go.name}'" };
+                return AnimatorResolver.NotResolvedError(go, animatorCandidates);
 
             var parameters = new List<object>();
             for (int i = 0; i < animator.parameterCount; i++)
@@ -73,6 +73,7 @@ namespace MCPForUnity.Editor.Tools.Animation
                 data = new
                 {
                     gameObject = go.name,
+                    animatorGameObject = animator.gameObject.name,
                     enabled = animator.enabled,
                     speed = animator.speed,
                     hasController = animator.runtimeAnimatorController != null,
@@ -95,9 +96,9 @@ namespace MCPForUnity.Editor.Tools.Animation
             if (go == null)
                 return new { success = false, message = "Target GameObject not found" };
 
-            var animator = go.GetComponent<Animator>();
+            var animator = AnimatorResolver.Find(go, out var animatorCandidates);
             if (animator == null)
-                return new { success = false, message = $"No Animator component on '{go.name}'" };
+                return AnimatorResolver.NotResolvedError(go, animatorCandidates);
 
             string paramName = @params["parameterName"]?.ToString();
             if (string.IsNullOrEmpty(paramName))

--- a/MCPForUnity/Editor/Tools/Animation/AnimatorResolver.cs
+++ b/MCPForUnity/Editor/Tools/Animation/AnimatorResolver.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using UnityEngine;
+
+namespace MCPForUnity.Editor.Tools.Animation
+{
+    internal static class AnimatorResolver
+    {
+        /// <summary>
+        /// Resolves the Animator that read and control operations should act on: the one on
+        /// <paramref name="go"/> itself, or the single Animator among its descendants.
+        /// </summary>
+        /// <remarks>
+        /// Imported models keep their Animator on the model root, which is normally a child of
+        /// the GameObject a caller names, so an exact-match lookup fails on the most common rig
+        /// setup. Inactive descendants are included because a disabled rig is still readable.
+        /// Operations that ADD an Animator must not use this - they need the exact target.
+        /// </remarks>
+        /// <param name="candidates">
+        /// The descendant Animators found when the target carried none. Unity's descendant search
+        /// is depth-first, so with several rigs under one wrapper it returns the first branch
+        /// however deep, which is not the nearest rig and not what a caller would predict. More
+        /// than one candidate therefore resolves to null and is reported, never guessed.
+        /// </param>
+        /// <returns>The resolved Animator, or null when there is none or the choice is ambiguous.</returns>
+        public static Animator Find(GameObject go, out Animator[] candidates)
+        {
+            candidates = System.Array.Empty<Animator>();
+            if (go == null)
+                return null;
+
+            var own = go.GetComponent<Animator>();
+            if (own != null)
+                return own;
+
+            // go carries none, so every hit here is a descendant.
+            candidates = go.GetComponentsInChildren<Animator>(true);
+            return candidates.Length == 1 ? candidates[0] : null;
+        }
+
+        /// <summary>
+        /// The error for a target whose Animator could not be resolved - missing, or ambiguous
+        /// because several descendants carry one.
+        /// </summary>
+        public static object NotResolvedError(GameObject go, Animator[] candidates)
+        {
+            if (candidates != null && candidates.Length > 1)
+            {
+                string names = string.Join(", ", candidates.Select(a => $"'{a.gameObject.name}'"));
+                return new
+                {
+                    success = false,
+                    message = $"'{go.name}' has no Animator and {candidates.Length} of its children do " +
+                              $"({names}). Target one of them directly."
+                };
+            }
+
+            return new { success = false, message = $"No Animator component on '{go.name}' or its children" };
+        }
+
+        /// <summary>
+        /// Names the object a response should report as changed. When resolution retargeted to a
+        /// descendant, the caller is told so - otherwise the response claims the wrapper changed.
+        /// </summary>
+        /// <summary>
+        /// A suffix disclosing that resolution retargeted to a descendant; empty when the target
+        /// carried the Animator itself, so responses that already read correctly are untouched.
+        /// </summary>
+        public static string ResolvedSuffix(GameObject target, Animator resolved)
+        {
+            return resolved.gameObject == target
+                ? string.Empty
+                : $" (on '{resolved.gameObject.name}', resolved from '{target.name}')";
+        }
+
+        public static string Describe(GameObject target, Animator resolved)
+        {
+            return resolved.gameObject == target
+                ? $"'{target.name}'"
+                : $"'{resolved.gameObject.name}' (resolved from '{target.name}')";
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/Animation/AnimatorResolver.cs.meta
+++ b/MCPForUnity/Editor/Tools/Animation/AnimatorResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c010b345a1c8474e8423ff919f94c5f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Server/src/cli/CLI_USAGE_GUIDE.md
+++ b/Server/src/cli/CLI_USAGE_GUIDE.md
@@ -606,7 +606,7 @@ unity-mcp audio volume "MusicPlayer" 0.5
 ### Animation Commands
 
 ```bash
-# Control Animator (target must have Animator component)
+# Control Animator (target or one of its children must have an Animator component)
 unity-mcp animation play "Character" "Walk"
 unity-mcp animation set-parameter "Character" "Speed" 1.5 --type float
 unity-mcp animation set-parameter "Character" "IsRunning" true --type bool

--- a/Server/src/cli/commands/animation.py
+++ b/Server/src/cli/commands/animation.py
@@ -96,7 +96,10 @@ def animator_play(target: str, state_name: str, layer: int, search_method: Optio
     result = run_command("manage_animation", _normalize_params(params), config)
     click.echo(format_output(result, config.format))
     if result.get("success"):
-        print_success(f"Playing state '{state_name}' on {target}")
+        # Prefer the tool's own message: the Animator may live on a descendant of
+        # `target`, and only the tool knows which object actually played. The fallback
+        # names no object for the same reason - here the tool told us nothing.
+        print_success(result.get("message") or f"Playing state '{state_name}'")
 
 
 @animator.command("crossfade")

--- a/Server/tests/test_manage_animation.py
+++ b/Server/tests/test_manage_animation.py
@@ -186,6 +186,32 @@ class TestAnimatorCLICommands:
                 # stateName goes into properties (non-top-level key)
                 assert params["properties"]["stateName"] == "Walk"
 
+    def test_animator_play_reports_the_object_the_tool_resolved(self, runner, mock_config):
+        """The Animator may live on a descendant of the named target, and only the tool
+        knows which object played. Echoing the CLI's own `target` back would contradict
+        the result it just printed."""
+        resolved = {
+            "success": True,
+            "message": "Playing state 'Walk' on 'Rig' (resolved from 'Wrapper')",
+            "data": {},
+        }
+        with patch("cli.commands.animation.get_config", return_value=mock_config):
+            with patch("cli.commands.animation.run_command", return_value=resolved):
+                result = runner.invoke(animation, ["animator", "play", "Wrapper", "Walk"])
+
+                assert "Rig" in result.output
+                assert "Playing state 'Walk' on Wrapper" not in result.output
+
+    def test_animator_play_fallback_names_no_object(self, runner, mock_config):
+        """With no message the CLI cannot know whether the target or a descendant played,
+        so the fallback must not claim one."""
+        with patch("cli.commands.animation.get_config", return_value=mock_config):
+            with patch("cli.commands.animation.run_command", return_value={"success": True, "data": {}}):
+                result = runner.invoke(animation, ["animator", "play", "Wrapper", "Walk"])
+
+                assert "Playing state 'Walk'" in result.output
+                assert "on Wrapper" not in result.output
+
     def test_animator_play_with_layer(self, runner, mock_config, mock_success):
         with patch("cli.commands.animation.get_config", return_value=mock_config):
             with patch("cli.commands.animation.run_command", return_value=mock_success) as mock_run:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/AnimatorResolverTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/AnimatorResolverTests.cs
@@ -1,0 +1,164 @@
+using NUnit.Framework;
+using UnityEngine;
+using MCPForUnity.Editor.Tools.Animation;
+using static MCPForUnityTests.Editor.TestUtilities;
+
+namespace MCPForUnityTests.Editor.Tools
+{
+    /// <summary>
+    /// Direct coverage of the resolver every animator read and control response depends on,
+    /// including the Play-mode parameter branches that an EditMode test cannot drive.
+    /// </summary>
+    public class AnimatorResolverTests
+    {
+        private GameObject _root;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null)
+                UnityEngine.Object.DestroyImmediate(_root);
+        }
+
+        private GameObject Child(string name)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(_root.transform);
+            return go;
+        }
+
+        [Test]
+        public void Find_NullTarget_ReturnsNullAndEmptyCandidates()
+        {
+            var resolved = AnimatorResolver.Find(null, out var candidates);
+            Assert.IsNull(resolved);
+            Assert.IsNotNull(candidates, "candidates must never be null - callers pass it straight on");
+            Assert.AreEqual(0, candidates.Length);
+        }
+
+        [Test]
+        public void Find_NoAnimatorAnywhere_ReturnsNullAndEmptyCandidates()
+        {
+            _root = new GameObject("AnimResTest_Empty");
+            Child("AnimResTest_EmptyChild");
+
+            var resolved = AnimatorResolver.Find(_root, out var candidates);
+            Assert.IsNull(resolved);
+            Assert.AreEqual(0, candidates.Length);
+        }
+
+        [Test]
+        public void Find_AnimatorOnTarget_PrefersItOverDescendants()
+        {
+            _root = new GameObject("AnimResTest_Priority");
+            var own = _root.AddComponent<Animator>();
+            Child("AnimResTest_PriorityChild").AddComponent<Animator>();
+
+            var resolved = AnimatorResolver.Find(_root, out var candidates);
+            Assert.AreSame(own, resolved, "An Animator on the target wins over any descendant");
+            Assert.AreEqual(0, candidates.Length, "The exact-target path reports no candidates");
+        }
+
+        [Test]
+        public void Find_SingleDescendantAnimator_ResolvesIt()
+        {
+            _root = new GameObject("AnimResTest_Single");
+            var rig = Child("AnimResTest_SingleRig").AddComponent<Animator>();
+
+            Assert.AreSame(rig, AnimatorResolver.Find(_root, out _));
+        }
+
+        [Test]
+        public void Find_InactiveDescendantAnimator_ResolvesIt()
+        {
+            _root = new GameObject("AnimResTest_Inactive");
+            var child = Child("AnimResTest_InactiveRig");
+            var rig = child.AddComponent<Animator>();
+            child.SetActive(false);
+
+            Assert.AreSame(rig, AnimatorResolver.Find(_root, out _),
+                "A disabled rig is still readable");
+        }
+
+        [Test]
+        public void Find_SeveralDescendantAnimators_ReturnsNullAndReportsThem()
+        {
+            _root = new GameObject("AnimResTest_Ambiguous");
+            Child("AnimResTest_RigA").AddComponent<Animator>();
+            Child("AnimResTest_RigB").AddComponent<Animator>();
+
+            var resolved = AnimatorResolver.Find(_root, out var candidates);
+            Assert.IsNull(resolved, "An ambiguous request must not pick one silently");
+            Assert.AreEqual(2, candidates.Length);
+        }
+
+        [Test]
+        public void NotResolvedError_Ambiguous_NamesEveryCandidate()
+        {
+            _root = new GameObject("AnimResTest_ErrAmbiguous");
+            Child("AnimResTest_ErrRigA").AddComponent<Animator>();
+            Child("AnimResTest_ErrRigB").AddComponent<Animator>();
+
+            AnimatorResolver.Find(_root, out var candidates);
+            var error = ToJObject(AnimatorResolver.NotResolvedError(_root, candidates));
+
+            Assert.IsFalse(error.Value<bool>("success"));
+            string message = error["message"].ToString();
+            StringAssert.Contains("AnimResTest_ErrRigA", message);
+            StringAssert.Contains("AnimResTest_ErrRigB", message);
+        }
+
+        [Test]
+        public void NotResolvedError_NoCandidates_ReportsTargetAndChildren()
+        {
+            _root = new GameObject("AnimResTest_ErrEmpty");
+
+            AnimatorResolver.Find(_root, out var candidates);
+            var error = ToJObject(AnimatorResolver.NotResolvedError(_root, candidates));
+
+            Assert.IsFalse(error.Value<bool>("success"));
+            StringAssert.Contains("or its children", error["message"].ToString());
+        }
+
+        [Test]
+        public void ResolvedSuffix_TargetCarriesTheAnimator_IsEmpty()
+        {
+            _root = new GameObject("AnimResTest_SuffixSame");
+            var own = _root.AddComponent<Animator>();
+
+            Assert.AreEqual(string.Empty, AnimatorResolver.ResolvedSuffix(_root, own),
+                "A response that did not retarget must read exactly as before");
+        }
+
+        [Test]
+        public void ResolvedSuffix_Retargeted_NamesBothObjects()
+        {
+            _root = new GameObject("AnimResTest_SuffixRoot");
+            var rig = Child("AnimResTest_SuffixRig").AddComponent<Animator>();
+
+            string suffix = AnimatorResolver.ResolvedSuffix(_root, rig);
+            StringAssert.Contains("AnimResTest_SuffixRig", suffix);
+            StringAssert.Contains("AnimResTest_SuffixRoot", suffix);
+        }
+
+        [Test]
+        public void Describe_TargetCarriesTheAnimator_NamesItOnce()
+        {
+            _root = new GameObject("AnimResTest_DescSame");
+            var own = _root.AddComponent<Animator>();
+
+            Assert.AreEqual("'AnimResTest_DescSame'", AnimatorResolver.Describe(_root, own));
+        }
+
+        [Test]
+        public void Describe_Retargeted_NamesBothObjects()
+        {
+            _root = new GameObject("AnimResTest_DescRoot");
+            var rig = Child("AnimResTest_DescRig").AddComponent<Animator>();
+
+            string described = AnimatorResolver.Describe(_root, rig);
+            StringAssert.Contains("AnimResTest_DescRig", described);
+            StringAssert.Contains("AnimResTest_DescRoot", described);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/AnimatorResolverTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/AnimatorResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2a73258659e4bb1a68221c941de6932
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageAnimationTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManageAnimationTests.cs
@@ -140,6 +140,346 @@ namespace MCPForUnityTests.Editor.Tools
         }
 
         // =============================================================================
+        // Animator: Child Resolution
+        // =============================================================================
+
+        [Test]
+        public void AnimatorGetInfo_AnimatorOnChild_ResolvesFromChild()
+        {
+            var root = new GameObject("AnimTest_ChildRoot");
+            var model = new GameObject("AnimTest_ChildModel");
+            model.transform.SetParent(root.transform);
+            model.AddComponent<Animator>();
+            try
+            {
+                Assert.IsNull(root.GetComponent<Animator>());
+
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_get_info",
+                    ["target"] = "AnimTest_ChildRoot"
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+
+                var data = result["data"] as JObject;
+                Assert.IsNotNull(data);
+                Assert.AreEqual("AnimTest_ChildRoot", data["gameObject"].ToString());
+                Assert.AreEqual("AnimTest_ChildModel", data["animatorGameObject"].ToString(),
+                    "Response must name the GameObject that actually carries the Animator");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorGetInfo_InactiveChildAnimator_ResolvesFromChild()
+        {
+            var root = new GameObject("AnimTest_InactiveRoot");
+            var model = new GameObject("AnimTest_InactiveModel");
+            model.transform.SetParent(root.transform);
+            model.AddComponent<Animator>();
+            model.SetActive(false);
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_get_info",
+                    ["target"] = "AnimTest_InactiveRoot"
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.AreEqual("AnimTest_InactiveModel", result["data"]["animatorGameObject"].ToString());
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorSetSpeed_AnimatorOnChild_AppliesToChildAnimator()
+        {
+            var root = new GameObject("AnimTest_ChildSpeedRoot");
+            var model = new GameObject("AnimTest_ChildSpeedModel");
+            model.transform.SetParent(root.transform);
+            var animator = model.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_set_speed",
+                    ["target"] = "AnimTest_ChildSpeedRoot",
+                    ["speed"] = 2.5f
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.AreEqual(2.5f, animator.speed, 0.001f);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorSetSpeed_MultipleDescendantAnimators_RefusesAndNamesThem()
+        {
+            var root = new GameObject("AnimTest_AmbigRoot");
+            var a = new GameObject("AnimTest_AmbigA");
+            var b = new GameObject("AnimTest_AmbigB");
+            a.transform.SetParent(root.transform);
+            b.transform.SetParent(root.transform);
+            var animA = a.AddComponent<Animator>();
+            var animB = b.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_set_speed",
+                    ["target"] = "AnimTest_AmbigRoot",
+                    ["speed"] = 2.5f
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsFalse(result.Value<bool>("success"), result.ToString());
+
+                var message = result["message"].ToString();
+                Assert.That(message, Does.Contain("AnimTest_AmbigA"));
+                Assert.That(message, Does.Contain("AnimTest_AmbigB"));
+                Assert.AreEqual(1f, animA.speed, 0.001f, "An ambiguous request must not mutate a rig");
+                Assert.AreEqual(1f, animB.speed, 0.001f, "An ambiguous request must not mutate a rig");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorSetSpeed_AnimatorOnChild_ResponseNamesTheChild()
+        {
+            var root = new GameObject("AnimTest_AttribRoot");
+            var model = new GameObject("AnimTest_AttribModel");
+            model.transform.SetParent(root.transform);
+            model.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_set_speed",
+                    ["target"] = "AnimTest_AttribRoot",
+                    ["speed"] = 2f
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.That(result["message"].ToString(), Does.Contain("AnimTest_AttribModel"),
+                    "A retargeted control response must name the object it actually changed");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorGetInfo_TargetAndDescendantsHaveAnimators_UsesTheTarget()
+        {
+            var root = new GameObject("AnimTest_PriorityRoot");
+            var child = new GameObject("AnimTest_PriorityChild");
+            child.transform.SetParent(root.transform);
+            root.AddComponent<Animator>();
+            child.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_get_info",
+                    ["target"] = "AnimTest_PriorityRoot"
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.AreEqual("AnimTest_PriorityRoot", result["data"]["animatorGameObject"].ToString(),
+                    "An Animator on the exact target wins over any descendant");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorGetInfo_MultipleDescendantAnimators_RefusesAndNamesThem()
+        {
+            var root = new GameObject("AnimTest_AmbigReadRoot");
+            var a = new GameObject("AnimTest_AmbigReadA");
+            var b = new GameObject("AnimTest_AmbigReadB");
+            a.transform.SetParent(root.transform);
+            b.transform.SetParent(root.transform);
+            a.AddComponent<Animator>();
+            b.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_get_info",
+                    ["target"] = "AnimTest_AmbigReadRoot"
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsFalse(result.Value<bool>("success"), result.ToString());
+
+                var message = result["message"].ToString();
+                Assert.That(message, Does.Contain("AnimTest_AmbigReadA"));
+                Assert.That(message, Does.Contain("AnimTest_AmbigReadB"));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        // Every resolver consumer, not just the two the other tests happen to call: a call site
+        // that drops the shared resolver must fail here rather than ship green.
+        [TestCase("animator_get_info")]
+        [TestCase("animator_get_parameter")]
+        [TestCase("animator_play")]
+        [TestCase("animator_crossfade")]
+        [TestCase("animator_set_parameter")]
+        [TestCase("animator_set_speed")]
+        [TestCase("animator_set_enabled")]
+        public void AnimatorActions_MultipleDescendantAnimators_AllRefuse(string action)
+        {
+            var root = new GameObject("AnimTest_AllRefuseRoot");
+            var a = new GameObject("AnimTest_AllRefuseA");
+            var b = new GameObject("AnimTest_AllRefuseB");
+            a.transform.SetParent(root.transform);
+            b.transform.SetParent(root.transform);
+            var animA = a.AddComponent<Animator>();
+            var animB = b.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = action,
+                    ["target"] = "AnimTest_AllRefuseRoot",
+                    ["stateName"] = "Walk",
+                    ["parameterName"] = "Speed",
+                    ["value"] = 1f,
+                    ["speed"] = 2f,
+                    ["enabled"] = false
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsFalse(result.Value<bool>("success"), $"{action} must refuse an ambiguous target: {result}");
+
+                var message = result["message"].ToString();
+                Assert.That(message, Does.Contain("AnimTest_AllRefuseA"), action);
+                Assert.That(message, Does.Contain("AnimTest_AllRefuseB"), action);
+                Assert.AreEqual(1f, animA.speed, 0.001f, $"{action} mutated a rig it should not have picked");
+                Assert.AreEqual(1f, animB.speed, 0.001f, $"{action} mutated a rig it should not have picked");
+                Assert.IsTrue(animA.enabled && animB.enabled, $"{action} mutated a rig it should not have picked");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorSetEnabled_AnimatorOnChild_ResponseNamesTheChild()
+        {
+            var root = new GameObject("AnimTest_EnabledRoot");
+            var model = new GameObject("AnimTest_EnabledModel");
+            model.transform.SetParent(root.transform);
+            var animator = model.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_set_enabled",
+                    ["target"] = "AnimTest_EnabledRoot",
+                    ["enabled"] = false
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.IsFalse(animator.enabled);
+                Assert.That(result["message"].ToString(), Does.Contain("AnimTest_EnabledModel"),
+                    "A retargeted control response must name the object it actually changed");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void AnimatorSetParameter_AnimatorOnChild_EditModeResponseNamesTheChild()
+        {
+            string controllerPath = $"{TempRoot}/ChildParam_{Guid.NewGuid():N}.controller";
+            var controller = AnimatorController.CreateAnimatorControllerAtPath(controllerPath);
+            controller.AddParameter("Speed", AnimatorControllerParameterType.Float);
+            AssetDatabase.SaveAssets();
+
+            var root = new GameObject("AnimTest_ParamRoot");
+            var model = new GameObject("AnimTest_ParamModel");
+            model.transform.SetParent(root.transform);
+            var animator = model.AddComponent<Animator>();
+            animator.runtimeAnimatorController = controller;
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "animator_set_parameter",
+                    ["target"] = "AnimTest_ParamRoot",
+                    ["parameterName"] = "Speed",
+                    ["parameterType"] = "float",
+                    ["value"] = 3f
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+                Assert.That(result["message"].ToString(), Does.Contain("AnimTest_ParamModel"),
+                    "A retargeted parameter write must disclose the Animator it resolved");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
+        public void ControllerAssign_AnimatorOnChild_AddsAnimatorToTarget()
+        {
+            string controllerPath = $"{TempRoot}/ChildAssign_{Guid.NewGuid():N}.controller";
+            AnimatorController.CreateAnimatorControllerAtPath(controllerPath);
+            AssetDatabase.SaveAssets();
+
+            var root = new GameObject("AnimTest_AssignRoot");
+            var model = new GameObject("AnimTest_AssignModel");
+            model.transform.SetParent(root.transform);
+            var childAnimator = model.AddComponent<Animator>();
+            try
+            {
+                var paramsObj = new JObject
+                {
+                    ["action"] = "controller_assign",
+                    ["target"] = "AnimTest_AssignRoot",
+                    ["controllerPath"] = controllerPath
+                };
+                var result = ToJObject(ManageAnimation.HandleCommand(paramsObj));
+                Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+
+                Assert.IsNotNull(root.GetComponent<Animator>(),
+                    "Assign must add an Animator to the named target, not reuse a descendant's");
+                Assert.IsNull(childAnimator.runtimeAnimatorController,
+                    "The child Animator must be left untouched");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        // =============================================================================
         // Animator: Set Speed / Set Enabled
         // =============================================================================
 


### PR DESCRIPTION
## Description

`manage_animation`'s `animator_*` actions resolved the Animator with
`GetComponent<Animator>()` on the target alone. Imported models keep their Animator on the
model root, which is normally a child of the GameObject a user names, so on the most common
rig setup every read and control call failed with `No Animator component on 'X'` even though
the Animator was right there.

The fix is not just "search children". A naive fallback trades a loud failure for a silent
wrong-target mutation — the same class of problem, made quieter. So this PR also makes an
ambiguous target an error, and makes retargeting visible in the response.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

**New `AnimatorResolver`** (`MCPForUnity/Editor/Tools/Animation/AnimatorResolver.cs`) —
prefers an Animator on the exact target, otherwise looks at descendants, inactive ones
included because a disabled rig is still readable. The seven read/control lookups
(`AnimatorRead.GetInfo`, `AnimatorRead.GetParameter`, and `AnimatorControl.{Play, Crossfade,
SetParameter, SetSpeed, SetEnabled}`) all route through it.

**Ambiguity is reported, never guessed.** Unity's descendant search is depth-first, so a
wrapper holding several rigs returns the first branch *however deep* — not the nearest rig,
and not what a caller would predict. I measured this on 6000.4.4f1: with Animators on
`Root/A/ADeep` and `Root/B`, the winner is `ADeep`. When more than one descendant carries an
Animator the call now fails and names the candidates, and mutates nothing.

**Every successful response names the object that actually changed.** A retargeted call used
to report success on the wrapper while a descendant was what moved. This includes the CLI's
own success line for `animator_play`, which echoed the requested target and so contradicted
the result it had just printed. It matters most for `animator_set_parameter`, which in Edit
mode writes the shared `AnimatorController` asset, so the caller needs to see which Animator
answered. Where the tool returns no message at all, the CLI fallback now names no object
rather than guessing the target.

**`animator_get_info` additionally reports `animatorGameObject`.** The existing `gameObject`
field keeps naming the resolved target, so nothing that reads it changes meaning.

**`controller_assign` deliberately keeps the exact-target lookup.** It ADDS an Animator when
none is found; making it search descendants would silently retarget the component it creates.
A test locks that boundary in.

The CLI usage guide still stated the old precondition, so it is updated too.

## Compatibility / Package Source

- Unity version(s) tested: **6000.4.4f1**
- Package source used: `file:` (`TestProjects/UnityMCPTests` → `file:../../../MCPForUnity`)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (local `file:` source)

## Testing/Screenshots/Recordings

- [x] Python tests (`cd Server && uv run pytest tests/ -v`) — 1376 passed, 3 skipped
- [x] Unity EditMode tests — 1206 total, 1140 passed, **0 failed**, 66 skipped
- [ ] Unity PlayMode tests
- [x] Package import/compile check — 0 compile errors

New tests:

| Where | What |
|---|---|
| `AnimatorResolverTests.cs` (new) | 12 direct resolver tests: null target, nothing found, exact-target precedence, single descendant, inactive descendant, ambiguity, both error shapes, and the two attribution helpers |
| `ManageAnimationTests.cs` | a `[TestCase]` set covering **all seven** entry points for ambiguity refusal (asserting no rig is mutated), plus child resolution, inactive-child resolution, control parity, response attribution for `set_speed`/`set_enabled`/Edit-mode `set_parameter`, and the `controller_assign` boundary |
| `test_manage_animation.py` | 2 CLI tests: the tool's attribution survives to the CLI, and the message-free fallback names no object |

I checked that these tests can actually fail, by mutating the resolver three ways and
re-running the animation suite each time:

| Mutation | Tests that turned red |
|---|---|
| descendant search removed (the pre-fix lookup) | 15 |
| ambiguity detection removed (silent first match) | 9 — the seven `AllRefuse` cases and both ambiguity tests |
| attribution helpers neutered | 3 — `set_speed`, `set_enabled`, Edit-mode `set_parameter` |

Reverting the CLI change turns both new Python tests red.

Two of the 17 animation test cases survived every mutation, both on purpose. The
`controller_assign` test guards behaviour this PR deliberately does *not* change, and is there
to catch a future edit that pulls it across the boundary. `AnimatorGetInfo_TargetAndDescendants
HaveAnimators_UsesTheTarget` pins exact-target precedence, which none of the three mutations
breaks. I am not counting either as proof of this change.

Worth noting for whoever reads the assertions: the ambiguity cases assert both candidate names
appear in the message, not merely that the call failed. `animator_get_parameter` and
`animator_set_parameter` still fail under the silent-match mutation — on a later parameter
check — so a bare `success == false` assertion would have passed there.

On the 66 skipped: that number is unchanged from before this branch, and none of them are
animation tests. They are `[Explicit]` process/port tests (38), missing
render-pipeline packages (18), domain-reload stress tests meant to be run by hand (4), and
tests with side effects such as writing real client configs or stopping the server (6).

## Documentation Updates

- [ ] I have added/removed/modified tools or resources

No tool, action, or parameter was added, and
`uv run python ../tools/generate_docs_reference.py --check` reports the generated reference is
up to date. The one documentation change is narrative: `Server/src/cli/CLI_USAGE_GUIDE.md`
said the target must carry the Animator.

## Related Issues

None found — I searched the open issues and PRs and did not find this reported.

## Additional Notes

**On the Unity version.** I could only test locally on 6000.4.4f1, which is not in
`tools/unity-versions.json`; none of the four matrix versions are installed on this machine.
`tools/check-unity-versions.sh` skips all four and still exits 0, so please don't read a local
green there as coverage — CI is the real check for the matrix. The change uses no
version-conditional code and no `#if UNITY_*` blocks.

**Two things I found and deliberately did not change.** Both are pre-existing and neither is
made worse per call by this PR, but this PR does make the first reachable from more targets,
so they seem worth your judgement rather than my silence:

1. `ClipCreate.Assign` also looks up `GetComponent<Animator>()`, and I left it on the
   exact-target side because it can add a component. Looking closer, that check is really a
   *branch selector*: with an Animator it returns non-mutating Mecanim guidance; without one
   it adds a legacy `Animation` component **and converts the clip asset to legacy**. So after
   this PR, `clip_assign` on `Wrapper` takes the legacy branch while `animator_get_info` on
   the same `Wrapper` reports the child's Animator — the two disagree about whether `Wrapper`
   has an Animator. I did not change it because putting a rig under a wrapper and deliberately
   animating the wrapper with a legacy clip looks like a legitimate setup the resolver would
   break. Happy to follow up either way.

2. Edit-mode `animator_set_parameter` writes the default onto the shared `AnimatorController`
   asset, which affects every Animator using that controller, and the response does not say
   so. This is unchanged from `beta` — I checked the same lines are there — and a direct
   target has always had the same effect, so this PR only broadens which target names reach
   it. Disclosing the controller in that message would be a small, separate improvement.

**Unrelated, noticed while checking the CLI's success lines.** `clip create`,
`clip create-preset` and `controller create` print a secondary success line using the caller's
raw path, while the tool sanitizes it and appends `.anim` / `.controller`. So
`animation clip create Assets/Walk` creates `Assets/Walk.anim` and then prints
`Created clip at Assets/Walk`. Untouched here — mentioning it in case it is useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Animation commands can now find an Animator on the selected object or its children, including inactive children.
  - Clear messages identify the resolved Animator and list candidates when multiple matches exist.
  - Animator information now includes the associated GameObject name.

- **Bug Fixes**
  - Prevented incorrect success messages when animation actions resolve a child object.
  - Improved fallback messages when no response details are available.

- **Documentation**
  - Updated animation command guidance to describe child Animator support.

- **Tests**
  - Added coverage for resolution, ambiguity handling, inactive children, and response accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
