### PR TITLE
perf: discover tools and resources via TypeCache instead of scanning every assembly

### DIFF
--- a/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
+++ b/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
@@ -23,28 +23,35 @@ namespace MCPForUnity.Editor.Services
 
             _cachedTools = new Dictionary<string, ToolMetadata>();
 
-            // Primary scan via TypeCache (fast, but can miss project assemblies in some domain-reload states)
-            var toolTypes = TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>();
+            // Primary scan via TypeCache: answers from Unity's prebuilt attribute index instead of
+            // walking every type of every loaded assembly, which the exhaustive scan below did on
+            // every call regardless of what the index already found (issue #1336).
+            TypeCache.TypeCollection toolTypes = TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>();
 
-            // Fallback scan via AppDomain (slower but exhaustive; mirrors CommandRegistry behaviour)
-            var appDomainTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(a => !a.IsDynamic)
-                .SelectMany(a =>
-                {
-                    try { return a.GetTypes(); }
-                    catch (Exception ex)
+            List<Type> allToolTypes;
+            if (toolTypes.Count > 0)
+            {
+                allToolTypes = toolTypes.ToList();
+            }
+            else
+            {
+                // Fallback scan via AppDomain (slower but exhaustive), reached only when the index
+                // is not usable for this domain yet; mirrors CommandRegistry behaviour.
+                allToolTypes = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => !a.IsDynamic)
+                    .SelectMany(a =>
                     {
-                        McpLog.Warn($"Failed to reflect types from assembly {a.FullName}: {ex.Message}");
-                        return new Type[0];
-                    }
-                })
-                .Where(t => t.GetCustomAttribute<McpForUnityToolAttribute>() != null);
-
-            // Merge both scans, deduplicating by type
-            var allToolTypes = toolTypes
-                .Concat(appDomainTypes)
-                .Distinct()
-                .ToList();
+                        try { return a.GetTypes(); }
+                        catch (Exception ex)
+                        {
+                            McpLog.Warn($"Failed to reflect types from assembly {a.FullName}: {ex.Message}");
+                            return new Type[0];
+                        }
+                    })
+                    .Where(t => t.GetCustomAttribute<McpForUnityToolAttribute>() != null)
+                    .Distinct()
+                    .ToList();
+            }
 
             foreach (var type in allToolTypes)
             {

--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -89,9 +89,15 @@ namespace MCPForUnity.Editor.Tools
                     resourceTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityResourceAttribute>(t));
                 }
 
+                // Ordered by FullName because RegisterCommandType lets a duplicate command
+                // name overwrite the previously registered handler, so registration order
+                // decides which type wins a collision. Neither TypeCache nor the fallback
+                // documents an order, so without sorting a name collision could resolve
+                // differently between domain reloads.
+
                 // Discover tools
                 int toolCount = 0;
