### PR TITLE
ci: report Skipped instead of a green check when Unity tests cannot run

### DIFF
--- a/.github/workflows/e2e-bridge.yml
+++ b/.github/workflows/e2e-bridge.yml
@@ -28,9 +28,18 @@ env:
   UNITY_IMAGE: unityci/editor:ubuntu-2021.3.45f2-linux-il2cpp-3
 
 jobs:
-  e2e-bridge:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 40
+  license:
+    # Hoisted out of the smoke job so the gate is a JOB-level condition. A step-level `if:`
+    # produces step-conclusion `skipped`, which contributes nothing to the job conclusion,
+    # so this workflow reported a green check having booted no Editor and exercised no tool
+    # call. A job skipped by a job-level `if:` reports "Skipped" in the merge box instead.
+    # Branch protection treats a skipped required check as satisfied, so merges are not blocked.
+    name: Detect Unity license secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      unity_ok: ${{ steps.detect.outputs.unity_ok }}
     steps:
       - name: Detect Unity license secrets
         id: detect
@@ -46,30 +55,34 @@ jobs:
           else
             echo "unity_ok=false" >> "$GITHUB_OUTPUT"
             echo "::warning::E2E bridge smoke SKIPPED - no license secrets in scope (normal for fork PRs). This check is NOT a pass: nothing was booted or exercised."
