### PR TITLE
perf(discovery): drop the redundant assembly walk from tool discovery too

### DIFF
--- a/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
+++ b/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
@@ -23,30 +23,22 @@ namespace MCPForUnity.Editor.Services
 
             _cachedTools = new Dictionary<string, ToolMetadata>();
 
-            // Primary scan via TypeCache (fast, but can miss project assemblies in some domain-reload states)
-            var toolTypes = TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>();
-
-            // Fallback scan via AppDomain (slower but exhaustive; mirrors CommandRegistry behaviour)
-            var appDomainTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(a => !a.IsDynamic)
-                .SelectMany(a =>
-                {
-                    try { return a.GetTypes(); }
-                    catch (Exception ex)
-                    {
-                        McpLog.Warn($"Failed to reflect types from assembly {a.FullName}: {ex.Message}");
-                        return new Type[0];
-                    }
-                })
-                .Where(t => t.GetCustomAttribute<McpForUnityToolAttribute>() != null);
-
-            // Merge both scans, deduplicating by type
-            var allToolTypes = toolTypes
-                .Concat(appDomainTypes)
-                .Distinct()
-                .ToList();
-
-            foreach (var type in allToolTypes)
+            // TypeCache is Unity's precomputed attribute index, rebuilt once per domain reload.
+            // This used to query it and then ALSO materialise every type in every loaded assembly
+            // and call GetCustomAttribute on each one, before merging the two sets — so the fast
+            // path never actually saved anything (issue #1336). The result is cached, so the walk
+            // ran once per domain reload, and again on each tool toggle in the editor window,
+            // which invalidates the cache. A reload therefore paid for two full assembly walks:
+            // this one and CommandRegistry.AutoDiscoverCommands, which #1364 removed. This brings
+            // the tool registry in line with it, and with ResourceDiscoveryService, which has
+            // always been TypeCache-only.
+            //
+            // Ordered by FullName because a duplicate tool name overwrites the previous
+            // registration below, so registration order decides which one wins. TypeCache does
+            // not document an order, so without sorting a name collision could resolve
+            // differently between domain reloads.
+            foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>()
+                         .OrderBy(t => t.FullName, StringComparer.Ordinal))
             {
                 McpForUnityToolAttribute toolAttr;
                 try

--- a/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
+++ b/MCPForUnity/Editor/Services/ToolDiscoveryService.cs
@@ -33,12 +33,9 @@ namespace MCPForUnity.Editor.Services
             // the tool registry in line with it, and with ResourceDiscoveryService, which has
             // always been TypeCache-only.
             //
-            // Ordered by FullName because a duplicate tool name overwrites the previous
-            // registration below, so registration order decides which one wins. TypeCache does
-            // not document an order, so without sorting a name collision could resolve
-            // differently between domain reloads.
-            foreach (var type in TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>()
-                         .OrderBy(t => t.FullName, StringComparer.Ordinal))
+            // Ordered because a duplicate tool name overwrites the previous registration below,
+            // so registration order decides which one wins, and TypeCache documents no order.
+            foreach (var type in InRegistrationOrder(TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>()))
             {
                 McpForUnityToolAttribute toolAttr;
                 try
@@ -70,6 +67,19 @@ namespace MCPForUnity.Editor.Services
 
             McpLog.Info($"Discovered {_cachedTools.Count} MCP tools via reflection", false);
             return _cachedTools.Values.ToList();
+        }
+
+        /// <summary>
+        /// Stable registration order for discovered tool types. FullName alone is not a total
+        /// order: two assemblies can declare the same full type name, and if their tool names
+        /// also collide the later registration wins, so the assembly identity breaks the tie.
+        /// Without both keys a collision could resolve differently between domain reloads.
+        /// </summary>
+        internal static IEnumerable<Type> InRegistrationOrder(IEnumerable<Type> types)
+        {
+            return types
+                .OrderBy(type => type.FullName, StringComparer.Ordinal)
+                .ThenBy(type => type.Assembly.FullName, StringComparer.Ordinal);
         }
 
         public ToolMetadata GetToolMetadata(string toolName)

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs
@@ -113,6 +113,53 @@ namespace MCPForUnity.Editor.Tests.EditMode.Services
             Assert.IsFalse(result, "Tool state should persist across service instances");
         }
 
