### PR TITLE
feat(transport): add a headless boot path for the HTTP plugin hub

### DIFF
--- a/MCPForUnity/Editor/Helpers/HttpEndpointUtility.cs
+++ b/MCPForUnity/Editor/Helpers/HttpEndpointUtility.cs
@@ -47,10 +47,13 @@ namespace MCPForUnity.Editor.Helpers
         }
 
         /// <summary>
-        /// Returns the normalized local HTTP base URL (always reads local pref).
+        /// Returns the normalized local HTTP base URL. UNITY_MCP_HTTP_PORT wins when set,
+        /// so a CI editor keeps its own port instead of the one a sibling last wrote.
         /// </summary>
         public static string GetLocalBaseUrl()
         {
+            if (McpHttpCiBoot.TryGetCiPort(out int ciPort)) return $"http://127.0.0.1:{ciPort}";
+
             string stored = EditorPrefs.GetString(LocalPrefKey, DefaultLocalBaseUrl);
             return NormalizeBaseUrl(stored, DefaultLocalBaseUrl, remoteScope: false);
         }
@@ -128,9 +131,12 @@ namespace MCPForUnity.Editor.Helpers
 
         /// <summary>
         /// Returns true if the active HTTP transport scope is "remote".
+        /// Always false under UNITY_MCP_HTTP_PORT: the CI endpoint is local by construction.
         /// </summary>
         public static bool IsRemoteScope()
         {
+            if (McpHttpCiBoot.TryGetCiPort(out _)) return false;
+
             string scope = EditorConfigurationCache.Instance.HttpTransportScope;
             return string.Equals(scope, "remote", StringComparison.OrdinalIgnoreCase);
         }

--- a/MCPForUnity/Editor/McpHttpCiBoot.cs
+++ b/MCPForUnity/Editor/McpHttpCiBoot.cs
@@ -1,5 +1,4 @@
 using System;
-using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Services;
 using MCPForUnity.Editor.Services.Transport;
@@ -7,51 +6,44 @@ using UnityEditor;
 
 namespace MCPForUnity.Editor
 {
-    // HTTP is a plugin-hub pull model: the bridge waits at ws://127.0.0.1:<port>/hub/plugin
-    // and the editor must dial in. StartStdioForCi forces stdio and only listens, so an
-    // editor booted that way never registers and every call returns no_unity_session.
-    //
-    // The port comes from UNITY_MCP_HTTP_PORT rather than a pref because sibling checkouts
-    // of one project share an EditorPrefs file, so a persisted HttpUrl is clobbered by
-    // whichever editor wrote last.
+    // HTTP is a plugin-hub pull model: the editor dials ws://127.0.0.1:<port>/hub/plugin
+    // StartStdioForCi only listens, so an editor booted that way never registers
     public static class McpHttpCiBoot
     {
         private const string PortEnv = "UNITY_MCP_HTTP_PORT";
 
-        // Re-asserted on every domain load so a reload cannot resume a sibling's port
-        [InitializeOnLoadMethod]
-        private static void ReassertEndpointFromEnv()
+        // Never persisted: sibling checkouts share one EditorPrefs file, so the last writer wins
+        public static bool TryGetCiPort(out int port)
         {
-            ApplyEndpointFromEnv();
+            port = 0;
+            string raw = Environment.GetEnvironmentVariable(PortEnv);
+            return !string.IsNullOrWhiteSpace(raw)
+                   && int.TryParse(raw, out port)
+                   && port > 0
+                   && port <= 65535;
         }
 
         public static void StartHttpForCi()
         {
-            if (!ApplyEndpointFromEnv())
+            if (!TryGetCiPort(out _))
             {
                 McpLog.Error($"[MCPForUnity] StartHttpForCi: {PortEnv} not set or invalid; cannot start HTTP transport");
                 return;
             }
 
             // Defer the connect so MCPServiceLocator and friends are initialized.
-            EditorApplication.delayCall += () =>
+            EditorApplication.delayCall += async () =>
             {
-                _ = MCPServiceLocator.TransportManager.StartAsync(TransportMode.Http);
+                try
+                {
+                    if (!await MCPServiceLocator.TransportManager.StartAsync(TransportMode.Http))
+                        McpLog.Error("[MCPForUnity] StartHttpForCi: HTTP transport failed to start");
+                }
+                catch (Exception e)
+                {
+                    McpLog.Error($"[MCPForUnity] StartHttpForCi: HTTP transport threw on start: {e}");
+                }
             };
-        }
-
-        private static bool ApplyEndpointFromEnv()
-        {
-            string portStr = Environment.GetEnvironmentVariable(PortEnv);
-            if (string.IsNullOrWhiteSpace(portStr) || !int.TryParse(portStr, out int port) || port <= 0)
-            {
-                return false;
-            }
-
-            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
-            EditorPrefs.SetString(EditorPrefKeys.HttpTransportScope, "local");
-            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, $"http://127.0.0.1:{port}");
-            return true;
         }
     }
 }