-            # Every step below is gated on unity_ok, so the job reports a green check
-            # having run nothing at all. Say so plainly on the run page.
+            # The dependent job is gated on this output, so it reports Skipped rather
+            # than a green check. Still say plainly on the run page what did not happen.
             {
               echo "## :warning: E2E bridge smoke was SKIPPED"
               echo
               echo "No Unity license secrets were in scope, so **no Editor was booted and no tool call was exercised**."
-              echo "The green check means the job exited cleanly - **not** that the bridge works."
+              echo "The dependent job reports **Skipped** - it did not pass, it did not run."
               echo
               echo "GitHub withholds repository secrets from workflow runs triggered by a fork's pull request."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
+
+  e2e-bridge:
+    runs-on: ubuntu-24.04
+    needs: license
+    if: needs.license.outputs.unity_ok == 'true'
+    timeout-minutes: 40
+    steps:
       - uses: actions/checkout@v4
-        if: steps.detect.outputs.unity_ok == 'true'
         with:
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v4
-        if: steps.detect.outputs.unity_ok == 'true'
         with:
           python-version: "3.11"
 
       - name: Install MCP server
-        if: steps.detect.outputs.unity_ok == 'true'
         run: |
           set -eux
           uv venv
@@ -79,7 +92,6 @@ jobs:
 
       # --- License staging (mirrors claude-nl-suite.yml) ---
       - name: Decide license sources
-        if: steps.detect.outputs.unity_ok == 'true'
         id: lic
         shell: bash
         env:
@@ -96,7 +108,7 @@ jobs:
           echo "use_ebl=$use_ebl" >> "$GITHUB_OUTPUT"
 
       - name: Stage Unity .ulf license (from secret)
-        if: steps.detect.outputs.unity_ok == 'true' && steps.lic.outputs.use_ulf == 'true'
+        if: steps.lic.outputs.use_ulf == 'true'
         id: ulf
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -119,7 +131,7 @@ jobs:
           fi
 
       - name: Activate Unity (EBL via container)
-        if: steps.detect.outputs.unity_ok == 'true' && steps.lic.outputs.use_ebl == 'true'
+        if: steps.lic.outputs.use_ebl == 'true'
         shell: bash
         env:
           UNITY_IMAGE: ${{ env.UNITY_IMAGE }}
@@ -140,7 +152,6 @@ jobs:
             '
 
       - name: Warm up project (import Library once)
-        if: steps.detect.outputs.unity_ok == 'true'
         shell: bash
         env:
           UNITY_IMAGE: ${{ env.UNITY_IMAGE }}
@@ -162,14 +173,12 @@ jobs:
               "${manual_args[@]}" -quit
 
       - name: Clean old MCP status
-        if: steps.detect.outputs.unity_ok == 'true'
         run: |
           set -eux
           mkdir -p "$GITHUB_WORKSPACE/.unity-mcp"
           rm -f "$GITHUB_WORKSPACE/.unity-mcp"/unity-mcp-status-*.json || true
 
       - name: Run headless bridge harness (boot + wait + smoke/editmode/playmode)
-        if: steps.detect.outputs.unity_ok == 'true'
         shell: bash
         env:
           UNITY_IMAGE: ${{ env.UNITY_IMAGE }}
@@ -192,11 +201,11 @@ jobs:
             "${license_args[@]}"
 
       - name: Unity logs on failure
-        if: failure() && steps.detect.outputs.unity_ok == 'true'
+        if: failure()
         run: docker logs unity-mcp --tail 200 | sed -E 's/((email|serial|license|password|token)[^[:space:]]*)/[REDACTED]/Ig' || true
 
       - name: Upload E2E report
-        if: always() && steps.detect.outputs.unity_ok == 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-bridge-report

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -24,9 +24,9 @@ on:
       - .github/workflows/unity-tests.yml
   # Same-repo PRs get a unity-tests status check on every open / push via this trigger
   # (mirrors python-tests.yml). Fork PRs ALSO fire this trigger but run in the fork's
-  # context without secrets — the detect step downstream writes unity_ok=false and the
-  # job reports a green check having compiled and tested nothing. That skip is stated
-  # loudly in the job's step summary so it is never mistaken for a pass.
+  # context without secrets — the `license` gate job writes unity_ok=false and the test
+  # job is skipped by its job-level `if:`, so the merge box shows "Skipped" rather than a
+  # green check. The reason is also written to the gate job's step summary.
   #
   # There is deliberately no pull_request_target trigger here. Running fork-authored
   # C# through game-ci/unity-test-runner with UNITY_* secrets in scope is the classic
@@ -88,9 +88,56 @@ jobs:
           fi
           echo "versions=$versions" >> "$GITHUB_OUTPUT"
 
+  license:
+    # Hoisted out of testAllModes so the gate is a JOB-level condition. A step-level `if:`
+    # produces step-conclusion `skipped`, which contributes nothing to the job conclusion,
+    # so the whole suite reported a green check having compiled and tested nothing. A job
+    # skipped by a job-level `if:` reports "Skipped" in the merge box instead, which is
+    # what a reviewer actually reads. Branch protection still treats a skipped required
+    # check as satisfied, so this does not block merges.
+    name: Detect Unity license secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      unity_ok: ${{ steps.detect.outputs.unity_ok }}
+    steps:
+      - name: Detect Unity license secrets
+        id: detect
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        run: |
+          set -e
+          if [ -n "$UNITY_LICENSE" ] || { [ -n "$UNITY_EMAIL" ] && [ -n "$UNITY_PASSWORD" ] && [ -n "$UNITY_SERIAL" ]; }; then
+            echo "unity_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "unity_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Explain why the Unity suite will not run
+        if: steps.detect.outputs.unity_ok != 'true'
+        run: |
+          echo "::warning::Unity tests will be SKIPPED - no license secrets in scope (normal for fork PRs). Nothing will be compiled or tested."
+          {
+            echo "## :warning: Unity tests will be SKIPPED"
+            echo
+            echo "No Unity license secrets were in scope for this run, so **no C# will be compiled and no test will be executed**."
+            echo "The dependent job reports **Skipped**, not a pass."
+            echo
+            echo "GitHub withholds repository secrets from workflow runs triggered by a fork's pull request."
+            echo "To get real signal, a maintainer must run the suite against this code from a trusted context -"
+            echo "push the reviewed fork branch into this repo and the \`push\` trigger runs the full suite."
+            echo
+            echo "\`Compile MCPForUnity (win/osx/linux)\` and \`Run Python Tests\` DO run on fork PRs and are real signal."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   testAllModes:
     name: Test in ${{ matrix.testMode }} on Unity ${{ matrix.unityVersion }}
-    needs: matrix
+    needs: [matrix, license]
+    if: needs.license.outputs.unity_ok == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -110,39 +157,6 @@ jobs:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - name: Detect Unity license secrets
-        id: detect
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        run: |
-          set -e
-          if [ -n "$UNITY_LICENSE" ] || { [ -n "$UNITY_EMAIL" ] && [ -n "$UNITY_PASSWORD" ] && [ -n "$UNITY_SERIAL" ]; }; then
-            echo "unity_ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "unity_ok=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # A skipped run and a real pass both report a green check, because step-level
-      # `if:` conditions produce step-conclusion `skipped`, which contributes nothing
-      # to the job conclusion. Make the difference unmissable on the run page so a
-      # reviewer never reads this green check as "the code compiled".
-      - name: Skip Unity tests (missing license secrets)
-        if: steps.detect.outputs.unity_ok != 'true'
-        run: |
-          echo "::warning::Unity tests SKIPPED - no license secrets in scope (normal for fork PRs). This check is NOT a pass: nothing was compiled or tested."
-          {
-            echo "## :warning: Unity tests were SKIPPED"
-            echo
-            echo "No Unity license secrets were in scope for this run, so **no C# was compiled and no test was executed**."
-            echo "The green check means the job exited cleanly - **not** that this code works."
-            echo
-            echo "GitHub withholds repository secrets from workflow runs triggered by a fork's pull request."
-            echo "To get real signal, a maintainer must run the suite against this code from a trusted context."
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - uses: actions/cache@v4
         with:
           path: ${{ matrix.projectPath }}/Library
@@ -153,7 +167,6 @@ jobs:
 
       # Run domain reload tests first (they're [Explicit] so need explicit category)
       - name: Run domain reload tests
-        if: steps.detect.outputs.unity_ok == 'true'
         uses: game-ci/unity-test-runner@v4
         id: domain-tests
         env:
@@ -168,7 +181,6 @@ jobs:
           customParameters: -testCategory domain_reload
 
       - name: Run tests
-        if: steps.detect.outputs.unity_ok == 'true'
         uses: game-ci/unity-test-runner@v4
         id: tests
         continue-on-error: true
@@ -183,7 +195,6 @@ jobs:
           testMode: ${{ matrix.testMode }}
 
       - name: Check test results
-        if: steps.detect.outputs.unity_ok == 'true'
         env:
           ARTIFACTS_PATH: ${{ steps.tests.outputs.artifactsPath }}
         run: |
@@ -238,7 +249,7 @@ jobs:
           PY
 
       - uses: actions/upload-artifact@v4
-        if: always() && steps.detect.outputs.unity_ok == 'true' && steps.tests.outcome != 'skipped'
+        if: always() && steps.tests.outcome != 'skipped'
         with:
           name: Test results for ${{ matrix.testMode }} on Unity ${{ matrix.unityVersion }}
           path: ${{ steps.tests.outputs.artifactsPath }}

--- a/website/docs/contributing/dev-setup.md
+++ b/website/docs/contributing/dev-setup.md
@@ -246,7 +246,21 @@ For compatibility PRs, note the exact editor versions you tested in the PR body.
 
 CI exercises the package across multiple Unity versions to catch breaks in `#if UNITY_*_OR_NEWER` branches. The matrix is configured in `tools/unity-versions.json` and consumed by `.github/workflows/unity-tests.yml`.
 
-**Every PR gets a unity-tests status check on open** (mirrors `python-tests.yml`). For same-repo PRs the default Unity 6 leg actually runs; for fork PRs the workflow appears but skips with a "missing license secrets" notice until a maintainer applies `safe-to-test` (existing secret-safety gate). The full 4-version matrix is opt-in via the `full-matrix` label.
+**Every PR gets a unity-tests status check on open** (mirrors `python-tests.yml`). For same-repo PRs the default Unity 6 leg actually runs. The full 4-version matrix is opt-in via the `full-matrix` label.
+
+### Which checks are real signal on a fork PR
+
+GitHub withholds repository secrets from workflow runs triggered by a fork's pull request, and both Unity workflows need a licence. They report **Skipped**, not a pass:
+
+| Check | On a fork PR |
+|---|---|
+| `Compile MCPForUnity (win/osx/linux)` | **Runs.** Licence-free compile across win/osx/linux — real signal. |
+| `Run Python Tests` | **Runs.** Real signal. |
+| `Check docs reference is fresh` | **Runs.** Real signal. |
+| `Test in editmode on Unity <version>` | **Skipped** — no Editor booted, no C# compiled by this job. |
+| `e2e-bridge` | **Skipped** — no Editor booted, no tool call exercised. |
+
+If you need a real Unity run against fork code, ask a maintainer: once the diff is reviewed, pushing the branch into this repo makes the `push` trigger run the full suite in a trusted context. There is deliberately no `pull_request_target` trigger for the Unity workflows — running fork-authored C# with `UNITY_*` secrets in scope is the classic "pwn request" shape, since an `[InitializeOnLoad]` script in the PR would be enough to read them.
 
 **When the full matrix runs (all 4 versions in parallel):**
 
@@ -254,8 +268,6 @@ CI exercises the package across multiple Unity versions to catch breaks in `#if 
 - `workflow_call` from `beta-release.yml` / `release.yml`.
 - Manual `workflow_dispatch` from the Actions tab.
 - Any PR (in-repo or fork) labeled with **`full-matrix`** — apply when your change touches compat shims, conditional compilation, or anything else version-sensitive. Triggers a full-matrix run on the next `pull_request` or `pull_request_target` event. Cost is ~6-8 min wall clock vs ~3 min for the default leg.
-
-Fork PRs still need `safe-to-test` as the base gate (so secrets are exposed against reviewed-only fork code); `full-matrix` is layered on top for fork-PR full-matrix runs.
 
 **Default (single leg)** — every other path runs only against `defaultVersion` from `tools/unity-versions.json` (currently Unity 6.0 LTS, `6000.0.75f1`). The `floor` role (`2021.3.45f2`) still identifies the package minimum and runs as part of the full matrix; it's no longer the default-leg version.
 

--- a/website/docs/contributing/dev-setup.md
+++ b/website/docs/contributing/dev-setup.md
@@ -246,15 +246,15 @@ For compatibility PRs, note the exact editor versions you tested in the PR body.
 
 CI exercises the package across multiple Unity versions to catch breaks in `#if UNITY_*_OR_NEWER` branches. The matrix is configured in `tools/unity-versions.json` and consumed by `.github/workflows/unity-tests.yml`.
 
-**Every PR gets a unity-tests status check on open** (mirrors `python-tests.yml`). For same-repo PRs the default Unity 6 leg actually runs. The full 4-version matrix is opt-in via the `full-matrix` label.
+**Every Unity-scoped PR gets a unity-tests status check on open** (mirrors `python-tests.yml`). The `pull_request` trigger is path-filtered to `MCPForUnity/Editor/**`, `MCPForUnity/Runtime/**`, `TestProjects/UnityMCPTests/**` and the workflow itself, so a PR touching only `Server/**` or docs never creates the check. For same-repo PRs the default Unity 6 leg actually runs. The full 4-version matrix is opt-in via the `full-matrix` label.
 
 ### Which checks are real signal on a fork PR
 
-GitHub withholds repository secrets from workflow runs triggered by a fork's pull request, and both Unity workflows need a licence. They report **Skipped**, not a pass:
+GitHub withholds repository secrets from workflow runs triggered by a fork's pull request, and both Unity workflows need a license. They report **Skipped**, not a pass:
 
 | Check | On a fork PR |
 |---|---|
-| `Compile MCPForUnity (win/osx/linux)` | **Runs.** Licence-free compile across win/osx/linux — real signal. |
+| `Compile MCPForUnity (win/osx/linux)` | **Runs.** License-free compile across win/osx/linux — real signal. |
 | `Run Python Tests` | **Runs.** Real signal. |
 | `Check docs reference is fresh` | **Runs.** Real signal. |
 | `Test in editmode on Unity <version>` | **Skipped** — no Editor booted, no C# compiled by this job. |
@@ -267,7 +267,7 @@ If you need a real Unity run against fork code, ask a maintainer: once the diff 
 - Push to `beta` (the release gate).
 - `workflow_call` from `beta-release.yml` / `release.yml`.
 - Manual `workflow_dispatch` from the Actions tab.
-- Any PR (in-repo or fork) labeled with **`full-matrix`** — apply when your change touches compat shims, conditional compilation, or anything else version-sensitive. Triggers a full-matrix run on the next `pull_request` or `pull_request_target` event. Cost is ~6-8 min wall clock vs ~3 min for the default leg.
+- Any PR (in-repo or fork) labeled with **`full-matrix`** — apply when your change touches compat shims, conditional compilation, or anything else version-sensitive. Triggers a full-matrix run on the next `pull_request` event (the label is read when the workflow fires, so applying it to an open PR takes effect on the next push). Cost is ~6-8 min wall clock vs ~3 min for the default leg.
 
 **Default (single leg)** — every other path runs only against `defaultVersion` from `tools/unity-versions.json` (currently Unity 6.0 LTS, `6000.0.75f1`). The `floor` role (`2021.3.45f2`) still identifies the package minimum and runs as part of the full matrix; it's no longer the default-leg version.
 


### PR DESCRIPTION
Both Unity workflows have been reporting a **green check having run nothing** on every fork PR. Since practically every PR to this repo comes from a fork, that is most of the queue.

### The mechanism

Both gate every real step on a step-level `if:` reading an in-job license-detection output:

```yaml
- name: Run tests
  if: steps.detect.outputs.unity_ok == 'true'
```

A step-level `if:` yields step-conclusion `skipped`, which contributes **nothing** to the job conclusion. So the job exits clean and the merge box shows a tick.

Both workflows already knew. From their own source, before this PR:

```
# the detect step downstream writes unity_ok=false and the
# job reports a green check having compiled and tested nothing.
```
```
# Every step below is gated on unity_ok, so the job reports a green check
# having run nothing at all. Say so plainly on the run page.
```

The step summary does say so. But a step summary is not what a reviewer scans — the tick is.

### What it looked like in practice

PR #1323 does not compile. `SkyboxOps.cs(18,17): error CS0266`, red on all three OS since 2026-08-15. Here is how it presents:

```
Compile MCPForUnity (win/osx/linux)   = FAILURE   ← the one honest check
Test in editmode on Unity 6000.0.75f1 = SUCCESS   ← ran nothing
e2e-bridge                            = SUCCESS   ← ran nothing
Build site                            = SUCCESS
Compute Unity version matrix          = SUCCESS
CodeRabbit                            = SUCCESS
```

Five green ticks on a PR that provably does not build. The same shape appears on #1285, #1287 and #1043, where the two hollow ticks are 100% of their green.

### The fix

Hoist detection into a `license` gate job and gate the real job on it with a **job-level** `if:`:

```yaml
  license:
    outputs:
      unity_ok: ${{ steps.detect.outputs.unity_ok }}

  testAllModes:
    needs: [matrix, license]
    if: needs.license.outputs.unity_ok == 'true'
```

A job skipped by a job-level `if:` reports **Skipped** in the merge box, which is visually distinct from a pass. Branch protection [treats a skipped required check as satisfied](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), so **this does not block merges** — it only stops the check claiming a pass it never earned.

No change to what runs when secrets *are* in scope: same steps, same `actions/cache` key, same matrix, same artifacts.

### Also

- Documents which checks are real signal on a fork PR, in `website/docs/contributing/dev-setup.md`:

  | Check | On a fork PR |
  |---|---|
  | `Compile MCPForUnity (win/osx/linux)` | **Runs** — real signal |
  | `Run Python Tests` | **Runs** — real signal |
  | `Check docs reference is fresh` | **Runs** — real signal |
  | `Test in editmode on Unity <version>` | **Skipped** |
  | `e2e-bridge` | **Skipped** |

- Surfaces the escape hatch that was previously buried in a workflow comment: to get a real Unity run against fork code, a maintainer pushes the reviewed branch into this repo and the `push` trigger runs the full suite in a trusted context. (There is deliberately no `pull_request_target` for these — fork-authored C# plus `UNITY_*` secrets is the classic "pwn request" shape.)
- Drops the stale `safe-to-test` references from the contributor docs; that gate was retired in #1308.

### Testing

Both files validate as YAML and the job graph is as intended (`matrix` → `license` → `testAllModes`; `license` → `e2e-bridge`). Touches no C# and no Python. The real proof is this PR's own checks: it comes from a fork, so `Test in editmode` and `e2e-bridge` should now read **Skipped** rather than green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unity validation workflows now report **Skipped** when required license secrets are unavailable, instead of showing a misleading successful check.
  * Simplified workflow execution and artifact handling for licensed test runs.
  * Unity checks now run only for changes within the relevant Unity-scoped paths.

* **Documentation**
  * Updated contributor guidance to explain fork pull request behavior, secret availability, trusted runs, and path-filtered Unity validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->