-                foreach (var type in toolTypes)
+                foreach (var type in toolTypes.OrderBy(t => t.FullName, StringComparer.Ordinal))
                 {
                     if (RegisterCommandType(type, isResource: false))
                         toolCount++;
@@ -99,7 +105,7 @@ namespace MCPForUnity.Editor.Tools
 
                 // Discover resources
                 int resourceCount = 0;
-                foreach (var type in resourceTypes)
+                foreach (var type in resourceTypes.OrderBy(t => t.FullName, StringComparer.Ordinal))
                 {
                     if (RegisterCommandType(type, isResource: true))
                         resourceCount++;

--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -71,31 +71,35 @@ namespace MCPForUnity.Editor.Tools
 
             try
             {
-                // TypeCache is Unity's precomputed attribute index, rebuilt once per domain
-                // reload. The previous scan materialised every type in every loaded assembly
-                // and then called GetCustomAttribute on each one twice, which measured at
-                // ~9s per reload on large projects (issue #1336) — work Unity had already
-                // done. McpClientRegistry.BuildRegistry() sets the in-tree precedent.
-                //
-                // It also removes the GetCustomAttribute calls that made the AssetImportWorker
-                // crash in issue #1134; the worker guard above stays regardless, since the
-                // registry is unused there either way.
-                // Ordered by FullName because RegisterCommandType lets a duplicate command
-                // name overwrite the previous handler, so registration order decides which
-                // one wins. TypeCache does not document an order, and the assembly scan this
-                // replaces was stable within a build, so without sorting a name collision
-                // could resolve differently between domain reloads.
+                // TypeCache answers from Unity's prebuilt attribute index instead of walking
+                // every type of every loaded assembly, which cost seconds of every domain
+                // reload in large projects (issue #1336).
+                TypeCache.TypeCollection cachedTools = TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>();
+                TypeCache.TypeCollection cachedResources = TypeCache.GetTypesWithAttribute<McpForUnityResourceAttribute>();
+
+                IEnumerable<Type> toolTypes = cachedTools;
+                IEnumerable<Type> resourceTypes = cachedResources;
+
+                // The index can come back empty before it is populated for this domain, so the
+                // exhaustive scan stays available as a safety net rather than the default path.
+                if (ShouldFallBackToExhaustiveScan(cachedTools.Count, cachedResources.Count))
+                {
+                    List<Type> allTypes = GetAllLoadedTypes();
+                    toolTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityToolAttribute>(t));
+                    resourceTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityResourceAttribute>(t));
+                }
+
+                // Discover tools
                 int toolCount = 0;
-                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>()
-                             .OrderBy(t => t.FullName, StringComparer.Ordinal))
+                foreach (var type in toolTypes)
                 {
                     if (RegisterCommandType(type, isResource: false))
                         toolCount++;
                 }
 
+                // Discover resources
                 int resourceCount = 0;
-                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityResourceAttribute>()
-                             .OrderBy(t => t.FullName, StringComparer.Ordinal))
+                foreach (var type in resourceTypes)
                 {
                     if (RegisterCommandType(type, isResource: true))
                         resourceCount++;
@@ -106,6 +110,44 @@ namespace MCPForUnity.Editor.Tools
             catch (Exception ex)
             {
                 McpLog.Error($"Failed to auto-discover MCP commands: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// True when Unity's TypeCache produced no tools and no resources at all, which means the
+        /// index is not usable for this domain yet. Any non-empty result is treated as authoritative,
+        /// so the exhaustive assembly walk is skipped on the normal path.
+        /// </summary>
+        internal static bool ShouldFallBackToExhaustiveScan(int cachedToolCount, int cachedResourceCount)
+            => cachedToolCount == 0 && cachedResourceCount == 0;
+
+        /// <summary>
+        /// Exhaustive fallback scan: every non-dynamic loaded assembly's types, tolerating
+        /// assemblies whose metadata cannot be reflected mid-reload.
+        /// </summary>
+        private static List<Type> GetAllLoadedTypes()
+        {
+            return UnityAssembliesCompat.GetLoadedAssemblies()
+                .Where(a => !a.IsDynamic)
+                .SelectMany(a =>
+                {
+                    try { return a.GetTypes(); }
+                    catch { return new Type[0]; }
+                })
+                .ToList();
+        }
+
+        private static bool HasAttributeSafe<T>(Type type) where T : Attribute
+        {
+            try
+            {
+                return type.GetCustomAttribute<T>() != null;
+            }
+            catch
+            {
+                // Type metadata can be in a half-loaded state during domain reload; treat
+                // those as "no attribute" rather than aborting the whole scan.
+                return false;
             }
         }
 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/CommandRegistryTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/CommandRegistryTests.cs
@@ -24,6 +24,23 @@ namespace MCPForUnityTests.Editor.Tools
             }, "Should throw InvalidOperationException for unknown handler");
         }
 
