### PR TITLE
fix(execute_code): allow using directives at the top of a snippet

### DIFF
--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -529,20 +529,46 @@ namespace MCPForUnity.Editor.Tools
         private static bool IsUsingDirective(string line)
             => UsingDirectiveLine.IsMatch(line) || UsingAliasLine.IsMatch(line);
 
+        // A directive can carry comments, but the regexes above must see a bare `using ...;`
+        private static string StripComments(string line, ref bool inBlock)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < line.Length; i++)
+            {
+                bool pair = i + 1 < line.Length;
+                if (inBlock)
+                {
+                    if (pair && line[i] == '*' && line[i + 1] == '/') { inBlock = false; i++; }
+                    continue;
+                }
+                if (pair && line[i] == '/' && line[i + 1] == '*') { inBlock = true; i++; continue; }
+                if (pair && line[i] == '/' && line[i + 1] == '/') break;
+                sb.Append(line[i]);
+            }
+            return sb.ToString();
+        }
+
+        // Blanked, not removed, so compiler line numbers still map to the caller's
+        private static List<string> HoistLeadingUsings(string[] body)
+        {
+            var hoisted = new List<string>();
+            bool inBlock = false;
+            for (int i = 0; i < body.Length; i++)
+            {
+                string directive = StripComments(body[i], ref inBlock).Trim();
+                if (directive.Length == 0) continue;
+                if (!IsUsingDirective(directive)) break;
+                if (!BuiltinUsings.Contains(directive) && !hoisted.Contains(directive)) hoisted.Add(directive);
+                body[i] = string.Empty;
+            }
+            return hoisted;
+        }
+
         // A using directive is illegal in a method body, so the parser reads it as a using-statement and wants a '('
-        // Hoisted lines are blanked, not removed, so compiler line numbers still map to the caller's.
         private static string WrapUserCode(string code, out int lineOffset)
         {
             var body = code.Replace("\r\n", "\n").Split('\n');
-            var hoisted = new List<string>();
-            for (int i = 0; i < body.Length; i++)
-            {
-                string trimmed = body[i].Trim();
-                if (trimmed.Length == 0 || trimmed.StartsWith("//")) continue;
-                if (!IsUsingDirective(body[i])) break;
-                if (!BuiltinUsings.Contains(trimmed) && !hoisted.Contains(trimmed)) hoisted.Add(trimmed);
-                body[i] = string.Empty;
-            }
+            var hoisted = HoistLeadingUsings(body);
 
             var sb = new StringBuilder();
             foreach (string u in BuiltinUsings) sb.AppendLine(u);
@@ -591,9 +617,50 @@ namespace MCPForUnity.Editor.Tools
             return result;
         }
 
