### PR TITLE
fix(stdio): refresh port discovery before reconnect backoff

### DIFF
--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -439,6 +439,7 @@ class UnityConnection:
 
                 # Re-discover the port for this specific instance
                 try:
+                    stdio_port_registry.get_instances(force_refresh=True)
                     new_port: int | None = None
                     if self.instance_id:
                         # Try to rediscover the specific instance via shared registry

--- a/Server/tests/integration/test_connection_deadline.py
+++ b/Server/tests/integration/test_connection_deadline.py
@@ -11,6 +11,8 @@ import pytest
 
 from core.config import config
 import transport.legacy.unity_connection as uc
+from models.models import UnityInstanceInfo
+from transport.legacy.stdio_port_registry import StdioPortRegistry
 from transport.legacy.unity_connection import UnityConnection
 
 
@@ -108,3 +110,50 @@ def test_reload_signal_drops_socket_for_fresh_reconnect(silent_bridge, tmp_path)
     response = conn.send_command("get_editor_state", {})
     assert conn.sock is None
     assert uc._extract_response_reason(response) == "reloading"
+
+
+def test_connection_failure_refreshes_cached_port_before_backoff(monkeypatch) -> None:
+    instance_id = "Repro@deadbeef"
+    discovered_port = 6400
+
+    def discover_instances() -> list[UnityInstanceInfo]:
+        return [
+            UnityInstanceInfo(
+                id=instance_id,
+                name="Repro",
+                path="/tmp/Repro/Assets",
+                hash="deadbeef",
+                port=discovered_port,
+                status="running",
+            )
+        ]
+
+    registry = StdioPortRegistry()
+    monkeypatch.setattr(
+        "transport.legacy.stdio_port_registry.PortDiscovery.discover_all_unity_instances",
+        discover_instances,
+    )
+    monkeypatch.setattr(config, "port_registry_ttl", 60.0)
+
+    assert registry.get_port(instance_id) == 6400
+    discovered_port = 6401
+
+    monkeypatch.setattr(uc, "stdio_port_registry", registry)
+    conn = UnityConnection(port=6400, instance_id=instance_id)
+    attempted_ports: list[int] = []
+    ports_before_backoff: list[int] = []
+
+    def fail_connect(connect_timeout: float | None = None) -> bool:
+        attempted_ports.append(conn.port)
+        return False
+
+    monkeypatch.setattr(conn, "connect", fail_connect)
+    monkeypatch.setattr(
+        uc.time, "sleep", lambda _seconds: ports_before_backoff.append(conn.port)
+    )
+
+    with pytest.raises(ConnectionError, match="Could not connect to Unity"):
+        conn.send_command("get_editor_state", {}, max_attempts=1)
+
+    assert attempted_ports == [6400, 6401]
+    assert ports_before_backoff == [6401]


### PR DESCRIPTION
## Description

Refresh stdio port discovery immediately after a Unity communication failure. This lets reconnect attempts follow a new port announced in the status registry after a domain reload instead of reusing the cached port until its TTL expires.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Force-refresh the stdio instance registry before resolving the reconnect port.
- Add a regression test that primes a stale cached port, changes discovery to a new port, and verifies the new port is selected before retry backoff and used by the next connection attempt.

## Compatibility / Package Source

- Unity version(s) tested: Not applicable (Python server-only change)
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `beta`
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): Not applicable

## Testing/Screenshots/Recordings

- [x] Python tests (`cd Server && uv run pytest tests/ -v`): 1375 passed, 3 skipped
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [ ] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

## Related Issues

Fixes #1339

## Additional Notes

Unity tests were not run because this change only affects Python stdio reconnection and does not modify the Unity package. The regression test exercises the cache TTL scenario without requiring a Unity Editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery when a cached Unity port becomes outdated.
  * Failed connection attempts now refresh available port information before retrying, increasing the likelihood of reconnecting successfully.
  * Connection errors are reported correctly after all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->