### PR TITLE
fix(read_console): stop the Console window's filters from hiding entries

### DIFF
--- a/MCPForUnity/Editor/Tools/ReadConsole.cs
+++ b/MCPForUnity/Editor/Tools/ReadConsole.cs
@@ -30,6 +30,19 @@ namespace MCPForUnity.Editor.Tools
         private static FieldInfo _messageField;
         private static FieldInfo _fileField;
         private static FieldInfo _lineField;
+
+        // Optional reflection members: used to neutralize the Console window's own filters
+        // while reading. Absent members degrade to the previous (filter-inheriting) behavior.
+        private static PropertyInfo _consoleFlagsProperty;
+        private static MethodInfo _setFilteringTextMethod;
+        private static MethodInfo _getFilteringTextMethod;
+
+        // Severity bits from the internal UnityEditor.ConsoleWindow.ConsoleFlags enum.
+        private const int ConsoleFlagLogLevelLog = 1 << 7;
+        private const int ConsoleFlagLogLevelWarning = 1 << 8;
+        private const int ConsoleFlagLogLevelError = 1 << 9;
+        private const int ConsoleFlagLogLevelMask =
+            ConsoleFlagLogLevelLog | ConsoleFlagLogLevelWarning | ConsoleFlagLogLevelError;
     
         // Static constructor for reflection setup
         static ReadConsole()
@@ -99,6 +112,13 @@ namespace MCPForUnity.Editor.Tools
                 if (_lineField == null)
                     throw new Exception("Failed to reflect LogEntry.line");
 
+                // Console window UI state. Present on every Unity version this package
+                // supports, but reflected optionally so a future rename degrades to the old
+                // behavior rather than disabling console reads outright.
+                _consoleFlagsProperty = logEntriesType.GetProperty("consoleFlags", staticFlags);
+                _setFilteringTextMethod = logEntriesType.GetMethod("SetFilteringText", staticFlags);
+                _getFilteringTextMethod = logEntriesType.GetMethod("GetFilteringText", staticFlags);
+
                 // (Calibration removed)
 
             }
@@ -115,6 +135,8 @@ namespace MCPForUnity.Editor.Tools
                     _getEntryMethod =
                         null;
                 _modeField = _messageField = _fileField = _lineField = null;
+                _consoleFlagsProperty = null;
+                _setFilteringTextMethod = _getFilteringTextMethod = null;
             }
         }
 
@@ -202,6 +224,99 @@ namespace MCPForUnity.Editor.Tools
 
         // --- Action Implementations ---
 