+        /// <summary>
+        /// Discovery is TypeCache-only, so the built-in tools must all still surface — this is the
+        /// guard that dropping the exhaustive assembly walk did not lose any of them.
+        /// </summary>
+        [Test]
+        public void DiscoverAllTools_FindsEveryBuiltInTool()
+        {
+            string[] expected =
+            {
+                "manage_asset",
+                "manage_editor",
+                "manage_gameobject",
+                "manage_scene",
+                "manage_script",
+                "manage_shader",
+                "read_console",
+                "execute_menu_item",
+                "manage_prefabs"
+            };
+
+            var service = new ToolDiscoveryService();
+            var discovered = service.DiscoverAllTools().Select(tool => tool.Name).ToList();
+
+            foreach (string name in expected)
+            {
+                CollectionAssert.Contains(discovered, name, $"built-in tool '{name}' should be discovered");
+            }
+        }
+
+        /// <summary>
+        /// A duplicate tool name overwrites the previous registration, so registration order
+        /// decides the winner. TypeCache documents no order, hence the explicit sort — without it
+        /// a name collision could resolve differently from one domain reload to the next.
+        /// </summary>
+        [Test]
+        public void DiscoverAllTools_RegistersInAStableOrder()
+        {
+            var service = new ToolDiscoveryService();
+
+            var first = service.DiscoverAllTools().Select(tool => tool.Name).ToList();
+            service.InvalidateCache();
+            var second = service.DiscoverAllTools().Select(tool => tool.Name).ToList();
+
+            CollectionAssert.AreEqual(first, second,
+                "repeated discovery must produce the same registration order");
+        }
+
         [Test]
         public void DiscoverAllTools_DoesNotOverrideStoredFalse_ForBuiltInAutoRegisterFalseTool()
         {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/ToolDiscoveryServiceTests.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using NUnit.Framework;
 using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Services;
@@ -158,6 +162,42 @@ namespace MCPForUnity.Editor.Tests.EditMode.Services
 
             CollectionAssert.AreEqual(first, second,
                 "repeated discovery must produce the same registration order");
+        }
+
+        /// <summary>
+        /// FullName alone is not a total order — two assemblies can declare the same full type
+        /// name. If their tool names also collide the later registration wins, so the tie has to
+        /// resolve the same way every reload. Two identically named types cannot coexist in one
+        /// assembly, so this emits them into separate dynamic assemblies to build a real tie.
+        /// </summary>
+        [Test]
+        public void InRegistrationOrder_BreaksFullNameTiesByAssembly()
+        {
+            const string sharedName = "McpTieBreak.Namespace.DuplicateTool";
+            Type fromA = EmitTypeInOwnAssembly("McpTieBreakAssemblyA", sharedName);
+            Type fromB = EmitTypeInOwnAssembly("McpTieBreakAssemblyB", sharedName);
+
+            Assert.AreEqual(fromA.FullName, fromB.FullName,
+                "precondition: the two types must share a full name for this to test a tie");
+            Assert.AreNotEqual(fromA.Assembly.FullName, fromB.Assembly.FullName,
+                "precondition: the two types must live in different assemblies");
+
+            var forward = ToolDiscoveryService.InRegistrationOrder(new[] { fromA, fromB }).ToList();
+            var reversed = ToolDiscoveryService.InRegistrationOrder(new[] { fromB, fromA }).ToList();
+
+            CollectionAssert.AreEqual(forward, reversed,
+                "input order must not decide the winner once full names tie");
+            Assert.AreSame(fromA, forward[0], "assembly A sorts before assembly B");
+            Assert.AreSame(fromB, forward[1], "assembly B registers last, so it would win a name collision");
+        }
+
+        private static Type EmitTypeInOwnAssembly(string assemblyName, string typeFullName)
+        {
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName(assemblyName), AssemblyBuilderAccess.Run);
+            ModuleBuilder module = assembly.DefineDynamicModule(assemblyName);
+            TypeBuilder type = module.DefineType(typeFullName, TypeAttributes.Public);
+            return type.CreateType();
         }
 
         [Test]


### PR DESCRIPTION
## Description

