### PR TITLE
docs: troubleshooting entries for the Unity 6.5 editor hang and Codex resource reads

### DIFF
--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -146,6 +146,30 @@ Unity AI Assistant bundles `System.Collections.Immutable` v10, while MCP for Uni
 
 ---
 
+## Editor hangs on load and the bridge never connects (Unity 6.5 + AI packages)
+
+If the Editor never finishes loading on **Unity 6000.5.x**, MCP for Unity can look like the culprit — the bridge never arms because the Editor never gets that far.
+
+*Reported by [@100yenadmin](https://github.com/CoplayDev/unity-mcp/issues/1219).*
+
+**Symptoms:**
+- The Editor launches, gets through licensing and package registration, then spins at ~100% CPU on the main thread forever
+- No Editor window ever appears, and the MCP for Unity bridge never connects
+- Happens on every launch method — Unity Hub, CLI, and `-batchmode`
+- A native stack of the spinning thread sits inside `AssetDatabase::InitialRefresh`
+
+**Cause:**
+Unity's own pre-release `com.unity.ai.assistant` package (with its `com.unity.ai.inference` and `com.unity.asset-manager-for-unity` dependencies) can livelock the AssetDatabase during the initial import. This is a Unity bug, tracked as **UUM-132096** — not an MCP for Unity issue.
+
+**Fix:**
+1. Remove `com.unity.ai.assistant`, `com.unity.ai.inference`, and `com.unity.asset-manager-for-unity` from `Packages/manifest.json`.
+2. Delete `Packages/packages-lock.json`. This step is essential — the lock file re-resolves the packages even after the manifest edit, which makes the problem look intermittent.
+3. Delete the `Library/` folder so the project reimports cleanly.
+
+**Note:** Disabling the package is not enough; the AI packages form an interlocking dependency chain that re-adds itself. See also the [DLL reference mismatch](#dll-reference-mismatch-with-unity-ai-assistant-package) section above, which covers a different problem caused by the same package.
+
+---
+
 ## "No Unity Instances Found"
 
 :::tip When in doubt, restart your client
@@ -181,3 +205,14 @@ A: Start a new chat — the bad chat didn't pick up the MCP server configuration
 
 **Q: My MCP client keeps failing to launch the server even though `uv` is installed.**
 A: Some Windows machines have multiple `uv.exe` locations. Auto-config sometimes picks a less stable path, causing the launch to fail or auto-rewrite on every restart. Use **"Choose UV Install Location"** in the MCP for Unity window and pin the **WinGet Links shim** path (`%LOCALAPPDATA%\Microsoft\WinGet\Links\uv.exe`) — it's stable across uv upgrades.
+
+## FAQ — Codex
+
+**Q: Reading `mcpforunity://custom-tools` fails with `unknown MCP server 'mcp__unityMCP'`.**
+A: Codex exposes callable tools and readable resources under different names. Tools are namespaced `mcp__unityMCP.*`, but generic resource reads want the bare server key returned by resource discovery — usually `unityMCP`. Call `list_mcp_resources` first and pass the server key it returns verbatim:
+
+```text
+resources/read  server: "unityMCP"  uri: "mcpforunity://custom-tools"
+```
+
+The same applies to `mcpforunity://instances`. This naming split is a client-side convention, so check the discovery output rather than assuming the tool namespace also works for resources.

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -159,14 +159,14 @@ If the Editor never finishes loading on **Unity 6000.5.x**, MCP for Unity can lo
 - A native stack of the spinning thread sits inside `AssetDatabase::InitialRefresh`
 
 **Cause:**
-Unity's own pre-release `com.unity.ai.assistant` package (with its `com.unity.ai.inference` and `com.unity.asset-manager-for-unity` dependencies) can livelock the AssetDatabase during the initial import. This is a Unity bug, tracked as **UUM-132096** — not an MCP for Unity issue.
+Unity's own pre-release `com.unity.ai.assistant` package (with its `com.unity.ai.inference` and `com.unity.asset-manager-for-unity` dependencies) can livelock the AssetDatabase during the initial import. This is a Unity-side problem, not an MCP for Unity issue.
 
 **Fix:**
 1. Remove `com.unity.ai.assistant`, `com.unity.ai.inference`, and `com.unity.asset-manager-for-unity` from `Packages/manifest.json`.
 2. Delete `Packages/packages-lock.json`. This step is essential — the lock file re-resolves the packages even after the manifest edit, which makes the problem look intermittent.
 3. Delete the `Library/` folder so the project reimports cleanly.
 
-**Note:** Disabling the package is not enough; the AI packages form an interlocking dependency chain that re-adds itself. See also the [DLL reference mismatch](#dll-reference-mismatch-with-unity-ai-assistant-package) section above, which covers a different problem caused by the same package.
+**Note:** Disabling the package is not enough; the AI packages form an interlocking dependency chain that re-adds itself — behaviour tracked in Unity issue **UUM-132096**. See also the [DLL reference mismatch](#dll-reference-mismatch-with-unity-ai-assistant-package) section above, which covers a different problem caused by the same package.
 
 ---
 


### PR DESCRIPTION
## Description

Adds two troubleshooting entries for failure modes that get misattributed to MCP for Unity.

**Editor hangs on load (Unity 6.5)** — closes #1219. Unity's pre-release `com.unity.ai.assistant` package can livelock the AssetDatabase during initial import, so the Editor never opens and the bridge never arms. Users reasonably read "bridge never connects" as an MCP for Unity fault. The reporter did the diagnostic work already (native stack in `AssetDatabase::InitialRefresh`, Unity issue UUM-132096) and verified the fix end to end; this just writes it down. The non-obvious step is deleting `packages-lock.json` — editing the manifest alone silently re-resolves the package, which is what made it look intermittent.

**Codex resource reads** — closes #1220. Codex exposes callable tools as `mcp__unityMCP.*` but generic resource reads want the bare server key from discovery (`unityMCP`), so agents following our instructions guess `server: "mcp__unityMCP"` and get `unknown MCP server`. Added as a `## FAQ — Codex` entry alongside the existing per-client FAQ sections.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made

- `website/docs/guides/troubleshooting.md`: new "Editor hangs on load and the bridge never connects (Unity 6.5 + AI packages)" section, placed next to the existing Unity AI Assistant DLL section since it is the same offending package, and cross-linked to it.
- `website/docs/guides/troubleshooting.md`: new "FAQ — Codex" section following the existing FAQ layout.

Both sections follow the file's existing Symptoms / Cause / Fix structure and credit the reporters the same way the `@rkroska` section does.

## Compatibility / Package Source
- Unity version(s) tested: n/a — documentation only, no code paths touched
- Package source used: n/a
- Resolved commit hash from `Packages/packages-lock.json`: n/a

## Testing/Screenshots/Recordings
- [ ] Python tests
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [ ] Package import/compile check
- [x] Not applicable (explain why in Additional Notes)

## Documentation Updates
- [ ] I have added/removed/modified tools or resources

No tool or resource surface changed, so the auto-generated reference under `website/docs/reference/` is untouched — this is hand-written narrative documentation only.

## Related Issues

Closes #1219
Closes #1220

## Additional Notes

Documentation-only; no code paths are affected, so there is nothing for the test suites to exercise. Happy to reword or relocate either section — #1220 in particular could equally live in the reference docs rather than the FAQ if you'd prefer it there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for Unity 6.5 Editor hangs related to Unity AI packages, including symptoms and reference to issue UUM-132096.
  * Documented cleanup steps involving packages, lockfiles, and the Library folder.
  * Added a Codex FAQ clarifying the distinction between MCP tool namespaces and resource server keys when accessing Unity MCP resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->