### PR TITLE
feat(refresh_unity): return console errors with the refresh

### DIFF
--- a/MCPForUnity/Editor/Tools/RefreshUnity.cs
+++ b/MCPForUnity/Editor/Tools/RefreshUnity.cs
@@ -118,10 +118,34 @@ namespace MCPForUnity.Editor.Tools
                 refresh_triggered = refreshTriggered,
                 compile_requested = compileRequested,
                 resulting_state = resultingState,
+                console_errors = shouldWaitForReady ? ConsoleErrors() : null,
                 hint = shouldWaitForReady
-                    ? "Unity refresh completed; editor should be ready."
+                    ? "Unity refresh completed; editor should be ready. console_errors holds what read_console would return."
                     : "If Unity enters compilation/domain reload, poll the mcpforunity://editor/state resource until data.advice.ready_for_tools is true."
             });
+        }
+
+        // Callers refresh to learn whether the code compiled, then always read_console for errors
+        private static object ConsoleErrors()
+        {
+            try
+            {
+                var res = ReadConsole.HandleCommand(JObject.FromObject(new
+                {
+                    action = "get",
+                    types = new[] { "error" },
+                    count = 20,
+                    format = "plain",
+                    include_stacktrace = false,
+                }));
+                // A null Data would read as "compiled clean", so never let a failed read look like one
+                if (res is SuccessResponse ok) return ok.Data ?? new object[0];
+                return new { error = (res as ErrorResponse)?.Error ?? "console_read_failed" };
+            }
+            catch (Exception ex)
+            {
+                return new { error = $"console_read_failed: {ex.Message}" };
+            }
         }
 
         private static Task WaitForUnityReadyAsync(TimeSpan timeout)

