### PR TITLE
fix: correct Trae MCP config path

### DIFF
--- a/MCPForUnity/Editor/Clients/Configurators/TraeConfigurator.cs
+++ b/MCPForUnity/Editor/Clients/Configurators/TraeConfigurator.cs
@@ -10,9 +10,9 @@ namespace MCPForUnity.Editor.Clients.Configurators
         public TraeConfigurator() : base(new McpClient
         {
             name = "Trae",
-            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Trae", "mcp.json"),
-            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Trae", "mcp.json"),
-            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "Trae", "mcp.json"),
+            windowsConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Trae", "User", "mcp.json"),
+            macConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Trae", "User", "mcp.json"),
+            linuxConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "Trae", "User", "mcp.json"),
         })
         { }
 
@@ -21,9 +21,9 @@ namespace MCPForUnity.Editor.Clients.Configurators
             "Open Trae and go to Settings > MCP",
             "Select Add Server > Add Manually",
             "Paste the JSON or point to the mcp.json file\n"+
-                "Windows: %AppData%\\Trae\\mcp.json\n" +
-                "macOS: ~/Library/Application Support/Trae/mcp.json\n" +
-                "Linux: ~/.config/Trae/mcp.json\n",
+                "Windows: %AppData%\\Trae\\User\\mcp.json\n" +
+                "macOS: ~/Library/Application Support/Trae/User/mcp.json\n" +
+                "Linux: ~/.config/Trae/User/mcp.json\n",
             "Save and restart Trae"
         };
     }


### PR DESCRIPTION
## Description

`TraeConfigurator` writes the Unity MCP entry to `.../Trae/mcp.json`, but Trae reads its global MCP config from `.../Trae/User/mcp.json`, one level down, in the profile folder.

This has been wrong since #337. The failure mode is silent and reports success because `IsInstalled` only stats the *parent* directory, which exists, so Trae is detected, the write succeeds, and the MCP for Unity window shows Configured while Trae loads nothing.

Trae derives the MCP config location from the profile folder, not the user data root. In `Trae.app/Contents/Resources/app/out/main.js`:

```js
get appSettingsHome(){ return URI.file(join(this.userDataPath, "User")) }
```

Trae appends mcp.json to the profile location, which for the default profile is appSettingsHome, resolving to `<userData>/User/mcp.json`. Nothing in the app's bundles joins userDataPath with mcp.json directly, so the old path is unreachable by Trae, not merely deprioritized.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made

`MCPForUnity/Editor/Clients/Configurators/TraeConfigurator.cs` only,

- `windowsConfigPath`: `%AppData%\Trae\mcp.json` → `%AppData%\Trae\User\mcp.json`
- `macConfigPath`: `~/Library/Application Support/Trae/mcp.json` → `~/Library/Application Support/Trae/User/mcp.json`
- `linuxConfigPath`: `~/.config/Trae/mcp.json` → `~/.config/Trae/User/mcp.json`
- The three matching paths printed by `GetInstallationSteps()`

## Compatibility / Package Source

- Unity version(s) tested: **6000.5.4f1** (manual in-Editor verification; automated EditMode suite not run locally)

## Testing/Screenshots/Recordings

- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

**Verified against a running Trae 3.5.87 (macOS arm64)** by planting a uniquely named MCP server at the old path:

| Files present | Result |
|---|---|
| `User/mcp.json` (Puppeteer, for testing) + old path (probe) | Trae starts Puppeteer; probe ignored |
| **only** the old path (probe) | MCP subsystem activates, loads **zero** servers |

The probe never appears anywhere in Trae's logs or state. The file is not read and rejected, it is never opened.

**End-to-end in Unity 6000.5.4f1 (macOS).** Loaded this branch as a local package, opened **Window → MCP for Unity → Configure** with Trae selected. The `unityMCP` entry was written to `~/Library/Application Support/Trae/User/mcp.json`, **merged** alongside existing MCP servers, and the old `.../Trae/mcp.json` path was never created. Trae then showed **unityMCP** in Settings → MCP.

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

## Related Issues

No issue was filed for this. Found while configuring Trae locally and noticing the UI reported Configured while Trae showed no Unity server.

## Additional Notes

**Why no test.** A `Path.Combine` assertion against a path literal restates the constant rather than verifying it, and would still pass if Trae relocated the file — so it would not catch the next occurrence of this bug either.

**Only macOS is verified against a running Trae.** The Windows and Linux paths are inferred from the same VS Code profile layout (`%AppData%\Code\User`, `~/.config/Code/User`) and would benefit from a check by someone on those platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Trae MCP configuration paths across Windows, macOS, and Linux to use the correct `User` subdirectory.
* **Documentation**
  * Updated installation instructions to reflect the revised configuration locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->