### PR TITLE
perf(discovery): use TypeCache instead of scanning every loaded assembly

### DIFF
--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -8,6 +8,7 @@ using MCPForUnity.Editor.Resources;
 using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using UnityEditor;
 
 namespace MCPForUnity.Editor.Tools
 {
@@ -70,28 +71,24 @@ namespace MCPForUnity.Editor.Tools
 
             try
             {
-                var allTypes = UnityAssembliesCompat.GetLoadedAssemblies()
-                    .Where(a => !a.IsDynamic)
-                    .SelectMany(a =>
-                    {
-                        try { return a.GetTypes(); }
-                        catch { return new Type[0]; }
-                    })
-                    .ToList();
-
-                // Discover tools
-                var toolTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityToolAttribute>(t));
+                // TypeCache is Unity's precomputed attribute index, rebuilt once per domain
+                // reload. The previous scan materialised every type in every loaded assembly
+                // and then called GetCustomAttribute on each one twice, which measured at
+                // ~9s per reload on large projects (issue #1336) — work Unity had already
+                // done. McpClientRegistry.BuildRegistry() sets the in-tree precedent.
+                //
+                // It also removes the GetCustomAttribute calls that made the AssetImportWorker
+                // crash in issue #1134; the worker guard above stays regardless, since the
+                // registry is unused there either way.
                 int toolCount = 0;
-                foreach (var type in toolTypes)
+                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>())
                 {
                     if (RegisterCommandType(type, isResource: false))
                         toolCount++;
                 }
 
-                // Discover resources
-                var resourceTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityResourceAttribute>(t));
                 int resourceCount = 0;
-                foreach (var type in resourceTypes)
+                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityResourceAttribute>())
                 {
                     if (RegisterCommandType(type, isResource: true))
                         resourceCount++;
@@ -102,20 +99,6 @@ namespace MCPForUnity.Editor.Tools
             catch (Exception ex)
             {
                 McpLog.Error($"Failed to auto-discover MCP commands: {ex.Message}");
-            }
-        }
-
-        private static bool HasAttributeSafe<T>(Type type) where T : Attribute
-        {
-            try
-            {
-                return type.GetCustomAttribute<T>() != null;
-            }
-            catch
-            {
-                // Type metadata can be in a half-loaded state during domain reload; treat
-                // those as "no attribute" rather than aborting the whole scan.
-                return false;
             }
         }
 

--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -80,15 +80,22 @@ namespace MCPForUnity.Editor.Tools
                 // It also removes the GetCustomAttribute calls that made the AssetImportWorker
                 // crash in issue #1134; the worker guard above stays regardless, since the
                 // registry is unused there either way.
+                // Ordered by FullName because RegisterCommandType lets a duplicate command
+                // name overwrite the previous handler, so registration order decides which
+                // one wins. TypeCache does not document an order, and the assembly scan this
+                // replaces was stable within a build, so without sorting a name collision
+                // could resolve differently between domain reloads.
                 int toolCount = 0;
-                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>())
+                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>()
+                             .OrderBy(t => t.FullName, StringComparer.Ordinal))
                 {
                     if (RegisterCommandType(type, isResource: false))
                         toolCount++;
                 }
 
                 int resourceCount = 0;
-                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityResourceAttribute>())
+                foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityResourceAttribute>()
+                             .OrderBy(t => t.FullName, StringComparer.Ordinal))
                 {
                     if (RegisterCommandType(type, isResource: true))
                         resourceCount++;


### PR DESCRIPTION
Closes #1336.

`CommandRegistry.AutoDiscoverCommands()` materialised **every type in every non-dynamic loaded assembly**, then called `GetCustomAttribute` on each one **twice** — once for tools, once for resources:

```csharp
var allTypes = UnityAssembliesCompat.GetLoadedAssemblies()
    .Where(a => !a.IsDynamic)
    .SelectMany(a => { try { return a.GetTypes(); } catch { return new Type[0]; } })
    .ToList();

var toolTypes     = allTypes.Where(t => HasAttributeSafe<McpForUnityToolAttribute>(t));
var resourceTypes = allTypes.Where(t => HasAttributeSafe<McpForUnityResourceAttribute>(t));
```

@kogangdon measured **~8.9 s per domain reload** on a large project — roughly half their total reload time. Every script edit pays it.

All of that repeats work Unity has already done. `TypeCache` is the precomputed attribute index, rebuilt once per domain reload:

```csharp
foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>())
foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityResourceAttribute>())
```

This is not a new mechanism for this repo — `McpClientRegistry.BuildRegistry()` already discovers configurators through `TypeCache.GetTypesDerivedFrom<IMcpClientConfigurator>()`, and `RendererFeatureOps` / `GraphicsHelpers` use it too.

**Bonus:** it removes the `GetCustomAttribute` calls that could hard-crash Mono inside the AssetImportWorker (#1134). The `IsRunningInAssetImportWorker()` guard stays regardless — the registry is unused there either way — but the crash-prone call is now gone from the path entirely.

`HasAttributeSafe` had no remaining callers, so it is deleted rather than left behind.

### Timing note

`TypeCache` is populated by Unity during domain reload, before `InitializeOnLoad` callbacks run. `CommandRegistry.Initialize()` is lazy (guarded by `_initialized`) and is called after that point, so the index is always ready — same timing `McpClientRegistry` has relied on.

### Testing

- **Unity 6000.4.11f1**: `CommandRegistryTests` 2/2 passed, including `AutoDiscovery_RegistersAllBuiltInTools`. Discovery still reports `Auto-discovered 35 tools and 19 resources (54 total handlers)` — unchanged.
- **Unity 2021.3.45f2** (package floor): compile check passes.

Net −17 lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved command and resource discovery in the Unity Editor, resulting in faster and more efficient startup scanning.
  * Enhanced compatibility by using Unity’s built-in type discovery system.
* **Bug Fixes**
  * Retained safeguards that prevent unnecessary discovery during asset import processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->