### PR TITLE
fix: MCP window shows 'Not connected' while the stdio bridge is serving requests

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/TransportManager.cs
+++ b/MCPForUnity/Editor/Services/Transport/TransportManager.cs
@@ -146,14 +146,19 @@ namespace MCPForUnity.Editor.Services.Transport
         /// listener resumes through StdioBridgeHost's editor-idle retry once the OS releases
         /// the port, bypassing StartAsync entirely (CI auto-start does the same). Without
         /// reconciling, the cached snapshot stays "Disconnected" and the editor window reports
-        /// a dead bridge while it is actually serving requests — until a manual Verify.
+        /// a dead bridge while it is actually serving requests — until a manual Verify. A
+        /// stop/start cycle between two reads can also rebind to a different port while both
+        /// snapshots stay "connected", so the bound port is reconciled too.
         /// </summary>
         private TransportState ReconciledStdioState()
         {
             IMcpTransportClient client = GetOrCreateClient(TransportMode.Stdio);
-            if (client.IsConnected != _stdioState.IsConnected)
+            TransportState live = client.State;
+            bool connectivityChanged = client.IsConnected != _stdioState.IsConnected;
+            bool portChanged = client.IsConnected && live?.Port != _stdioState.Port;
+            if (connectivityChanged || portChanged)
             {
-                _stdioState = client.State ?? (client.IsConnected
+                _stdioState = live ?? (client.IsConnected
                     ? TransportState.Connected(client.TransportName)
                     : TransportState.Disconnected(client.TransportName));
             }

--- a/MCPForUnity/Editor/Services/Transport/TransportManager.cs
+++ b/MCPForUnity/Editor/Services/Transport/TransportManager.cs
@@ -136,9 +136,28 @@ namespace MCPForUnity.Editor.Services.Transport
             return mode switch
             {
                 TransportMode.Http => _httpState,
-                TransportMode.Stdio => _stdioState,
+                TransportMode.Stdio => ReconciledStdioState(),
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported transport mode"),
             };
+        }
+
+        /// <summary>
+        /// The stdio bridge can start or stop outside this manager: after a domain reload the
+        /// listener resumes through StdioBridgeHost's editor-idle retry once the OS releases
+        /// the port, bypassing StartAsync entirely (CI auto-start does the same). Without
+        /// reconciling, the cached snapshot stays "Disconnected" and the editor window reports
+        /// a dead bridge while it is actually serving requests — until a manual Verify.
+        /// </summary>
+        private TransportState ReconciledStdioState()
+        {
+            IMcpTransportClient client = GetOrCreateClient(TransportMode.Stdio);
+            if (client.IsConnected != _stdioState.IsConnected)
+            {
+                _stdioState = client.State ?? (client.IsConnected
+                    ? TransportState.Connected(client.TransportName)
+                    : TransportState.Disconnected(client.TransportName));
+            }
+            return _stdioState;
         }
 
         public bool IsRunning(TransportMode mode) => GetState(mode).IsConnected;

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioTransportClient.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioTransportClient.cs
@@ -14,7 +14,24 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
 
         public bool IsConnected => StdioBridgeHost.IsRunning;
         public string TransportName => "stdio";
-        public TransportState State => _state;
+
+        // The bridge host can bind or drop outside StartAsync/StopAsync (editor-idle retry
+        // after a busy-port reload, CI auto-start), so the cached snapshot can go stale in
+        // both directions. Refresh it from the live listener whenever they disagree.
+        public TransportState State
+        {
+            get
+            {
+                bool bridgeRunning = StdioBridgeHost.IsRunning;
+                if (bridgeRunning != _state.IsConnected)
+                {
+                    _state = bridgeRunning
+                        ? TransportState.Connected("stdio", port: StdioBridgeHost.GetCurrentPort())
+                        : TransportState.Disconnected("stdio", "Bridge not running");
+                }
+                return _state;
+            }
+        }
 
         // Bounded window to wait for the bridge to actually bind after StartAutoConnect. Covers the
         // OS port-release delay after a domain reload (the same port can stay held for a few hundred

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioTransportClient.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioTransportClient.cs
@@ -15,18 +15,23 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         public bool IsConnected => StdioBridgeHost.IsRunning;
         public string TransportName => "stdio";
 
-        // The bridge host can bind or drop outside StartAsync/StopAsync (editor-idle retry
-        // after a busy-port reload, CI auto-start), so the cached snapshot can go stale in
-        // both directions. Refresh it from the live listener whenever they disagree.
+        /// <summary>
+        /// The bridge host can bind or drop outside StartAsync/StopAsync (editor-idle retry
+        /// after a busy-port reload, CI auto-start), so the cached snapshot can go stale in
+        /// both directions — and a stop/start cycle between two reads can land on a different
+        /// port while staying "connected". Refresh from the live listener whenever
+        /// connectivity or the bound port disagrees.
+        /// </summary>
         public TransportState State
         {
             get
             {
                 bool bridgeRunning = StdioBridgeHost.IsRunning;
-                if (bridgeRunning != _state.IsConnected)
+                int livePort = StdioBridgeHost.GetCurrentPort();
+                if (bridgeRunning != _state.IsConnected || (bridgeRunning && _state.Port != livePort))
                 {
                     _state = bridgeRunning
-                        ? TransportState.Connected("stdio", port: StdioBridgeHost.GetCurrentPort())
+                        ? TransportState.Connected("stdio", port: livePort)
                         : TransportState.Disconnected("stdio", "Bridge not running");
                 }
                 return _state;

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportManagerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportManagerTests.cs
@@ -48,6 +48,72 @@ namespace MCPForUnityTests.Editor.Services
             client.Pending.SetResult(true); // let the shared attempt finish
         }
 
+        /// <summary>
+        /// Stdio fake whose connectivity is flipped by the test without going through
+        /// StartAsync/StopAsync — mirrors StdioBridgeHost binding via its editor-idle
+        /// retry after a busy-port domain reload, which bypasses TransportManager.
+        /// </summary>
+        private sealed class ExternallyControlledStdioClient : IMcpTransportClient
+        {
+            public bool Connected;
+
+            public bool IsConnected => Connected;
+            public string TransportName => "stdio";
+            public TransportState State => Connected
+                ? TransportState.Connected("stdio", port: 6400)
+                : TransportState.Disconnected("stdio", "Bridge not running");
+
+            public Task<bool> StartAsync()
+            {
+                Connected = true;
+                return Task.FromResult(true);
+            }
+
+            public Task StopAsync()
+            {
+                Connected = false;
+                return Task.CompletedTask;
+            }
+
+            public Task<bool> VerifyAsync() => Task.FromResult(Connected);
+            public Task ReregisterToolsAsync() => Task.CompletedTask;
+        }
+
+        [Test]
+        public void GetState_Stdio_ReconcilesWhenBridgeStartsOutsideManager()
+        {
+            var client = new ExternallyControlledStdioClient();
+            var manager = new TransportManager();
+            manager.Configure(() => client, () => client);
+
+            Assert.IsFalse(manager.IsRunning(TransportMode.Stdio), "sanity: starts disconnected");
+
+            client.Connected = true; // bridge bound via editor-idle retry, no StartAsync involved
+
+            Assert.IsTrue(manager.IsRunning(TransportMode.Stdio),
+                "manager must report the live bridge even when it started outside StartAsync");
+            TransportState state = manager.GetState(TransportMode.Stdio);
+            Assert.IsTrue(state.IsConnected);
+            Assert.AreEqual(6400, state.Port, "reconciled state comes from the client, port included");
+        }
+
+        [Test]
+        public void GetState_Stdio_ReconcilesWhenBridgeStopsOutsideManager()
+        {
+            var client = new ExternallyControlledStdioClient();
+            var manager = new TransportManager();
+            manager.Configure(() => client, () => client);
+
+            Task<bool> started = manager.StartAsync(TransportMode.Stdio);
+            Assert.IsTrue(started.IsCompleted && started.Result, "fake start completes synchronously");
+            Assert.IsTrue(manager.IsRunning(TransportMode.Stdio));
+
+            client.Connected = false; // listener died without StopAsync (e.g. socket teardown on reload)
+
+            Assert.IsFalse(manager.IsRunning(TransportMode.Stdio),
+                "manager must not report a bridge that is no longer listening");
+        }
+
         [Test]
         public void StartAsync_AfterCompletedStart_StartsFresh()
         {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportManagerTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/TransportManagerTests.cs
@@ -56,11 +56,12 @@ namespace MCPForUnityTests.Editor.Services
         private sealed class ExternallyControlledStdioClient : IMcpTransportClient
         {
             public bool Connected;
+            public int Port = 6400;
 
             public bool IsConnected => Connected;
             public string TransportName => "stdio";
             public TransportState State => Connected
-                ? TransportState.Connected("stdio", port: 6400)
+                ? TransportState.Connected("stdio", port: Port)
                 : TransportState.Disconnected("stdio", "Bridge not running");
 
             public Task<bool> StartAsync()
@@ -79,6 +80,10 @@ namespace MCPForUnityTests.Editor.Services
             public Task ReregisterToolsAsync() => Task.CompletedTask;
         }
 
+        /// <summary>
+        /// The bridge binding via its editor-idle retry (no StartAsync) must surface as
+        /// connected through GetState/IsRunning, port included.
+        /// </summary>
         [Test]
         public void GetState_Stdio_ReconcilesWhenBridgeStartsOutsideManager()
         {
@@ -97,6 +102,10 @@ namespace MCPForUnityTests.Editor.Services
             Assert.AreEqual(6400, state.Port, "reconciled state comes from the client, port included");
         }
 
+        /// <summary>
+        /// A listener that died without StopAsync (e.g. socket teardown on reload) must stop
+        /// being reported as connected.
+        /// </summary>
         [Test]
         public void GetState_Stdio_ReconcilesWhenBridgeStopsOutsideManager()
         {
@@ -112,6 +121,28 @@ namespace MCPForUnityTests.Editor.Services
 
             Assert.IsFalse(manager.IsRunning(TransportMode.Stdio),
                 "manager must not report a bridge that is no longer listening");
+        }
+
+        /// <summary>
+        /// A stop/start cycle between two reads can rebind to a different port while both
+        /// snapshots stay "connected" (the 6400↔6401 busy-port fallback); GetState must
+        /// surface the new port, not the stale one.
+        /// </summary>
+        [Test]
+        public void GetState_Stdio_ReconcilesWhenBridgePortChangesWhileConnected()
+        {
+            var client = new ExternallyControlledStdioClient();
+            var manager = new TransportManager();
+            manager.Configure(() => client, () => client);
+
+            client.Connected = true;
+            Assert.AreEqual(6400, manager.GetState(TransportMode.Stdio).Port, "sanity: initial port");
+
+            client.Port = 6401; // bridge restarted onto the fallback port between reads
+
+            TransportState state = manager.GetState(TransportMode.Stdio);
+            Assert.IsTrue(state.IsConnected);
+            Assert.AreEqual(6401, state.Port, "a rebind while connected must refresh the reported port");
         }
 
         [Test]


### PR DESCRIPTION
## Description

After a domain reload, `StdioBridgeHost` resumes its TCP listener through its editor-idle retry loop once the OS releases the port (the busy-port path from #1173). That resume path — and CI/`[InitializeOnLoad]` auto-start — bypasses `TransportManager.StartAsync`, so the manager's cached `TransportState` stays `Disconnected` while the bridge is actually up and serving tool calls.

The MCP for Unity window reads that cached snapshot (`BridgeControlService.IsRunning` → `TransportManager.GetState`), so it reports **Not connected** indefinitely until a manual Verify. During compile-heavy sessions (frequent reloads + port ping-pong between 6400/6401) the window is wrong most of the time, sending users chasing a connection problem that doesn't exist.

Reproduced on macOS, Unity 6000.3.15f1, package v10.1.0: window showed Not connected while MCP tool calls (including `execute_code`) succeeded; `TransportManager.IsRunning(Stdio)` returned `false` with the listener bound and a handshake ping succeeding on the same port.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

Two-layer reconcile, no behavior change on the HTTP path:

- `StdioTransportClient.State` refreshes its snapshot from the live listener whenever connectivity **or the bound port** disagrees — covering the late bind after a busy port, a listener that died without `StopAsync`, and a stop/start cycle that rebinds to a different port between two reads.
- `TransportManager.GetState(Stdio)` reconciles its own cached state with the client's live connectivity and port before returning it, creating the client lazily so host auto-start without any prior `StartAsync` is also covered.
- Three new EditMode tests in `TransportManagerTests` pin all three reconcile directions (start outside manager, stop outside manager, port rebind while connected) using a fake stdio client whose connectivity/port flip without going through Start/Stop.

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f1 (full EditMode suite), 6000.3.15f1 (live repro/verification of the bug in-editor)
- Package source used: `file:` (local clone of this repo, branch `fix/stdio-window-state-desync` off `beta`)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (file reference)

## Testing/Screenshots/Recordings
- [ ] Python tests — not applicable, no Python-side changes
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests — not applicable, editor-only services
- [x] Package import/compile check

Full EditMode suite on 2022.3.62f1 (direct `-runTests -testResults` invocation): **1113 passed, 0 failed** (66 pre-existing ignores), new tests passing.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources — no tool/resource surface changes

## Related Issues

Relates to #1173 (the busy-port fallback whose resume path bypasses the manager state).

## Additional Notes

`tools/check-unity-versions.sh --full` currently passes `-quit` together with `-runTests`, which makes Unity exit after import without executing any tests (its log shows no test run; exit code is 0 regardless). I verified with a direct `-runTests -testResults` invocation instead — happy to file that separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stdio transport status reporting by detecting bridge starts and stops that occur outside the manager.
  * Updated connection status when the bridge changes ports while connected.
  * Ensured reported state reflects the bridge’s live connectivity and bound port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->