### PR TITLE
fix: suppress broker command resends instead of running the work twice

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -27,6 +27,12 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         public TaskCompletionSource<string> Tcs;
         public bool IsExecuting;
         public long EnqueuedAtMs;
+
+        /// <summary>
+        /// Connection that queued this command, used to tell a broker resend apart from a
+        /// genuinely new request. Never dereferenced — identity only.
+        /// </summary>
+        public object Owner;
     }
 
     [InitializeOnLoad]
@@ -262,6 +268,36 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         // Routed through EditorStateCache so a deferred domain reload (issue #1276) does not
         // pin the bridge off: raw EditorApplication.isCompiling stays true for as long as the
         // reload is held, and this gates bridge startup.
+        /// <summary>
+        /// True when an already-queued command is the same payload arriving from a different
+        /// connection — the signature of a broker that reconnected and resent. Payload equality
+        /// alone is not enough: a single connection handles one command at a time, so two
+        /// identical payloads on the same connection are sequential and genuinely distinct.
+        /// </summary>
+        internal static bool IsBrokerResend(
+            string queuedCommandJson, object queuedOwner, string incomingCommandJson, object incomingOwner)
+        {
+            if (queuedOwner == null || incomingOwner == null) return false;
+            if (ReferenceEquals(queuedOwner, incomingOwner)) return false;
+            return string.Equals(queuedCommandJson, incomingCommandJson, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Finds an in-flight command that <paramref name="incomingOwner"/> is resending.
+        /// Callers must hold <see cref="lockObj"/>.
+        /// </summary>
+        private static QueuedCommand FindBrokerResendTarget(string commandText, object incomingOwner)
+        {
+            foreach (var kvp in commandQueue)
+            {
+                if (IsBrokerResend(kvp.Value.CommandJson, kvp.Value.Owner, commandText, incomingOwner))
+                {
+                    return kvp.Value;
+                }
+            }
+            return null;
+        }
+
         private static bool IsCompiling() => EditorStateCache.GetActualIsCompiling();
 
         public static void Start()
@@ -600,15 +636,31 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                                 continue;
                             }
 
+                            // A command already in flight from a different connection means the
+                            // broker gave up waiting, reconnected and resent it. Running it a
+                            // second time would duplicate side effects (issue #1130), so attach
+                            // to the original instead of queueing a copy.
+                            TaskCompletionSource<string> pending = tcs;
                             lock (lockObj)
                             {
-                                commandQueue[commandId] = new QueuedCommand
+                                QueuedCommand inFlight = FindBrokerResendTarget(commandText, client);
+                                if (inFlight != null)
                                 {
-                                    CommandJson = commandText,
-                                    Tcs = tcs,
-                                    IsExecuting = false,
-                                    EnqueuedAtMs = _uptime.ElapsedMilliseconds
-                                };
+                                    pending = inFlight.Tcs;
+                                    McpLog.Warn("Suppressed duplicate command resent on a new connection; "
+                                                + "awaiting the in-flight result instead of running it twice.");
+                                }
+                                else
+                                {
+                                    commandQueue[commandId] = new QueuedCommand
+                                    {
+                                        CommandJson = commandText,
+                                        Tcs = tcs,
+                                        IsExecuting = false,
+                                        EnqueuedAtMs = _uptime.ElapsedMilliseconds,
+                                        Owner = client
+                                    };
+                                }
                             }
 
                             // Force Unity's main loop to iterate even when backgrounded,
