### PR TITLE
fix: reference the Roslyn assemblies from MCPForUnity.Editor.asmdef

### DIFF
--- a/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
+++ b/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
@@ -10,7 +10,12 @@
     "excludePlatforms": [],
     "overrideReferences": true,
     "precompiledReferences": [
-        "Newtonsoft.Json.dll"
+        "Newtonsoft.Json.dll",
+        "Microsoft.CodeAnalysis.dll",
+        "Microsoft.CodeAnalysis.CSharp.dll",
+        "System.Collections.Immutable.dll",
+        "System.Reflection.Metadata.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll"
     ],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Setup.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Setup.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed99e0d6a139b40f8b6003ee96468772
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Setup/RoslynAsmdefReferenceTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Setup/RoslynAsmdefReferenceTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor.Compilation;
+using MCPForUnity.Editor.Setup;
+
+namespace MCPForUnityTests.Editor.Setup
+{
+    /// <summary>
+    /// MCPForUnity.Editor sets overrideReferences, so it only sees precompiled assemblies it
+    /// names explicitly. RoslynInstaller drops its DLLs into the consuming project's
+    /// Assets/Plugins/Roslyn, which is outside the package — if those names are missing from
+    /// the asmdef, defining USE_ROSLYN breaks the build for UPM installs (issue #1295).
+    /// </summary>
+    public class RoslynAsmdefReferenceTests
+    {
+        [Test]
+        public void EditorAsmdef_ReferencesEveryDllRoslynInstallerInstalls()
+        {
+            List<string> installedDlls = GetInstallerDllNames();
+            CollectionAssert.IsNotEmpty(installedDlls, "RoslynInstaller should declare at least one DLL");
+
+            string asmdefJson = ReadEditorAsmdefJson();
+
+            List<string> missing = new List<string>();
+            foreach (string dll in installedDlls)
+            {
+                if (asmdefJson.IndexOf($"\"{dll}\"", StringComparison.Ordinal) < 0)
+                {
+                    missing.Add(dll);
+                }
+            }
+
+            CollectionAssert.IsEmpty(missing,
+                "MCPForUnity.Editor.asmdef must list every DLL RoslynInstaller installs in "
+                + "precompiledReferences, otherwise USE_ROSLYN cannot compile against them. Missing: "
+                + string.Join(", ", missing));
+        }
+
+        private static List<string> GetInstallerDllNames()
+        {
+            FieldInfo field = typeof(RoslynInstaller).GetField(
+                "NuGetEntries", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(field, "RoslynInstaller.NuGetEntries not found — was it renamed?");
+
+            List<string> names = new List<string>();
+            foreach (object entry in (Array)field.GetValue(null))
+            {
+                // Tuple field: (packageId, version, dllPath, dllName)
+                FieldInfo dllName = entry.GetType().GetField("Item4");
+                Assert.IsNotNull(dllName, "NuGetEntries tuple shape changed — expected Item4 to be the DLL name");
+                names.Add((string)dllName.GetValue(entry));
+            }
+            return names;
+        }
+
+        private static string ReadEditorAsmdefJson()
+        {
+            string path = CompilationPipeline.GetAssemblyDefinitionFilePathFromAssemblyName("MCPForUnity.Editor");
+            Assert.IsFalse(string.IsNullOrEmpty(path), "Could not locate MCPForUnity.Editor.asmdef");
+            Assert.IsTrue(File.Exists(path), $"asmdef path does not exist: {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Setup/RoslynAsmdefReferenceTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Setup/RoslynAsmdefReferenceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9a2fe364845a4839be3858dae64bf32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description

`MCPForUnity.Editor.asmdef` sets `"overrideReferences": true`, which means the assembly only sees precompiled assemblies it names explicitly — and `precompiledReferences` listed just `Newtonsoft.Json.dll`. `RoslynInstaller` writes its DLLs to `Application.dataPath/Plugins/Roslyn`, i.e. the *consuming project's* `Assets/Plugins/Roslyn`, which is outside the package. So the moment a user follows the Roslyn guide and defines `USE_ROSLYN`, the `using Microsoft.CodeAnalysis;` directives in `ManageScript.cs` cannot resolve and the build breaks. Embedded installs happened to work; UPM installs could not.

Worth noting `ExecuteCode.cs` already dodges this by reaching Roslyn through `Type.GetType(...)` reflection instead of compile-time `using` directives — `ManageScript.cs` was simply never given the same treatment.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- `MCPForUnity/Editor/MCPForUnity.Editor.asmdef`: added the five DLL names `RoslynInstaller` installs to `precompiledReferences`.
- New `RoslynAsmdefReferenceTests`: asserts the asmdef references every DLL the installer writes. It reads that list **off `RoslynInstaller.NuGetEntries` by reflection** rather than duplicating it, so if someone adds or renames a Roslyn dependency the test fails instead of silently drifting.

I wrote the test first and confirmed it fails on `beta` before the asmdef change, naming all five missing assemblies:

```
MCPForUnity.Editor.asmdef must list every DLL RoslynInstaller installs in precompiledReferences,
otherwise USE_ROSLYN cannot compile against them. Missing: Microsoft.CodeAnalysis.dll,
Microsoft.CodeAnalysis.CSharp.dll, System.Collections.Immutable.dll,
System.Reflection.Metadata.dll, System.Runtime.CompilerServices.Unsafe.dll
```

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f1
- Package source used: `file:` (local clone, branch `fix/roslyn-upm-asmdef-references` off `beta`)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (file reference)

## Testing/Screenshots/Recordings
- [ ] Python tests — not applicable, no Python-side changes
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests — not applicable
- [x] Package import/compile check

Full EditMode suite on 2022.3.62f1: **1120 passed, 0 failed** (66 pre-existing ignores), with **zero compile errors**.

That last point is the one I most wanted to verify rather than assume: `TestProjects/UnityMCPTests` has **none** of these Roslyn DLLs present, and the project still compiles cleanly with them listed. So Unity does ignore a `precompiledReferences` entry whose assembly is absent, and this change is a no-op for the majority of projects that never install Roslyn.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources — no tool or resource surface changed

`website/docs/guides/roslyn.md` still describes the correct user-facing flow, so no doc change was needed.

## Related Issues

Closes #1295

## Additional Notes

What I could **not** verify locally is the positive case end to end: a UPM install with the DLLs actually present in `Assets/Plugins/Roslyn` and `USE_ROSLYN` defined, compiling successfully. I verified the mechanism (absent entries are ignored; the names now match what the installer writes) but if one of you has a project already set up that way, a confirmation would be worth having before merge.

The alternative fix would be converting `ManageScript.cs`'s six `#if USE_ROSLYN` blocks to reflection, mirroring `ExecuteCode.cs`. That removes the asmdef question entirely but is a much larger and riskier change, so I went with the small one — happy to take the other route if you'd prefer it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor compatibility by ensuring required Roslyn compiler libraries are available.
  * Prevented package builds from failing when Roslyn support is enabled.

* **Tests**
  * Added automated coverage to verify all required Roslyn libraries are correctly referenced and remain available during Unity package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->