+        /// <summary>
+        /// Forces the Console window's Log/Warning/Error severity bits on so that
+        /// StartGettingEntries reports every entry regardless of the toolbar toggles.
+        /// </summary>
+        /// <param name="savedConsoleFlags">The flags as they were, for restoration.</param>
+        /// <returns>True when the flags were changed and must be restored.</returns>
+        private static bool TryForceLogLevelFlags(out int savedConsoleFlags)
+        {
+            savedConsoleFlags = 0;
+            if (_consoleFlagsProperty == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                savedConsoleFlags = (int)_consoleFlagsProperty.GetValue(null);
+                int forcedFlags = savedConsoleFlags | ConsoleFlagLogLevelMask;
+                if (forcedFlags == savedConsoleFlags)
+                {
+                    return false; // Nothing is hidden; leave the property untouched.
+                }
+
+                _consoleFlagsProperty.SetValue(null, forcedFlags);
+                return true;
+            }
+            catch (Exception e)
+            {
+                McpLog.Warn(
+                    $"[ReadConsole] Could not override console severity flags; entries hidden by the Console window may be missing: {e.Message}"
+                );
+                return false;
+            }
+        }
+
+        private static void RestoreConsoleFlags(int savedConsoleFlags)
+        {
+            try
+            {
+                _consoleFlagsProperty.SetValue(null, savedConsoleFlags);
+            }
+            catch (Exception e)
+            {
+                McpLog.Error($"[ReadConsole] Failed to restore console severity flags: {e}");
+            }
+        }
+
+        /// <summary>
+        /// Clears the Console window's search query for the duration of a read. Only clears it
+        /// when it can also be read back, so a user's search is never silently discarded.
+        /// </summary>
+        /// <param name="savedFilteringText">The query as it was, for restoration.</param>
+        /// <returns>True when the query was cleared and must be restored.</returns>
+        private static bool TryClearFilteringText(out string savedFilteringText)
+        {
+            savedFilteringText = null;
+            if (_setFilteringTextMethod == null || _getFilteringTextMethod == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                savedFilteringText = _getFilteringTextMethod.Invoke(null, null) as string;
+                if (string.IsNullOrEmpty(savedFilteringText))
+                {
+                    return false; // No search query active; nothing to neutralize.
+                }
+
+                _setFilteringTextMethod.Invoke(null, new object[] { string.Empty });
+                return true;
+            }
+            catch (Exception e)
+            {
+                McpLog.Warn(
+                    $"[ReadConsole] Could not clear the console search filter; entries hidden by it may be missing: {e.Message}"
+                );
+                return false;
+            }
+        }
+
+        private static void RestoreFilteringText(string savedFilteringText)
+        {
+            try
+            {
+                _setFilteringTextMethod.Invoke(null, new object[] { savedFilteringText });
+            }
+            catch (Exception e)
+            {
+                McpLog.Error($"[ReadConsole] Failed to restore the console search filter: {e}");
+            }
+        }
+
         private static object ClearConsole()
         {
             try
@@ -246,8 +361,20 @@ namespace MCPForUnity.Editor.Tools
             int resolvedCursor = Mathf.Max(0, cursor ?? 0);
             int pageEndExclusive = resolvedCursor + resolvedPageSize;
 
+            // LogEntries filtering state is global and shared with the Console window, so a
+            // severity toggle switched off or a leftover search query in the toolbar silently
+            // starves this tool of entries. Neutralize both for the duration of the read; the
+            // tool applies its own 'types' and 'filterText' arguments instead.
+            int savedConsoleFlags = 0;
+            bool consoleFlagsOverridden = false;
+            string savedFilteringText = null;
+            bool filteringTextOverridden = false;
+
             try
             {
+                consoleFlagsOverridden = TryForceLogLevelFlags(out savedConsoleFlags);
+                filteringTextOverridden = TryClearFilteringText(out savedFilteringText);
+
                 // LogEntries requires calling Start/Stop around GetEntries/GetEntryInternal.
                 // StartGettingEntries() returns the entry count — use it instead of GetCount()
                 // which may return stale values within an active iteration session.
@@ -391,6 +518,18 @@ namespace MCPForUnity.Editor.Tools
                 {
                     McpLog.Error($"[ReadConsole] Failed to call EndGettingEntries: {e}");
                     // Don't return error here as we might have valid data, but log it.
+                }
+
+                // Restore the Console window's filters once the iteration session is closed,
+                // so the user's view is left exactly as they had it.
+                if (filteringTextOverridden)
+                {
+                    RestoreFilteringText(savedFilteringText);
+                }
+
+                if (consoleFlagsOverridden)
+                {
+                    RestoreConsoleFlags(savedConsoleFlags);
                 }
             }
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Reflection;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using MCPForUnity.Editor.Tools;
 using static MCPForUnityTests.Editor.TestUtilities;
@@ -152,5 +154,114 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.AreEqual(LogType.Log, ReadConsole.GetLogTypeFromMode(1 << 14));
         }
 