+        /// <summary>
+        /// The exhaustive assembly walk is a fallback, not the default path: it must be reached
+        /// only when TypeCache produced nothing at all for this domain (issue #1336).
+        /// </summary>
+        [Test]
+        public void ShouldFallBackToExhaustiveScan_OnlyWhenTypeCacheFoundNothing()
+        {
+            Assert.IsTrue(CommandRegistry.ShouldFallBackToExhaustiveScan(0, 0),
+                "an empty index means TypeCache is unusable for this domain");
+            Assert.IsFalse(CommandRegistry.ShouldFallBackToExhaustiveScan(12, 3),
+                "a populated index must not trigger the slow scan");
+            Assert.IsFalse(CommandRegistry.ShouldFallBackToExhaustiveScan(12, 0),
+                "tools found means the index works, even with no resources");
+            Assert.IsFalse(CommandRegistry.ShouldFallBackToExhaustiveScan(0, 3),
+                "resources found means the index works, even with no tools");
+        }
+
         [Test]
         public void AutoDiscovery_RegistersAllBuiltInTools()
         {


### PR DESCRIPTION
## Description

`CommandRegistry.AutoDiscoverCommands` walks every type of every loaded assembly and then runs two full attribute-matching passes over that list, once per domain reload. `ToolDiscoveryService.DiscoverAllTools` is worse: it queries `TypeCache` first and then runs the same exhaustive `AppDomain` walk anyway — unconditionally, merging and de-duplicating the two results — so the fast path never actually saved anything.

`ResourceDiscoveryService` already trusts `TypeCache` alone, so this brings the other two in line with it.

Measured in this repo's own `TestProjects/UnityMCPTests` on Unity 2022.3.62f1 — 193 non-dynamic assemblies, 44,195 types, averaged over 5 runs after warm-up:

| Path | Time | Types found |
|---|---|---|
| `TypeCache` | 0.01 ms | 54 |
| Exhaustive assembly walk | 310.63 ms | 54 |

Both find **exactly the same 54 types**, which is the important part: this is a pure cost reduction, not a change in what gets discovered. That is 310 ms per domain reload in a near-empty project; the multi-second figure in #1336 comes from real projects carrying far more assemblies.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- `CommandRegistry.AutoDiscoverCommands` reads tools and resources from `TypeCache`. The old assembly walk moves into a `GetAllLoadedTypes()` helper, reached only when the index returns nothing at all for this domain.
- `ToolDiscoveryService.DiscoverAllTools` runs the `AppDomain` scan only when `TypeCache` came back empty, instead of always running it and merging.
- New `CommandRegistry.ShouldFallBackToExhaustiveScan(int, int)` pure predicate expressing that rule, following the existing `ShouldAbandonBusyPort` / `ShouldKeepWaitingForReady` pattern, plus an EditMode test covering all four combinations.
- The AssetImportWorker guard from #1134 is untouched and still short-circuits before any scanning.

**The one behavioural trade-off worth your call:** the old code always merged the exhaustive scan in, so a type that `TypeCache` somehow missed while other types resolved would still have been found. Now a non-empty index is treated as authoritative. I chose this because it keeps a safety net for the "index not ready" case the original comments describe while removing the cost from the normal path — but if you would rather always merge, or gate the fallback differently (say, per-attribute rather than on the combined count), that is a small change to `ShouldFallBackToExhaustiveScan` and its call site.

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f1 (full EditMode suite + benchmark)
- Package source used: `file:` (local clone, branch `perf/typecache-command-discovery` off `beta`)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (file reference)

`TypeCache` is `UnityEditor` API available well below this package's 2021.3 floor, so no version gating is needed.

## Testing/Screenshots/Recordings
- [ ] Python tests — not applicable, no Python-side changes
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests — not applicable, editor-only services
- [x] Package import/compile check

Full EditMode suite on 2022.3.62f1: **1121 passed, 0 failed** (66 pre-existing ignores). The existing `CommandRegistryTests.AutoDiscovery_RegistersAllBuiltInTools` and `ToolDiscoveryServiceTests` are the real regression guard here — they assert the built-in tools still resolve, and they pass unchanged.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources — no tool or resource surface changed

## Related Issues

Closes #1336

## Additional Notes

The benchmark above came from a throwaway test I did not commit; it timed both strategies in the same editor session and asserted their results matched. Happy to add it as a permanent `[Explicit]` test if that is useful to you, though wall-clock assertions in CI tend to be flaky, which is why I left it out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved tool, command, and resource discovery speed in the Unity Editor by prioritizing indexed discovery results.
  * Reduced unnecessary scanning of loaded assemblies during setup and refresh operations.
* **Reliability**
  * Added a fallback scan when indexed discovery finds no tools or resources.
  * Improved handling of assemblies that cannot be inspected, helping discovery complete more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->