### PR TITLE
fix(build): skip never-saved scenes instead of opening the save modal

### DIFF
--- a/MCPForUnity/Editor/Tools/Build/BuildRunner.cs
+++ b/MCPForUnity/Editor/Tools/Build/BuildRunner.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEditor.Build.Reporting;
 using UnityEditor.Build;
 using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
 using MCPForUnity.Editor.Helpers;
 
 namespace MCPForUnity.Editor.Tools.Build
@@ -234,16 +235,39 @@ namespace MCPForUnity.Editor.Tools.Build
         }
 
         /// <summary>
-        /// Saves assets and open scenes before building so BuildPipeline does not block on a save dialog.
+        /// Saves assets and dirty open scenes before building so BuildPipeline does not block on
+        /// a save dialog. Scenes that have never been saved carry an empty path, and handing one
+        /// to Unity's save API opens the modal "Save Scene" file panel — the exact block this is
+        /// meant to prevent — so those are skipped with a warning instead. Mirrors the guard in
+        /// TestRunnerService.SaveDirtyScenes.
         /// </summary>
-        private static void SaveBeforeBuild()
+        internal static void SaveBeforeBuild()
         {
             AssetDatabase.SaveAssets();
-            if (!EditorSceneManager.SaveOpenScenes())
+
+            int sceneCount = SceneManager.sceneCount;
+            for (int i = 0; i < sceneCount; i++)
             {
-                McpLog.Warn(
-                    "[MCP Build] Some modified scenes could not be saved (new scenes need a path). " +
-                    "Build may still prompt to save.");
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.isDirty) continue;
+
+                if (string.IsNullOrEmpty(scene.path))
+                {
+                    McpLog.Warn(
+                        $"[MCP Build] Skipping unsaved scene '{scene.name}': it has never been saved, " +
+                        "so saving it would open a modal file dialog. Save it manually, or the build " +
+                        "will use the last saved state of the build-settings scenes.");
+                    continue;
+                }
+
+                try
+                {
+                    EditorSceneManager.SaveScene(scene);
+                }
+                catch (Exception ex)
+                {
+                    McpLog.Warn($"[MCP Build] Failed to save dirty scene '{scene.name}': {ex.Message}");
+                }
             }
         }
     }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildSaveBeforeBuildTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildSaveBeforeBuildTests.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+using MCPForUnity.Editor.Tools.Build;
+
+namespace MCPForUnityTests.Editor.Tools
+{
+    /// <summary>
+    /// SaveBeforeBuild originally called EditorSceneManager.SaveOpenScenes() unconditionally.
+    /// A scene that has never been saved carries an empty path, and handing one to Unity's save
+    /// API opens the modal "Save Scene" file panel — the exact block manage_build exists to
+    /// avoid (issue #1341). These tests pin the guard so the modal cannot come back.
+    /// </summary>
+    [TestFixture]
+    public class BuildSaveBeforeBuildTests
+    {
+        [Test]
+        public void SaveBeforeBuild_LeavesUntitledSceneUnsaved()
+        {
+            // In batchmode the active scene is already untitled; in the interactive Test Runner
+            // it usually is not, so fall back to an additive scratch scene there.
+            Scene target = SceneManager.GetActiveScene();
+            bool createdAdditive = false;
+            if (!string.IsNullOrEmpty(target.path))
+            {
+                target = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
+                createdAdditive = true;
+            }
+
+            try
+            {
+                Assert.IsTrue(string.IsNullOrEmpty(target.path),
+                    "sanity: the target scene must have never been saved");
+
+                EditorSceneManager.MarkSceneDirty(target);
+                Assert.IsTrue(target.isDirty, "sanity: scene must be dirty to reach the save path");
+
+                // Before the guard this reached SaveOpenScenes(), which opens a modal file panel
+                // for a pathless scene.
+                Assert.DoesNotThrow(() => BuildRunner.SaveBeforeBuild());
+
+                // The sharp assertion: the scene was skipped, not saved. A saved scene would have
+                // been given a path and would no longer be dirty.
+                Assert.IsTrue(string.IsNullOrEmpty(target.path),
+                    "an untitled scene must not be written anywhere");
+                Assert.IsTrue(target.isDirty,
+                    "an untitled scene must be left dirty — saving it is what opens the modal");
+            }
+            finally
+            {
+                if (createdAdditive)
+                {
+                    EditorSceneManager.CloseScene(target, removeScene: true);
+                }
+            }
+        }
+
+        [Test]
+        public void SaveBeforeBuild_WithNoDirtyScenes_IsANoOp()
+        {
+            Assert.DoesNotThrow(() => BuildRunner.SaveBeforeBuild());
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildSaveBeforeBuildTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BuildSaveBeforeBuildTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f56897cde3284e85a0697ae3ea90eeb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Follow-up to #1340, which landed in `beta` at 498acd1e.

#1340 added `SaveBeforeBuild()` so `manage_build` would stop blocking on Unity's unsaved-scene dialog (#1341). The intent is right, but it calls `EditorSceneManager.SaveOpenScenes()` unconditionally:

```csharp
AssetDatabase.SaveAssets();
if (!EditorSceneManager.SaveOpenScenes())
{
    McpLog.Warn("[MCP Build] Some modified scenes could not be saved (new scenes need a path). "
              + "Build may still prompt to save.");
}
```

**A scene that has never been saved carries an empty path, and handing one to Unity's save API opens the modal "Save Scene" file panel** — the exact block this change exists to prevent. The warning cannot help: it runs *after* `SaveOpenScenes()` returns, which is after the modal has already stalled the main thread.

### Why this is reachable

An untitled scene is routine in agent-driven workflows — `EditorSceneManager.NewScene` via `execute_code`, or a plain Ctrl+N — and the next instruction is often "build it".

### The repo already solved this twice

`TestRunnerService.SaveDirtyScenes` hit the same problem and guards it:

```csharp
if (string.IsNullOrEmpty(scene.path))
{
    McpLog.Warn($"[TestRunnerService] Skipping unsaved scene '{scene.name}': save it manually before running tests.");
    continue;
}
```

`ManageScene.cs:492` refuses the same case: *"Cannot save an untitled scene without providing a 'name' and 'path'."*

This change makes `BuildRunner` consistent with both: save dirty scenes individually, skip pathless ones with a warning that names the scene, and keep a per-scene try/catch so one failure does not abort the rest.

### Testing

- New EditMode tests in `BuildSaveBeforeBuildTests.cs`. The sharp assertion is that an untitled scene is left **dirty and path-less** after `SaveBeforeBuild()` — a saved scene would have neither, so this fails if the unconditional save ever comes back.
- Unity 6000.4.11f1: 2/2 passed.
- Unity 2021.3.45f2 (package floor): compile check passed.

`SaveBeforeBuild` changed from `private` to `internal` so the test assembly can call it directly; `MCPForUnity.Editor` already has `InternalsVisibleTo("MCPForUnityTests.EditMode")`.

cc @TeapoyY — thanks for the original fix, this only adds the pathless guard on top of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build preparation now saves each dirty open scene individually.
  * Unsaved scenes are skipped to prevent unexpected save dialogs.
  * Scene save failures are logged without interrupting the build process.

* **Tests**
  * Added coverage for unsaved dirty scenes and builds with no dirty scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->