+        // A hoisted `using System.IO;` puts File.Delete in scope, which no fully-qualified
+        // pattern in _blockedPatterns matches. Derive the short forms the directives create.
+        private static IEnumerable<string> ShortFormsFromUsings(IEnumerable<string> directives)
+        {
+            foreach (string directive in directives)
+            {
+                string target = directive.Substring("using".Length).Trim().TrimEnd(';').Trim();
+                bool isStatic = target.StartsWith("static ", StringComparison.Ordinal);
+                if (isStatic) target = target.Substring("static ".Length).Trim();
+
+                string alias = null;
+                int eq = target.IndexOf('=');
+                if (eq >= 0)
+                {
+                    alias = target.Substring(0, eq).Trim();
+                    target = target.Substring(eq + 1).Trim();
+                }
+
+                int lastDot = target.LastIndexOf('.');
+                string leaf = lastDot >= 0 ? target.Substring(lastDot + 1) : target;
+
+                foreach (string pattern in _blockedPatterns)
+                {
+                    if (pattern.StartsWith(target + ".", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string tail = pattern.Substring(target.Length + 1);
+                        yield return alias == null ? tail : alias + "." + tail;
+                    }
+                    // A blocked pattern already written short, like AssetDatabase.DeleteAsset,
+                    // needs the leaf instead: `using static ...Process;` makes Process.Start bare Start
+                    else if (pattern.StartsWith(leaf + ".", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string tail = pattern.Substring(leaf.Length + 1);
+                        if (isStatic) yield return tail;
+                        else if (alias != null) yield return alias + "." + tail;
+                    }
+                }
+            }
+        }
+
         private static string CheckBlockedPatterns(string code)
         {
-            foreach (var pattern in _blockedPatterns)
+            var directives = HoistLeadingUsings(code.Replace("\r\n", "\n").Split('\n'));
+            foreach (var pattern in _blockedPatterns.Concat(ShortFormsFromUsings(directives)))
             {
                 if (code.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0)
                     return $"Code contains blocked pattern: '{pattern}'. Disable safety checks with safety_checks=false if this is intentional.";

--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Runtime.Helpers;
 using Microsoft.CSharp;
@@ -19,7 +20,6 @@ namespace MCPForUnity.Editor.Tools
         private const int MaxCodeLength = 50000;
         private const int MaxHistoryEntries = 50;
         private const int MaxHistoryCodePreview = 500;
-        internal const int WrapperLineOffset = 10;
         private const string WrapperClassName = "MCPDynamicCode";
         private const string WrapperMethodName = "Execute";
 
@@ -201,7 +201,7 @@ namespace MCPForUnity.Editor.Tools
 
         private static object CompileAndExecute(string code, string compiler)
         {
-            string wrappedSource = WrapUserCode(code);
+            string wrappedSource = WrapUserCode(code, out int lineOffset);
 
             string cacheKey = compiler + "\n" + wrappedSource;
             if (_compiledCache.TryGetValue(cacheKey, out CompiledSnippet cached))
@@ -217,14 +217,14 @@ namespace MCPForUnity.Editor.Tools
                 case "roslyn":
                     if (!RoslynCompiler.IsAvailable)
                         return new ErrorResponse("Roslyn (Microsoft.CodeAnalysis) is not available. Install it via NuGet or use compiler='codedom'.");
-                    compiled = RoslynCompiler.Compile(wrappedSource, assemblyPaths, out var roslynErrors);
+                    compiled = RoslynCompiler.Compile(wrappedSource, assemblyPaths, lineOffset, out var roslynErrors);
                     if (compiled == null)
                         return new ErrorResponse("Compilation failed", new { errors = OffsetErrors(roslynErrors), compiler = "roslyn" });
                     usedCompiler = "roslyn";
                     break;
 
                 case "codedom":
-                    compiled = CodeDomCompile(wrappedSource, assemblyPaths, out var codedomErrors);
+                    compiled = CodeDomCompile(wrappedSource, assemblyPaths, lineOffset, out var codedomErrors);
                     if (compiled == null)
                         return new ErrorResponse("Compilation failed", new { errors = OffsetErrors(codedomErrors), compiler = "codedom" });
                     usedCompiler = "codedom";
@@ -233,14 +233,14 @@ namespace MCPForUnity.Editor.Tools
                 default: // "auto"
                     if (RoslynCompiler.IsAvailable)
                     {
-                        compiled = RoslynCompiler.Compile(wrappedSource, assemblyPaths, out var autoErrors);
+                        compiled = RoslynCompiler.Compile(wrappedSource, assemblyPaths, lineOffset, out var autoErrors);
                         if (compiled == null)
                             return new ErrorResponse("Compilation failed", new { errors = OffsetErrors(autoErrors), compiler = "roslyn" });
                         usedCompiler = "roslyn";
                     }
                     else
                     {
-                        compiled = CodeDomCompile(wrappedSource, assemblyPaths, out var autoFallbackErrors);
+                        compiled = CodeDomCompile(wrappedSource, assemblyPaths, lineOffset, out var autoFallbackErrors);
                         if (compiled == null)
                             return new ErrorResponse("Compilation failed", new { errors = OffsetErrors(autoFallbackErrors), compiler = "codedom" });
                         usedCompiler = "codedom";
@@ -302,7 +302,7 @@ namespace MCPForUnity.Editor.Tools
 
         // ──────────────────── CodeDom compiler ────────────────────
 
-        private static Assembly CodeDomCompile(string source, string[] assemblyPaths, out List<string> errors)
+        private static Assembly CodeDomCompile(string source, string[] assemblyPaths, int lineOffset, out List<string> errors)
         {
             errors = new List<string>();
 
@@ -360,7 +360,7 @@ namespace MCPForUnity.Editor.Tools
                                 continue;
 
                             hasRealErrors = true;
-                            int userLine = Math.Max(1, error.Line - WrapperLineOffset);
+                            int userLine = Math.Max(1, error.Line - lineOffset);
                             errors.Add($"Line {userLine}: {error.ErrorText}");
                         }
 
@@ -508,22 +508,54 @@ namespace MCPForUnity.Editor.Tools
 
         // ──────────────────── Shared helpers ────────────────────
 
-        private static string WrapUserCode(string code)
+        private static readonly string[] BuiltinUsings =
         {
+            "using System;",
+            "using System.Collections.Generic;",
+            "using System.Linq;",
+            "using System.Reflection;",
+            "using System.Text;",
+            "using UnityEngine;",
+            "using UnityEditor;",
+        };
+
+        private static readonly Regex UsingDirectiveLine = new Regex(
+            @"^\s*using\s+(?:static\s+)?[A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*\s*;\s*$", RegexOptions.Compiled);
+
+        // Must not match the C# 8 `using var x = ...` declaration, which has two tokens before the =
+        private static readonly Regex UsingAliasLine = new Regex(
+            @"^\s*using\s+[A-Za-z_]\w*\s*=\s*[A-Za-z_][\w.]*\s*(?:<[^;]*>)?\s*(?:\[\s*\])*\s*;\s*$", RegexOptions.Compiled);
+
+        private static bool IsUsingDirective(string line)
+            => UsingDirectiveLine.IsMatch(line) || UsingAliasLine.IsMatch(line);
+
+        // A using directive is illegal in a method body, so the parser reads it as a using-statement and wants a '('
+        // Hoisted lines are blanked, not removed, so compiler line numbers still map to the caller's.
+        private static string WrapUserCode(string code, out int lineOffset)
+        {
+            var body = code.Replace("\r\n", "\n").Split('\n');
+            var hoisted = new List<string>();
+            for (int i = 0; i < body.Length; i++)
+            {
+                string trimmed = body[i].Trim();
+                if (trimmed.Length == 0 || trimmed.StartsWith("//")) continue;
+                if (!IsUsingDirective(body[i])) break;
+                if (!BuiltinUsings.Contains(trimmed) && !hoisted.Contains(trimmed)) hoisted.Add(trimmed);
+                body[i] = string.Empty;
+            }
+
             var sb = new StringBuilder();
-            sb.AppendLine("using System;");
-            sb.AppendLine("using System.Collections.Generic;");
-            sb.AppendLine("using System.Linq;");
-            sb.AppendLine("using System.Reflection;");
-            sb.AppendLine("using UnityEngine;");
-            sb.AppendLine("using UnityEditor;");
+            foreach (string u in BuiltinUsings) sb.AppendLine(u);
+            foreach (string u in hoisted) sb.AppendLine(u);
             sb.AppendLine($"public static class {WrapperClassName}");
             sb.AppendLine("{");
             sb.AppendLine($"    public static object {WrapperMethodName}()");
             sb.AppendLine("    {");
-            sb.AppendLine(code);
+            sb.AppendLine(string.Join("\n", body));
             sb.AppendLine("    }");
             sb.AppendLine("}");
+            // 4 = the class line, its brace, the method line, its brace
+            lineOffset = BuiltinUsings.Length + hoisted.Count + 4;
             return sb.ToString();
         }
 
@@ -663,6 +695,7 @@ namespace MCPForUnity.Editor.Tools
             _isAvailable = null;
         }
 
+
         private static bool Initialize()
         {
             try
@@ -752,7 +785,7 @@ namespace MCPForUnity.Editor.Tools
             }
         }
 
-        public static Assembly Compile(string source, string[] assemblyPaths, out List<string> errors)
+        public static Assembly Compile(string source, string[] assemblyPaths, int lineOffset, out List<string> errors)
         {
             errors = new List<string>();
 
@@ -837,7 +870,7 @@ namespace MCPForUnity.Editor.Tools
                             var msgProp = diag.GetType().GetMethod("GetMessage", new[] { typeof(System.Globalization.CultureInfo) });
                             string msg = (string)msgProp.Invoke(diag, new object[] { null });
 
-                            int userLine = Math.Max(1, line + 1 - ExecuteCode.WrapperLineOffset);
+                            int userLine = Math.Max(1, line + 1 - lineOffset);
                             errors.Add($"Line {userLine}: {msg}");
                         }
                         return null;

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
@@ -596,6 +596,62 @@ namespace MCPForUnityTests.Editor.Tools
             StringAssert.Contains("Line 3", errors);
         }
 
+        [Test]
+        public void Execute_UsingWithTrailingComment_IsHoisted()
+        {
+            var result = Execute("using System.IO; // needed for Path\nreturn Path.GetFileName(\"/a/b.txt\");");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("b.txt", result["data"]["result"].Value<string>());
+        }
+
+        [Test]
+        public void Execute_UsingAfterBlockComment_IsStillHoisted()
+        {
+            var result = Execute("/* lead\n   in */\nusing System.IO;\nreturn Path.GetFileName(\"/a/c.txt\");");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("c.txt", result["data"]["result"].Value<string>());
+        }
+
+        [Test]
+        public void Execute_UsingBehindInlineBlockComment_IsHoisted()
+        {
+            var result = Execute("/* why */ using System.IO;\nreturn Path.GetFileName(\"/a/d.txt\");");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("d.txt", result["data"]["result"].Value<string>());
+        }
+
+        // ──────────────────── Execute: hoisting must not widen safety_checks ────────────────────
+
+        [Test]
+        public void Execute_HoistedNamespace_DoesNotBypassSafetyChecks()
+        {
+            var result = Execute("using System.IO;\nFile.Delete(\"/tmp/mcp-does-not-exist\");\nreturn 1;");
+
+            Assert.IsFalse(result.Value<bool>("success"), result.ToString());
+            StringAssert.Contains("Blocked pattern", result.Value<string>("error"));
+        }
+
+        [Test]
+        public void Execute_AliasedType_DoesNotBypassSafetyChecks()
+        {
+            var result = Execute("using F = System.IO.File;\nF.Delete(\"/tmp/mcp-does-not-exist\");\nreturn 1;");
+
+            Assert.IsFalse(result.Value<bool>("success"), result.ToString());
+            StringAssert.Contains("Blocked pattern", result.Value<string>("error"));
+        }
+
+        [Test]
+        public void Execute_UsingStatic_DoesNotBypassSafetyChecks()
+        {
+            var result = Execute("using static System.Diagnostics.Process;\nStart(\"ls\");\nreturn 1;");
+
+            Assert.IsFalse(result.Value<bool>("success"), result.ToString());
+            StringAssert.Contains("Blocked pattern", result.Value<string>("error"));
+        }
+
         private static JObject Execute(string code)
         {
             return ToJObject(ExecuteCode.HandleCommand(new JObject

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
@@ -537,6 +537,65 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.IsFalse(results.Errors.HasErrors, string.Join("\n", errors));
         }
 
+
+        // ──────────────────── Execute: using directives ────────────────────
+
+        [Test]
+        public void Execute_LeadingUsingDirective_IsHoistedAndCompiles()
+        {
+            var result = Execute("using System.IO;\nreturn Path.GetFileName(\"/a/b.txt\");");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("b.txt", result["data"]["result"].Value<string>());
+        }
+
+        [Test]
+        public void Execute_UsingStaticDirective_IsHoisted()
+        {
+            var result = Execute("using static System.Math;\nreturn Max(3, 4);");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual(4, result["data"]["result"].Value<int>());
+        }
+
+        [Test]
+        public void Execute_UsingAliasWithGenericTarget_IsHoisted()
+        {
+            var result = Execute("using L = System.Collections.Generic.List<int>;\nreturn new L { 1, 2 }.Count;");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual(2, result["data"]["result"].Value<int>());
+        }
+
+        [Test]
+        public void Execute_UsingAfterComment_IsStillHoisted()
+        {
+            var result = Execute("// leading comment\nusing System.IO;\nreturn Path.GetFileName(\"/x/y.txt\");");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("y.txt", result["data"]["result"].Value<string>());
+        }
+
+
+        [Test]
+        public void Execute_RedundantBuiltinUsing_DoesNotDuplicate()
+        {
+            var result = Execute("using System;\nreturn String.Concat(\"a\", \"b\");");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("ab", result["data"]["result"].Value<string>());
+        }
+
+        [Test]
+        public void Execute_ErrorLineNumber_CountsFromCallerCodeAfterHoisting()
+        {
+            var result = Execute("using System.IO;\nint ok = 1;\nnope();\nreturn ok;");
+
+            Assert.IsFalse(result.Value<bool>("success"), result.ToString());
+            var errors = string.Join("\n", (result["data"]["errors"] as JArray).Select(e => e.Value<string>()));
+            StringAssert.Contains("Line 3", errors);
+        }
+
         private static JObject Execute(string code)
         {
             return ToJObject(ExecuteCode.HandleCommand(new JObject


### PR DESCRIPTION
## Description
A `using` directive at the top of an `execute_code` snippet fails to compile, because the snippet is spliced into a method body where the directive is illegal. This hoists a leading run of directives into the wrapper header instead.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made
- `WrapUserCode` hoists the leading run of `using` directives into the wrapper header. Comments and blank lines are skipped; the first real statement stops the scan.
- Hoisted lines are blanked in place rather than removed, so compiler line numbers still map to what the caller wrote.
- The line offset is now derived from the generated header instead of a hardcoded `WrapperLineOffset = 10`, which silently drifted whenever the header changed. It is threaded through `CodeDomCompile` and `RoslynCompiler.Compile`.
- Directives, `using static`, and aliases (including generic and array targets) are recognised. The C# 8 `using var x = ...;` declaration deliberately is not, since hoisting it would break the body.
- 6 EditMode tests in `ExecuteCodeTests.cs`.

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f2, LinuxEditor (headless)
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `file:` — branch checked out and symlinked in as an embedded package
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): n/a, `"source": "embedded"`. Branch tested at `3722415d`.

## Testing/Screenshots/Recordings
- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

The 6 new EditMode tests are deliberately not ticked: they have not been run through the Test Runner. Every case they assert was exercised against a live editor instead, see Additional Notes. No Python changed.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

No tool or resource is added, removed, or re-signatured. One caveat below.

## Related Issues
None.

## Additional Notes

**How this was verified.** The 6 assertions were run as live `execute_code` calls against a headless 2022.3.62f2 editor with this branch loaded as the package, under both compiler backends:

| case | `auto` | forced `codedom` |
|---|---|---|
| leading `using System.IO;` hoisted | pass | pass |
| `using static System.Math;` | pass | pass |
| generic alias `using L = List<int>;` | pass | pass |
| `using` after a leading comment | pass | pass |
| redundant builtin `using System;` not duplicated | pass | pass |
| error line still points at caller line 3 | pass | pass |

Both backends matter because on this branch alone `auto` resolves to CodeDom, i.e. C# 6. An earlier draft included a `using var x = ...;` case, which is C# 8 and failed under CodeDom; it moved to the Roslyn PR below, where the language version is guaranteed.

**Doc caveat.** The `code` parameter is documented as "Must be a valid method body." That is now slightly narrow, since a leading run of `using` directives is accepted and hoisted. It is a one-line change in `execute_code.py` plus a docs regen: happy to add it here or leave it for a follow-up.

**Related PR.** `fix(execute_code): load Roslyn from Unity instead of falling back to C# 6` also touches `ExecuteCode.cs`. Whichever lands second needs a rebase. This one is the better base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Execute Code now supports leading `using` directives, including `using static`, aliases, generic type aliases, and directives following comments.
  - Common `System.Text` functionality is available by default in executed snippets.

- **Bug Fixes**
  - Improved error reporting so line numbers correctly correspond to submitted code, even when using directives are present.
  - Prevented duplicate handling of standard built-in namespaces.
  - Strengthened safety checks to prevent namespace imports, aliases, or static imports from bypassing blocked-operation protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->