Follow-up to #1364, which fixed `CommandRegistry.AutoDiscoverCommands` but left the same problem in the other discovery path.

`ToolDiscoveryService.DiscoverAllTools` queries `TypeCache` and then materialises every type in every non-dynamic loaded assembly anyway — calling `GetCustomAttribute` on each one — before merging and de-duplicating the two sets:

```csharp
var toolTypes = TypeCache.GetTypesWithAttribute<McpForUnityToolAttribute>();

var appDomainTypes = AppDomain.CurrentDomain.GetAssemblies()   // runs regardless
    .Where(a => !a.IsDynamic)
    .SelectMany(a => { try { return a.GetTypes(); } catch { … } })
    .Where(t => t.GetCustomAttribute<McpForUnityToolAttribute>() != null);

var allToolTypes = toolTypes.Concat(appDomainTypes).Distinct().ToList();
```

Because the exhaustive scan is unconditional, the `TypeCache` query above it never saved anything.

The result is cached in `_cachedTools`, so this ran once per domain reload rather than per call — plus again whenever a tool is toggled in the editor window, since `McpToolsSection` calls `InvalidateCache()`. So before #1364 a domain reload paid for **two** full assembly walks, one here and one in `CommandRegistry`. #1364 removed that one; this removes this one.

Same reasoning as yours: `TypeCache` is the precomputed index Unity rebuilds each reload, `ResourceDiscoveryService` has always been TypeCache-only, and `McpClientRegistry.BuildRegistry()` set the in-tree precedent.

I measured the walk in `TestProjects/UnityMCPTests` — 193 non-dynamic assemblies, 44,195 types, Unity 2022.3.62f1, averaged over 5 runs after warm-up: **310.63 ms** for the assembly walk versus **0.01 ms** for `TypeCache`, both finding **exactly the same 54 types**. A near-empty project is the floor here; the projects in #1336 carry far more assemblies.

I also adopted your `OrderBy(t => t.FullName, StringComparer.Ordinal)`. It applies verbatim to this file — a duplicate tool name overwrites the previous registration (there is an explicit `McpLog.Warn` on that path), so registration order decides the winner and `TypeCache` documents no order. Without the sort, a name collision could resolve differently between reloads.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- `ToolDiscoveryService.DiscoverAllTools` is TypeCache-only, ordered by `FullName`. The `AppDomain` walk is gone; the per-type `GetCustomAttribute` in the loop stays, since it reads the attribute instance.
- `DiscoverAllTools_FindsEveryBuiltInTool` — the guard that dropping the exhaustive walk did not lose any built-in tool.
- `DiscoverAllTools_RegistersInAStableOrder` — pins the ordering guarantee via `InvalidateCache()` and a second discovery.

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f1
- Package source used: `file:` (local clone, branch `perf/typecache-tool-discovery` off `beta` at b2fd964d)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (file reference)

## Testing/Screenshots/Recordings
- [ ] Python tests — not applicable, no Python-side changes
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests — not applicable, editor-only service
- [x] Package import/compile check

Full EditMode suite on 2022.3.62f1: **1152 passed, 0 failed** (67 pre-existing ignores), zero compile errors.

To be straight about what the tests can and cannot show: there is no honest failing-test-first for this one. Discovery returns the same tools before and after, so the only observable difference is time spent, and a wall-clock assertion in CI would be flaky. The existing `ToolDiscoveryServiceTests` plus the new built-in-tools guard are the real regression evidence, and the measurement above is the justification.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources — no tool or resource surface changed

## Related Issues

Relates to #1336 (already closed by #1364; this finishes the second call site).

## Additional Notes

I had an earlier PR for both files (#1358) which I closed once #1364 landed — yours was the better change, and the `OrderBy` in particular was something I had missed. This is just the half that #1364 did not cover, rebased onto current `beta` and with your ordering approach applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool discovery now uses a consistent registration order across domain reloads, including predictable handling when tool names or type names overlap.
  * Built-in tools continue to be discovered reliably.

* **Tests**
  * Added coverage confirming all built-in tools are found.
  * Added validation that repeated discovery produces a stable registration order.
  * Added coverage for deterministic ordering when matching tool types come from different assemblies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->