--- a/Server/src/services/tools/refresh_unity.py
+++ b/Server/src/services/tools/refresh_unity.py
@@ -61,6 +61,35 @@ async def wait_for_editor_ready(ctx: Context, timeout_s: float = 30.0) -> tuple[
     return (False, time.monotonic() - start)
 
 
+async def _reread_payload_after_reconnect(unity_instance: str | None) -> dict[str, Any] | None:
+    """Fetch the payload the lost response would have carried.
+
+    The reload closes the connection mid-command, so the original response cannot be
+    reconstructed - ask again once the editor is back. compile stays "none" so the
+    re-read cannot trigger a second reload (#577).
+    """
+    try:
+        response = await unity_transport.send_with_unity_instance(
+            _legacy_conn.async_send_command_with_retry,
+            unity_instance,
+            "refresh_unity",
+            {"mode": "if_dirty", "scope": "all",
+                "compile": "none", "wait_for_ready": True},
+            retry_on_reload=False,
+        )
+    except Exception as e:
+        logger.warning(
+            "refresh_unity: could not re-read state after reconnect: %s", e)
+        return None
+
+    payload = response if isinstance(response, dict) else (
+        response.model_dump() if hasattr(response, "model_dump") else getattr(response, "__dict__", None))
+    if not isinstance(payload, dict) or not payload.get("success"):
+        return None
+    data = payload.get("data")
+    return data if isinstance(data, dict) else None
+
+
 def is_reloading_rejection(resp: Any) -> bool:
     """True when Unity rejected a command because it thinks it is reloading.
 
@@ -264,10 +293,11 @@ async def refresh_unity(
         pass
 
     if recovered_from_disconnect:
+        data = await _reread_payload_after_reconnect(unity_instance) or {}
         return MCPResponse(
             success=True,
             message="Refresh recovered after Unity disconnect/retry; editor is ready.",
-            data={"recovered_from_disconnect": True},
+            data={**data, "recovered_from_disconnect": True},
         )
 
     return MCPResponse(**response_dict) if isinstance(response, dict) else response

--- a/Server/src/services/tools/refresh_unity.py
+++ b/Server/src/services/tools/refresh_unity.py
@@ -293,11 +293,13 @@ async def refresh_unity(
         pass
 
     if recovered_from_disconnect:
-        data = await _reread_payload_after_reconnect(unity_instance) or {}
+        # The re-read waits for the editor, so a caller that asked not to wait keeps the
+        # bare response rather than a hidden stall and a console_errors it opted out of
+        data = await _reread_payload_after_reconnect(unity_instance) if wait_for_ready else None
         return MCPResponse(
             success=True,
             message="Refresh recovered after Unity disconnect/retry; editor is ready.",
-            data={**data, "recovered_from_disconnect": True},
+            data={**(data or {}), "recovered_from_disconnect": True},
         )
 
     return MCPResponse(**response_dict) if isinstance(response, dict) else response

--- a/Server/tests/integration/test_refresh_unity_retry_recovery.py
+++ b/Server/tests/integration/test_refresh_unity_retry_recovery.py
@@ -105,3 +105,31 @@ async def test_reconnect_still_succeeds_when_the_reread_fails(monkeypatch):
 
     assert payload["success"] is True
     assert payload.get("data", {}).get("recovered_from_disconnect") is True
+
+
+@pytest.mark.asyncio
+async def test_no_reread_when_the_caller_asked_not_to_wait(monkeypatch):
+    """wait_for_ready=False opts out of console_errors, so the re-read must not run."""
+    from services.tools.refresh_unity import refresh_unity
+
+    ctx = DummyContext()
+    await ctx.set_state("unity_instance", "UnityMCPTests@cc8756d4cce0805a")
+
+    seen: list[dict] = []
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        if command_type == "refresh_unity":
+            seen.append(params)
+            return {"success": False, "error": "connection closed", "hint": "retry"}
+        raise ValueError(f"Unexpected command: {command_type}")
+
+    import services.tools.refresh_unity as refresh_mod
+    monkeypatch.setattr(refresh_mod.unity_transport,
+                        "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await refresh_unity(ctx, compile="request", wait_for_ready=False)
+    payload = resp.model_dump() if hasattr(resp, "model_dump") else resp
+
+    assert payload["success"] is True
+    assert payload["data"] == {"recovered_from_disconnect": True}
+    assert len(seen) == 1, "the recovery path re-read despite wait_for_ready=False"

--- a/Server/tests/integration/test_refresh_unity_retry_recovery.py
+++ b/Server/tests/integration/test_refresh_unity_retry_recovery.py
@@ -41,3 +41,67 @@ async def test_refresh_unity_recovers_from_retry_disconnect(monkeypatch):
     assert external_changes_scanner._states[inst].dirty is False
 
 
+
+
+@pytest.mark.asyncio
+async def test_reconnect_rereads_the_payload_it_lost(monkeypatch):
+    """The disconnect drops the tool payload, so console_errors must be fetched again."""
+    from services.tools.refresh_unity import refresh_unity
+
+    ctx = DummyContext()
+    await ctx.set_state("unity_instance", "UnityMCPTests@cc8756d4cce0805a")
+
+    seen: list[dict] = []
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        if command_type == "refresh_unity":
+            seen.append(params)
+            if params.get("compile") == "request":
+                return {"success": False, "error": "connection closed", "hint": "retry"}
+            return {"success": True, "data": {
+                "refresh_triggered": True,
+                "console_errors": ["Assets/Foo.cs(1,1): error CS0246: nope"],
+            }}
+        if command_type == "get_editor_state":
+            return {"success": True, "data": {"advice": {"ready_for_tools": True}}}
+        raise ValueError(f"Unexpected command: {command_type}")
+
+    import services.tools.refresh_unity as refresh_mod
+    monkeypatch.setattr(refresh_mod.unity_transport,
+                        "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await refresh_unity(ctx, compile="request", wait_for_ready=True)
+    payload = resp.model_dump() if hasattr(resp, "model_dump") else resp
+    data = payload.get("data", {})
+
+    assert payload["success"] is True
+    assert data.get("recovered_from_disconnect") is True
+    assert data.get("console_errors") == [
+        "Assets/Foo.cs(1,1): error CS0246: nope"]
+    assert seen[-1]["compile"] == "none", "the re-read must not trigger a second reload"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_still_succeeds_when_the_reread_fails(monkeypatch):
+    """A failed re-read must not turn a recovered refresh into an error."""
+    from services.tools.refresh_unity import refresh_unity
+
+    ctx = DummyContext()
+    await ctx.set_state("unity_instance", "UnityMCPTests@cc8756d4cce0805a")
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        if command_type == "refresh_unity":
+            return {"success": False, "error": "connection closed", "hint": "retry"}
+        if command_type == "get_editor_state":
+            return {"success": True, "data": {"advice": {"ready_for_tools": True}}}
+        raise ValueError(f"Unexpected command: {command_type}")
+
+    import services.tools.refresh_unity as refresh_mod
+    monkeypatch.setattr(refresh_mod.unity_transport,
+                        "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await refresh_unity(ctx, compile="request", wait_for_ready=True)
+    payload = resp.model_dump() if hasattr(resp, "model_dump") else resp
+
+    assert payload["success"] is True
+    assert payload.get("data", {}).get("recovered_from_disconnect") is True


### PR DESCRIPTION
## Description

A session that calls `refresh_unity` almost never wants to know that the refresh
happened. It wants to know whether the code compiled. So it refreshes, then immediately
calls `read_console` with `types=['error']` — 501 of 618 refreshes in one project's
history do exactly that.

This makes `refresh_unity` answer that question itself, in both halves of the system:

- **C#** — the response carries a `console_errors` field holding what the follow-up
  `read_console` would have returned.
- **Python** — the reconnect path stops discarding it.

The second half is not a nice-to-have. `compile="request"` triggers a domain reload,
which closes the connection mid-command, so the response is never received. The recovery
path correctly treats that as success but returns only
`{"recovered_from_disconnect": true}` — the whole payload is dropped.

| Call shape | Refreshes | Followed by read_console | Payload reaches caller |
|---|---|---|---|
| `compile != 'request'` | 144 | 87 | yes |
| `compile == 'request'` | 474 | 414 | no, discarded |

Without the Python half, the C# half reaches the caller in 87 of 501 cases.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made

`MCPForUnity/Editor/Tools/RefreshUnity.cs`
- `console_errors` in the success payload, populated only when the handler actually
  waited for readiness — otherwise the read would race the compile.
- A failed console read returns `{error: ...}`, never `null`. A null there would read as
  "compiled clean", which is the one wrong answer this must not give.

`Server/src/services/tools/refresh_unity.py`
- `_reread_payload_after_reconnect()`: once the editor is ready again, re-send
  `refresh_unity` with `compile="none"` so the re-read cannot itself trigger a second
  domain reload (#577).
- The `recovered_from_disconnect` branch merges that payload into its response.
  `recovered_from_disconnect: true` is still set, so nothing keyed on it breaks.
- A failed re-read falls back to the previous stub rather than turning a recovered
  refresh into an error. Recovery is strictly non-regressing.

## Compatibility / Package Source

- Unity version(s) tested: 2022.3.62f2
- Package source used: `file:` (local checkout)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (local package)

The `console_errors` field is additive. Existing callers ignore it.

## Testing/Screenshots/Recordings

- [x] Python tests (`cd Server && uv run pytest tests/ -v`) — 1376 passed, 3 skipped
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

Verified live against a 2022.3 editor over HTTP transport on four editors: `refresh_unity`
returns a populated `console_errors` array, and on the unpatched server the disconnect
path returned exactly `{"recovered_from_disconnect": true}` where the patched one returns
the full payload.

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

No tool or resource was added, removed, or resignatured — only the data `refresh_unity`
returns.

## Related Issues

Relates to #577

## Additional Notes

The disconnect is timing-dependent and does not reproduce on demand — repeated forced
recompiles mostly kept the connection alive. The recovery branch is covered by two tests
rather than a live capture.

Worth checking whether other long-running tools lose their payload the same way. Anything
that triggers a domain reload goes through this path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refresh results now include up to 20 Unity console errors when waiting for readiness.
  - Console-reading failures are reported as structured errors instead of appearing as successful results.
  - Refresh recovery after a disconnect now restores available console error details when requested.
  - Recovery avoids unnecessary follow-up requests when readiness waiting is disabled.
  - Successful recovery is preserved even if restoring console details fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->