+        // The Console window's severity toggles and search box live on the shared internal
+        // UnityEditor.LogEntries state, so they leak into every StartGettingEntries caller.
+        // read_console must neutralize them for the duration of a read and restore them after.
+
+        private const int ConsoleFlagLogLevelLog = 1 << 7;
+        private const int ConsoleFlagLogLevelWarning = 1 << 8;
+
+        private static Type LogEntriesType =>
+            typeof(EditorApplication).Assembly.GetType("UnityEditor.LogEntries");
+
+        private static PropertyInfo ConsoleFlagsProperty => LogEntriesType.GetProperty(
+            "consoleFlags", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+        private static MethodInfo SetFilteringTextMethod => LogEntriesType.GetMethod(
+            "SetFilteringText", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+        private static MethodInfo GetFilteringTextMethod => LogEntriesType.GetMethod(
+            "GetFilteringText", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+        private static int ConsoleFlags
+        {
+            get => (int)ConsoleFlagsProperty.GetValue(null);
+            set => ConsoleFlagsProperty.SetValue(null, value);
+        }
+
+        private static string FilteringText
+        {
+            get => (string)GetFilteringTextMethod.Invoke(null, null);
+            set => SetFilteringTextMethod.Invoke(null, new object[] { value });
+        }
+
+        private static JArray GetAllEntries()
+        {
+            var result = ToJObject(ReadConsole.HandleCommand(new JObject
+            {
+                ["action"] = "get",
+                ["types"] = new JArray { "error", "warning", "log" },
+                ["format"] = "detailed",
+                ["count"] = 1000
+            }));
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            return result["data"] as JArray;
+        }
+
+        private static bool ContainsMessage(JArray entries, string needle)
+        {
+            if (entries == null) return false;
+            foreach (var entry in entries)
+            {
+                if (entry["message"]?.ToString().Contains(needle) == true) return true;
+            }
+            return false;
+        }
+
+        [Test]
+        public void HandleCommand_Get_IgnoresConsoleSearchFilter()
+        {
+            string uniqueMessage = $"Search filter probe {Guid.NewGuid()}";
+            string unrelatedQuery = $"no-entry-matches-{Guid.NewGuid()}";
+            string originalFilter = FilteringText;
+
+            try
+            {
+                Debug.Log(uniqueMessage);
+                FilteringText = unrelatedQuery;
+
+                var entries = GetAllEntries();
+
+                Assert.IsTrue(
+                    ContainsMessage(entries, uniqueMessage),
+                    "read_console must return entries hidden by the Console window's search query.");
+                Assert.AreEqual(
+                    unrelatedQuery,
+                    FilteringText,
+                    "read_console must leave the user's console search query untouched.");
+            }
+            finally
+            {
+                FilteringText = originalFilter ?? string.Empty;
+            }
+        }
+
+        [Test]
+        public void HandleCommand_Get_IgnoresConsoleSeverityToggles()
+        {
+            string uniqueMessage = $"Severity toggle probe {Guid.NewGuid()}";
+            int originalFlags = ConsoleFlags;
+            int hiddenFlags = originalFlags & ~(ConsoleFlagLogLevelLog | ConsoleFlagLogLevelWarning);
+
+            try
+            {
+                Debug.Log(uniqueMessage);
+                ConsoleFlags = hiddenFlags;
+
+                var entries = GetAllEntries();
+
+                Assert.IsTrue(
+                    ContainsMessage(entries, uniqueMessage),
+                    "read_console must return entries hidden by the Console window's severity toggles.");
+                Assert.AreEqual(
+                    hiddenFlags,
+                    ConsoleFlags,
+                    "read_console must restore the Console window's severity toggles.");
+            }
+            finally
+            {
+                ConsoleFlags = originalFlags;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

`read_console` inherits the Console window's UI filters, so entries the user has hidden in the Editor are invisible to the agent — and the tool still reports `success: true`, so "Retrieved 0 log entries" is indistinguishable from a clean console. Worst case is right after a compile, where an agent proceeds on broken state.

`LogEntries` filtering state is global and shared with the Console window. `StartGettingEntries()` honors both:

- the toolbar's Log / Warning / Error severity toggles — `ConsoleFlags.LogLevelLog|Warning|Error`, bits `1<<7`, `1<<8`, `1<<9`
- the toolbar's search box — `LogEntries.SetFilteringText`

The tool's own `filterText` argument is applied client-side afterwards, so it cannot compensate for entries the native call never returned.

`GetConsoleEntries` now snapshots both, neutralizes them for the duration of the read, and restores them in the `finally` block once the iteration session is closed — so the user's Console view is left exactly as they had it. The tool's own `types` and `filterText` arguments still do the filtering, which is what the caller actually asked for.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

`MCPForUnity/Editor/Tools/ReadConsole.cs`

- Reflect `LogEntries.consoleFlags`, `SetFilteringText` and `GetFilteringText`.
- `TryForceLogLevelFlags` / `RestoreConsoleFlags` — OR the three severity bits on for the read, restore afterwards. Idempotent: when the bits are already set the property is not written at all.
- `TryClearFilteringText` / `RestoreFilteringText` — blank the search query for the read, restore afterwards.
- Restoration happens after `EndGettingEntries`, so it never runs inside an open iteration session, and it runs even if the iteration throws.

`TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs`

- `HandleCommand_Get_IgnoresConsoleSearchFilter` — logs a probe, sets a non-matching search query, asserts the probe is still returned and that the query is left as the user set it.
- `HandleCommand_Get_IgnoresConsoleSeverityToggles` — logs a probe, switches the Log/Warning bits off, asserts the probe is still returned and that the flags are restored.

### Notes on the approach

- **The three severity bits only, not the whole mask.** `Collapse` (`1<<0`) also changes what `StartGettingEntries` returns, but forcing it off would flood a page with duplicates of a spammed message and push distinct entries past the `count`/`pageSize` limit — that hides output rather than revealing it. Left alone deliberately.
- **The search query is only cleared when `GetFilteringText` is also available**, so a user's search is never discarded without a way to put it back.
- **All four reflected members exist in 2021.3, 2022.3, 6000.0 and 6000.3** (checked against UnityCsReference at each tag), so this is not a version-gated path in practice. They are still reflected *optionally*: if a future Unity renames one, console reads degrade to the current behavior instead of failing outright. The `HandleCommand` reflection guard is deliberately unchanged — these members are not required for a console read to work at all, and `clear` does not depend on them.

## Compatibility / Package Source

- Unity version(s) tested: compile-verified against **2022.3.27f1** and **6000.3.14f1** for **win, osx and linux** each; behavior verified at runtime in a live **6000.3.14f1** Editor
- Package source used: local `file:` checkout
- Resolved commit hash from `Packages/packages-lock.json`: n/a (`file:` source)

## Testing/Screenshots/Recordings

- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

### Compile

`tools/compile-check.sh` run against local Hub installs of 2022.3.27f1 and 6000.3.14f1 — `MCPForUnity.Runtime` and `MCPForUnity.Editor` compile clean on win, osx and linux for both. The EditMode test assembly was compiled the same way (same reference set plus the built package DLLs) to confirm the two new tests build; the only diagnostics are pre-existing `CS0618`/`CS0649` warnings from unrelated test files.

### Runtime, in a live 6000.3.14f1 Editor

Verified against a project consuming this branch through a `file:` package reference, confirming first that the loaded `MCPForUnity.Editor` assembly actually contained the new methods.

**The bug, reproduced:** with the Log and Warning toggles switched off, a raw `LogEntries.StartGettingEntries()` returns **0** — with a freshly logged entry sitting in the console. That is the tool's old view.

**The fix, against that same state:** `read_console` returns the probe entry, and `consoleFlags` is left byte-identical afterwards.

**Search-box case** (the reported one): with the search box set to a query matching nothing, `read_console` returns the probe, and `GetFilteringText()` afterwards still returns the user's query unchanged.

**Idempotence confirmed incidentally:** in that project the three severity bits were already on, so `TryForceLogLevelFlags` correctly declined to write the property at all and `consoleFlags` never changed.

### On the two new tests

They have **not** been run as an NUnit fixture. `TestProjects/UnityMCPTests` is pinned to 2021.3.45f2 and I have no 2021 Editor installed; opening it in a newer one would silently upgrade the tracked `ProjectVersion.txt`. Note that the `Test in editmode` check on this PR passes in ~5s without a license, so it has not run them either — they need a licensed Editor run.

What I could do instead: execute both test bodies verbatim — same NUnit `Assert` calls, same setup and teardown — against the live Editor. Both pass. That exercises the assertion logic, but not the fixture plumbing (`[Test]` discovery, test-runner domain state), so a maintainer's licensed run is still the real gate.

Python tests were not run — this change touches no Python.

### Manual repro, for anyone verifying by hand

1. Type anything into the Console window's search box (or switch the Log/Warning toggles off).
2. `Debug.Log("PROBE")`.
3. `read_console` with `action: "get"`, `types: ["log"]`.
4. Before: `{"success": true, "message": "Retrieved 0 log entries"}`. After: the probe is returned, and the search box / toggles are left untouched.

## Documentation Updates

- [ ] I have added/removed/modified tools or resources

No tool or resource signature changed — the response shape and every argument are identical, so `website/docs/reference/` is unaffected.

## Related Issues

Fixes #1239

## Additional Notes

Supersedes #1252, which fixed the same issue and was closed unmerged by its author. Differences from that patch, all of them the review points it collected:

- The search query is saved and restored rather than cleared permanently — #1252 noted it cleared the box "without saving because `GetFilteringText` is not guaranteed to exist", but it does exist on every version this package supports, and losing a user's search on every console read is avoidable.
- Both mutations sit inside the same `try`/`finally` as the iteration, so a throw restores both.
- The `HandleCommand` reflection guard is left alone, so `clear` stays available regardless of these optional members.

Credit for the original diagnosis goes to @beast-ofcourse in #1239.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Console reads now include messages hidden by active search filters or disabled severity toggles.
  * The Console’s existing search and severity settings are preserved and restored after reading.
  * Console reads continue gracefully when these settings cannot be accessed, with warnings provided when necessary.
  * Restoration issues are reported without preventing the console read from completing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