@@ -620,11 +672,11 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                             try
                             {
                                 using var respCts = new CancellationTokenSource(FrameIOTimeoutMs);
-                                var completed = await Task.WhenAny(tcs.Task, Task.Delay(FrameIOTimeoutMs, respCts.Token)).ConfigureAwait(false);
-                                if (completed == tcs.Task)
+                                var completed = await Task.WhenAny(pending.Task, Task.Delay(FrameIOTimeoutMs, respCts.Token)).ConfigureAwait(false);
+                                if (completed == pending.Task)
                                 {
                                     respCts.Cancel();
-                                    response = tcs.Task.Result;
+                                    response = pending.Task.Result;
                                     Interlocked.Exchange(ref _consecutiveTimeouts, 0);
                                 }
                                 else

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -269,6 +269,16 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         // pin the bridge off: raw EditorApplication.isCompiling stays true for as long as the
         // reload is held, and this gates bridge startup.
         /// <summary>
+        /// Number of commands currently queued, read under the queue lock. Diagnostics only —
+        /// callers must not reason about individual entries, since the queue mutates from both
+        /// the listener tasks and the editor update loop.
+        /// </summary>
+        internal static int QueuedCommandCount
+        {
+            get { lock (lockObj) { return commandQueue.Count; } }
+        }
+
+        /// <summary>
         /// True when an already-queued command is the same payload arriving from a different
         /// connection — the signature of a broker that reconnected and resent. Payload equality
         /// alone is not enough: a single connection handles one command at a time, so two

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBrokerResendTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBrokerResendTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.IO;
-using System.Reflection;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -91,13 +90,13 @@ namespace MCPForUnityTests.Editor.Services
                 // has to happen before the second connect: a new connection closes stale clients,
                 // and if it wins that race the first frame is never read at all.
                 Thread.Sleep(1500);
-                queuedAfterFirst = ReadQueueDepth();
+                queuedAfterFirst = StdioBridgeHost.QueuedCommandCount;
 
                 // A second connection is what the broker opens after giving up on the first.
                 second = Connect(port);
                 SendFrame(second.GetStream(), command);
                 Thread.Sleep(1500);
-                queuedAfterResend = ReadQueueDepth();
+                queuedAfterResend = StdioBridgeHost.QueuedCommandCount;
             }
             finally
             {
@@ -115,20 +114,6 @@ namespace MCPForUnityTests.Editor.Services
             Assert.AreEqual(1, queuedAfterResend,
                 $"the resend should have attached to the in-flight command, but {queuedAfterResend} "
                 + "entries were queued — the command would run that many times");
-        }
-
-        /// <summary>
-        /// Reads StdioBridgeHost's private command queue by reflection, so this test compiles and
-        /// runs against builds both with and without the suppression fix.
-        /// </summary>
-        private static int ReadQueueDepth()
-        {
-            FieldInfo field = typeof(StdioBridgeHost).GetField(
-                "commandQueue", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.IsNotNull(field, "StdioBridgeHost.commandQueue not found — was it renamed?");
-            var queue = field.GetValue(null) as ICollection;
-            Assert.IsNotNull(queue, "commandQueue is not a collection");
-            return queue.Count;
         }
 
         private static TcpClient Connect(int port)

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBrokerResendTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBrokerResendTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using NUnit.Framework;
+
+using UnityEngine.TestTools;
+using MCPForUnity.Editor.Services.Transport.Transports;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    /// <summary>
+    /// When a long-running command outlives the broker's patience, the Python side reconnects and
+    /// resends it. The bridge used to queue that resend as a brand-new command behind the original,
+    /// so the work ran twice — visibly, for commands with side effects (issue #1130).
+    /// </summary>
+    [TestFixture]
+    public class StdioBrokerResendTests
+    {
+        private const int ConnectTimeoutMs = 5000;
+        private const int ReadTimeoutMs = 10000;
+
+        [Test]
+        public void IsBrokerResend_SamePayloadFromAnotherConnection_IsAResend()
+        {
+            object first = new object();
+            object second = new object();
+
+            Assert.IsTrue(StdioBridgeHost.IsBrokerResend("{\"type\":\"a\"}", first, "{\"type\":\"a\"}", second),
+                "same payload arriving on a different connection is the resend signature");
+        }
+
+        [Test]
+        public void IsBrokerResend_SameConnection_IsNotAResend()
+        {
+            object connection = new object();
+
+            Assert.IsFalse(StdioBridgeHost.IsBrokerResend("{\"type\":\"a\"}", connection, "{\"type\":\"a\"}", connection),
+                "one connection handles commands sequentially, so identical payloads are distinct requests");
+        }
+
+        [Test]
+        public void IsBrokerResend_DifferentPayload_IsNotAResend()
+        {
+            Assert.IsFalse(StdioBridgeHost.IsBrokerResend("{\"type\":\"a\"}", new object(), "{\"type\":\"b\"}", new object()),
+                "different work must never be collapsed");
+        }
+
+        [Test]
+        public void IsBrokerResend_UnknownOwner_IsNotAResend()
+        {
+            Assert.IsFalse(StdioBridgeHost.IsBrokerResend("{\"type\":\"a\"}", null, "{\"type\":\"a\"}", new object()),
+                "a command with no recorded owner cannot be proven to be a resend");
+            Assert.IsFalse(StdioBridgeHost.IsBrokerResend("{\"type\":\"a\"}", new object(), "{\"type\":\"a\"}", null),
+                "an incoming command with no owner cannot be proven to be a resend");
+        }
+
+        /// <summary>
+        /// The bridge must not queue a second copy of a command that is already in flight from
+        /// another connection. Asserted on the queue itself while the main thread is blocked, so
+        /// no command has been dispatched yet and the result does not depend on what the command
+        /// would have done. Requires the bridge (batchmode needs UNITY_MCP_ALLOW_BATCH).
+        /// </summary>
+        [UnityTest]
+        public IEnumerator IdenticalCommandResentOnNewConnection_IsQueuedOnce()
+        {
+            if (!StdioBridgeHost.IsRunning)
+            {
+                Assert.Ignore("StdioBridgeHost is not running; skipping broker-resend test.");
+                yield break;
+            }
+
+            int port = StdioBridgeHost.GetCurrentPort();
+            byte[] command = Encoding.UTF8.GetBytes(
+                "{\"type\":\"read_console\",\"params\":{\"action\":\"get\",\"count\":1}}");
+
+            TcpClient first = null;
+            TcpClient second = null;
+            int queuedAfterFirst;
+            int queuedAfterResend;
+            try
+            {
+                first = Connect(port);
+                SendFrame(first.GetStream(), command);
+
+                // Sleeping on the main thread lets the listener task read and queue the frame while
+                // ProcessCommands — an editor-update hook — cannot run and drain it. The wait also
+                // has to happen before the second connect: a new connection closes stale clients,
+                // and if it wins that race the first frame is never read at all.
+                Thread.Sleep(1500);
+                queuedAfterFirst = ReadQueueDepth();
+
+                // A second connection is what the broker opens after giving up on the first.
+                second = Connect(port);
+                SendFrame(second.GetStream(), command);
+                Thread.Sleep(1500);
+                queuedAfterResend = ReadQueueDepth();
+            }
+            finally
+            {
+                SafeClose(first);
+                SafeClose(second);
+            }
+
+            // Let the queue drain so we do not leak state into later tests.
+            for (int i = 0; i < 120; i++)
+                yield return null;
+
+            Assert.AreEqual(1, queuedAfterFirst,
+                "precondition: the first command must be sitting in the queue undrained — "
+                + $"found {queuedAfterFirst} entries, so this run proves nothing about the resend");
+            Assert.AreEqual(1, queuedAfterResend,
+                $"the resend should have attached to the in-flight command, but {queuedAfterResend} "
+                + "entries were queued — the command would run that many times");
+        }
+
+        /// <summary>
+        /// Reads StdioBridgeHost's private command queue by reflection, so this test compiles and
+        /// runs against builds both with and without the suppression fix.
+        /// </summary>
+        private static int ReadQueueDepth()
+        {
+            FieldInfo field = typeof(StdioBridgeHost).GetField(
+                "commandQueue", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(field, "StdioBridgeHost.commandQueue not found — was it renamed?");
+            var queue = field.GetValue(null) as ICollection;
+            Assert.IsNotNull(queue, "commandQueue is not a collection");
+            return queue.Count;
+        }
+
+        private static TcpClient Connect(int port)
+        {
+            var client = new TcpClient();
+            Assert.IsTrue(client.ConnectAsync("127.0.0.1", port).Wait(ConnectTimeoutMs), "connect timed out");
+            client.ReceiveTimeout = ReadTimeoutMs;
+            string handshake = ReadLine(client.GetStream(), ReadTimeoutMs);
+            Assert.That(handshake, Does.Contain("FRAMING=1"), "expected the framing handshake");
+            return client;
+        }
+
+        private static void SafeClose(TcpClient client)
+        {
+            if (client == null) return;
+            try
+            {
+                client.Client.LingerState = new LingerOption(true, 0);
+                client.Close();
+            }
+            catch { }
+        }
+
+        private static string ReadLine(NetworkStream stream, int timeoutMs)
+        {
+            stream.ReadTimeout = timeoutMs;
+            var sb = new StringBuilder();
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow <= deadline)
+            {
+                int b = stream.ReadByte();
+                if (b < 0) throw new IOException("Connection closed while reading handshake");
+                if (b == '\n') return sb.ToString();
+                sb.Append((char)b);
+            }
+            throw new TimeoutException("Timed out reading handshake line");
+        }
+
+        private static void SendFrame(NetworkStream stream, byte[] payload)
+        {
+            byte[] header = new byte[8];
+            ulong len = (ulong)payload.LongLength;
+            for (int i = 0; i < 8; i++)
+                header[i] = (byte)(len >> (56 - 8 * i));
+            stream.Write(header, 0, 8);
+            stream.Write(payload, 0, payload.Length);
+            stream.Flush();
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBrokerResendTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBrokerResendTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e01078ef9fbb449a0a1788974b41a61f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description

When a command outlives the broker's patience, `send_command_with_retry` on the Python side closes the socket, rediscovers the port, reconnects and resends the *same* payload. The bridge queued that resend as a brand-new `commandId` behind the still-executing original, so the work ran twice. For a read that is merely wasteful; for `execute_menu_item` or a build it duplicates real side effects, which is what #1130 reports.

The enqueue path now checks for an in-flight command with the same payload that was queued by a **different connection**, and attaches the new caller to that command's `TaskCompletionSource` instead of queueing a copy. The resent request still gets a real answer — the original's — it just doesn't cause the work to happen again.

Comparing the owning connection as well as the payload is what makes this safe. A single connection handles one command at a time (the read loop awaits each response before reading the next frame), so two identical payloads on one connection are necessarily sequential and genuinely distinct requests, and are never collapsed. Only a payload that reappears on a *second* connection while the first is still in flight matches — which is precisely the reconnect-and-resend signature, and stdio is single-agent by design (a new connection already closes stale ones).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- `QueuedCommand` gains an `Owner` field, held for identity comparison only and never dereferenced.
- New `StdioBridgeHost.IsBrokerResend(...)` pure predicate, following the existing `ShouldAbandonBusyPort` / `ShouldKeepWaitingForReady` pattern, plus `FindBrokerResendTarget` which applies it across the queue under `lockObj`.
- The enqueue block attaches to the in-flight command's completion source when a resend is detected, and logs a warning when it does so.

## Known limitation

This narrows the window rather than closing it completely, and it is worth being explicit about where it stops.

Suppression only applies while the original command is still in `commandQueue`. If the original finishes in the gap between the broker's new connection closing the stale socket and the resend arriving, `ExecuteQueuedCommand` has already removed the entry, so the resend queues and runs a second time — and the original's response has nowhere to go.

Closing that remaining window needs a stable request identifier that survives a reconnect, with the completed response retained under it until the broker collects it or a bounded expiry passes. The broker does not send such an identifier today, so that is a wire-protocol change across both `Server/src` and the bridge, which felt well outside this fix.

I deliberately did **not** approximate it by retaining completed responses keyed on payload text. Payload alone cannot distinguish a late resend from a genuinely new identical request, so that would risk answering a real request with a stale cached response. The in-flight + different-connection test used here cannot make that mistake: a single connection processes commands sequentially, so an overlapping identical payload can only come from a reconnect.

So this covers the reported case — a long-running command still executing when the broker gives up and resends — without introducing a false-positive risk. Happy to follow up with the request-identifier work if you want the protocol change.

## Testing/Screenshots/Recordings
- [ ] Python tests — not applicable, the fix is entirely Unity-side
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests — not applicable
- [x] Package import/compile check

Five new tests: four covering the predicate's branches, and one end-to-end regression test that drives real sockets against the live bridge.

I wrote the regression test first and confirmed it fails on `beta`:

```
the resend should have attached to the in-flight command, but 2 entries were queued
  — the command would run that many times
Expected: 1
But was:  2
```

and passes with the fix. Full EditMode suite on 2022.3.62f1 with `UNITY_MCP_ALLOW_BATCH=1`: **1126 passed, 0 failed** (64 pre-existing ignores).

Two notes on how that test is built, since both were dead ends first:

- It asserts on **queue depth**, read off `commandQueue` by reflection, rather than on a command's side effect. That keeps the assertion about the thing the fix changes, makes it deterministic, and lets the same test compile and run against builds with and without the fix.
- It sleeps on the main thread *before* opening the second connection. This matters: a new connection closes stale clients, and if that close wins the race the first frame is never read at all, leaving one queue entry and a test that passes for the wrong reason. There is an explicit precondition assertion guarding exactly that, so the test cannot silently stop testing anything.

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f1
- Package source used: `file:` (local clone, branch `fix/stdio-suppress-broker-resend` off `beta`)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (file reference)

## Documentation Updates
- [ ] I have added/removed/modified tools or resources — no tool or resource surface changed

## Related Issues

Closes #1130

## Additional Notes

The regression test only runs where the bridge is up, so like the neighbouring `StdioBridgeReconnectTests` it `Assert.Ignore`s otherwise — which means it is skipped by the standard editmode CI job, where batchmode does not arm the bridge without `UNITY_MCP_ALLOW_BATCH`. The four predicate tests run everywhere. If you would like the socket test to run in CI, setting `UNITY_MCP_ALLOW_BATCH=1` on the editmode job would also un-skip the existing reconnect tests, which are currently dormant there — happy to do that in a separate PR since it changes what CI covers.

The issue also proposes cancelling the command on timeout. I did not go that route: `ExecuteMenuItem`'s call is synchronous and non-cancellable, so cancellation could not stop work already running, and it would only prevent future duplicates — the same outcome as this change for considerably more surface area. The issue text also refers to a 30s frame timeout, which is now 5 minutes and configurable via `UNITY_MCP_STDIO_COMMAND_TIMEOUT_MS`; that raises the bar for reproduction but does not change the underlying defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate commands when the same request is resent through another connection.
  - Resent commands now share the original request’s result instead of being processed twice.
  - Added queue-count diagnostics to improve visibility into pending requests.

- **Tests**
  - Added coverage for resend detection, connection ownership, differing payloads, and duplicate queue prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->