--- a/MCPForUnity/Editor/McpHttpCiBoot.cs
+++ b/MCPForUnity/Editor/McpHttpCiBoot.cs
@@ -1,0 +1,57 @@
+using System;
+using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Services;
+using MCPForUnity.Editor.Services.Transport;
+using UnityEditor;
+
+namespace MCPForUnity.Editor
+{
+    // HTTP is a plugin-hub pull model: the bridge waits at ws://127.0.0.1:<port>/hub/plugin
+    // and the editor must dial in. StartStdioForCi forces stdio and only listens, so an
+    // editor booted that way never registers and every call returns no_unity_session.
+    //
+    // The port comes from UNITY_MCP_HTTP_PORT rather than a pref because sibling checkouts
+    // of one project share an EditorPrefs file, so a persisted HttpUrl is clobbered by
+    // whichever editor wrote last.
+    public static class McpHttpCiBoot
+    {
+        private const string PortEnv = "UNITY_MCP_HTTP_PORT";
+
+        // Re-asserted on every domain load so a reload cannot resume a sibling's port
+        [InitializeOnLoadMethod]
+        private static void ReassertEndpointFromEnv()
+        {
+            ApplyEndpointFromEnv();
+        }
+
+        public static void StartHttpForCi()
+        {
+            if (!ApplyEndpointFromEnv())
+            {
+                McpLog.Error($"[MCPForUnity] StartHttpForCi: {PortEnv} not set or invalid; cannot start HTTP transport");
+                return;
+            }
+
+            // Defer the connect so MCPServiceLocator and friends are initialized.
+            EditorApplication.delayCall += () =>
+            {
+                _ = MCPServiceLocator.TransportManager.StartAsync(TransportMode.Http);
+            };
+        }
+
+        private static bool ApplyEndpointFromEnv()
+        {
+            string portStr = Environment.GetEnvironmentVariable(PortEnv);
+            if (string.IsNullOrWhiteSpace(portStr) || !int.TryParse(portStr, out int port) || port <= 0)
+            {
+                return false;
+            }
+
+            EditorPrefs.SetBool(EditorPrefKeys.UseHttpTransport, true);
+            EditorPrefs.SetString(EditorPrefKeys.HttpTransportScope, "local");
+            EditorPrefs.SetString(EditorPrefKeys.HttpBaseUrl, $"http://127.0.0.1:{port}");
+            return true;
+        }
+    }
+}

--- a/MCPForUnity/Editor/McpHttpCiBoot.cs.meta
+++ b/MCPForUnity/Editor/McpHttpCiBoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fff0044fbf5420d8be6c5bb79828276
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
An editor booted headlessly for CI over the HTTP transport never registers with the bridge, so every tool call returns `no_unity_session` against a perfectly healthy editor. This adds the missing boot entry point.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made
- New `MCPForUnity.Editor.McpHttpCiBoot` with `StartHttpForCi`, usable as a `-executeMethod` target.
- HTTP is a plugin-hub pull model: the bridge waits at `ws://127.0.0.1:<port>/hub/plugin` and the editor must dial in. `StartStdioForCi` forces stdio and only listens, so it cannot serve this case.
- The endpoint comes from `UNITY_MCP_HTTP_PORT` rather than a persisted pref, because sibling checkouts of one project share an `EditorPrefs` file and a stored `HttpBaseUrl` is clobbered by whichever editor wrote last.
- An `[InitializeOnLoadMethod]` re-asserts the endpoint from the env on every domain load, so a reload cannot resume a sibling's port. It is a no-op unless the variable is set, so interactive editors are unaffected.
- The connect is deferred via `EditorApplication.delayCall` so `MCPServiceLocator` is initialised first.

## Compatibility / Package Source
- Unity version(s) tested: 2022.3.62f2, LinuxEditor (headless, Xvfb)
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `file:` — branch checked out and symlinked in as an embedded package
- Resolved commit hash from `Packages/packages-lock.json` (if using a Git package URL): n/a, `"source": "embedded"`. Branch tested at `c79bd10a`.

## Testing/Screenshots/Recordings
- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

No automated test: this is an `InitializeOnLoad` boot path gated on an environment variable, so a unit test would assert little beyond the pref writes. It is covered by continuous real-world use instead, see below. No Python changed.

## Documentation Updates
- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files using:
  - [ ] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [ ] Manual review of the generated changes

No tool or resource added, removed, or modified.

## Related Issues
None.

## Additional Notes

**This is in daily production use.** Four headless editors here boot with `-executeMethod MCPForUnity.Editor.McpHttpCiBoot.StartHttpForCi` against four shared always-on HTTP servers, and have done so across many restarts, domain reloads and recompiles. Before it existed, those editors booted healthy and every tool call returned `no_unity_session`.

**The multi-checkout detail is the non-obvious part.** Several checkouts of the same project share one `EditorPrefs` file, keyed on company plus product name. Persisting the endpoint there means the last editor to write wins and the others silently dial the wrong port. Reading it from the environment on every domain load is what makes concurrent editors of one project workable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for automatically starting the local HTTP transport in CI workflows when a valid port is configured.
  * CI-configured HTTP endpoints now use the selected loopback port automatically.
  * Local endpoint detection is applied consistently when CI HTTP configuration is present.
* **Bug Fixes**
  * Invalid or missing port configurations are reported without starting the HTTP transport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->