### PR TITLE
chore: drop unmatched MultiEdit permission rule from .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,7 @@
   "permissions": {
     "allow": [
       "mcp__unity",
-      "Edit(reports/**)",
-      "MultiEdit(reports/**)"
+      "Edit(reports/**)"
     ],
     "deny": [
     ]


### PR DESCRIPTION
## Description
Claude Code gates every file-editing tool (Edit, Write, MultiEdit, NotebookEdit) on `Edit(path)` permission rules and no longer matches `MultiEdit(path)` rules. The `MultiEdit(reports/**)` entry in `.claude/settings.json` is dead config, and current Claude Code builds print this on every launch in the repo:

```
Permission allow rule (.claude\settings.json): MultiEdit(reports/**) is not matched by file permission checks — only Edit(path) rules are. Use Edit(reports/**) instead (Edit rules cover all file-editing tools).
```

`Edit(reports/**)` is already in the allow list, so removing the line changes nothing about what is permitted.

## Type of Change
- [x] Refactoring (no functional changes)

## Changes Made
- Remove `"MultiEdit(reports/**)"` from `permissions.allow` in `.claude/settings.json`

## Compatibility / Package Source
- Unity version(s) tested: n/a
- Package source used: n/a
- Resolved commit hash: n/a

## Testing/Screenshots/Recordings
- [x] Not applicable (explain why in Additional Notes)

## Documentation Updates
- [ ] I have added/removed/modified tools or resources

## Related Issues
None.

## Additional Notes
Config-only change to the Claude Code project settings; no package or server code touched. The remaining `Edit(reports/**)` rule is the exact replacement the warning itself recommends.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated editing permissions for report files to allow standard edits while removing multi-edit access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->