### PR TITLE
fix(execute_code): load Roslyn from Unity instead of falling back to C# 6

### DIFF
--- a/MCPForUnity/Editor/Tools/ExecuteCode.cs
+++ b/MCPForUnity/Editor/Tools/ExecuteCode.cs
@@ -663,10 +663,32 @@ namespace MCPForUnity.Editor.Tools
             _isAvailable = null;
         }
 
+        // Unity's script updater ships a Mono-loadable Roslyn, so roslyn needs nothing installed
+        // The DotNetSdkRoslyn copy beside it is .NET Core and BadImageFormats in the editor domain
+        private static void TryLoadUnityRoslyn()
+        {
+            try
+            {
+                string dir = Path.Combine(UnityEditor.EditorApplication.applicationContentsPath, "Tools", "ScriptUpdater");
+                foreach (string name in new[] { "Microsoft.CodeAnalysis.dll", "Microsoft.CodeAnalysis.CSharp.dll" })
+                {
+                    string path = Path.Combine(dir, name);
+                    if (File.Exists(path)) Assembly.LoadFrom(path);
+                }
+            }
+            catch (Exception e)
+            {
+                McpLog.Warn($"[ExecuteCode] Could not load Unity's Roslyn: {e.Message}");
+            }
+        }
+
         private static bool Initialize()
         {
             try
             {
+                if (Type.GetType("Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree, Microsoft.CodeAnalysis.CSharp") == null)
+                    TryLoadUnityRoslyn();
+
                 _syntaxTreeType = Type.GetType("Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree, Microsoft.CodeAnalysis.CSharp");
                 _compilationType = Type.GetType("Microsoft.CodeAnalysis.CSharp.CSharpCompilation, Microsoft.CodeAnalysis.CSharp");
                 _compilationOptionsType = Type.GetType("Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions, Microsoft.CodeAnalysis.CSharp");

--- a/Server/src/services/tools/execute_code.py
+++ b/Server/src/services/tools/execute_code.py
@@ -26,7 +26,7 @@ from transport.legacy.unity_connection import async_send_command_with_retry
         "Actions: execute (run code), get_history (list past executions), "
         "replay (re-run a history entry), clear_history. "
         "NOTE: safety_checks blocks known dangerous patterns but is not a full sandbox. "
-        "Compiler options: 'auto' (Roslyn if available, else CodeDom), 'roslyn' (C# 12+, requires Microsoft.CodeAnalysis), 'codedom' (C# 6 only)."
+        "Compiler options: 'auto' and 'roslyn' both use the Roslyn that ships with Unity (C# 9); 'codedom' forces the legacy provider (C# 6 only)."
     ),
     group="scripting_ext",
     annotations=ToolAnnotations(
@@ -61,8 +61,8 @@ async def execute_code(
     compiler: Annotated[
         Literal["auto", "roslyn", "codedom"],
         "Compiler backend for 'execute' action. "
-        "'auto' uses Roslyn if Microsoft.CodeAnalysis is installed, else falls back to CodeDom. "
-        "'roslyn' forces Roslyn (C# 12+). 'codedom' forces legacy CSharpCodeProvider (C# 6). Default: auto.",
+        "'auto' and 'roslyn' both load the Roslyn shipped with the editor, which caps the language at C# 9. "
+        "'codedom' forces the legacy CSharpCodeProvider (C# 6). Default: auto.",
     ] = "auto",
 ) -> dict[str, Any]:
     unity_instance = await get_unity_instance_from_context(ctx)

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ExecuteCodeTests.cs
@@ -537,6 +537,29 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.IsFalse(results.Errors.HasErrors, string.Join("\n", errors));
         }
 
+
+        // ──────────────────── Execute: compiler selection ────────────────────
+
+        [Test]
+        public void Execute_Auto_UsesRoslynLoadedFromUnity()
+        {
+            var result = Execute("return 1;");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.AreEqual("roslyn", result["data"]["compiler"].Value<string>(),
+                "auto fell back to CodeDom, so execute_code is silently limited to C# 6");
+        }
+
+        [Test]
+        public void Execute_UsingDeclaration_CompilesUnderRoslyn()
+        {
+            // C# 8: unavailable on the CodeDom fallback, so this also pins the language version
+            var result = Execute("using var s = new System.IO.MemoryStream();\nreturn s.CanRead;");
+
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            Assert.IsTrue(result["data"]["result"].Value<bool>());
+        }
+
         private static JObject Execute(string code)
         {
             return ToJObject(ExecuteCode.HandleCommand(new JObject

--- a/website/docs/reference/tools/scripting_ext/execute_code.md
+++ b/website/docs/reference/tools/scripting_ext/execute_code.md
@@ -12,7 +12,7 @@ description: "Execute arbitrary C# code inside the Unity Editor."
 
 ## Description
 
-Execute arbitrary C# code inside the Unity Editor. The code runs as a method body with access to UnityEngine and UnityEditor namespaces. Use 'return' to send data back. Compiled in-memory — no script files created. Actions: execute (run code), get_history (list past executions), replay (re-run a history entry), clear_history. NOTE: safety_checks blocks known dangerous patterns but is not a full sandbox. Compiler options: 'auto' (Roslyn if available, else CodeDom), 'roslyn' (C# 12+, requires Microsoft.CodeAnalysis), 'codedom' (C# 6 only).
+Execute arbitrary C# code inside the Unity Editor. The code runs as a method body with access to UnityEngine and UnityEditor namespaces. Use 'return' to send data back. Compiled in-memory — no script files created. Actions: execute (run code), get_history (list past executions), replay (re-run a history entry), clear_history. NOTE: safety_checks blocks known dangerous patterns but is not a full sandbox. Compiler options: 'auto' and 'roslyn' both use the Roslyn that ships with Unity (C# 9); 'codedom' forces the legacy provider (C# 6 only).
 
 ## Parameters
 
@@ -23,7 +23,7 @@ Execute arbitrary C# code inside the Unity Editor. The code runs as a method bod
 | `safety_checks` | `bool` | — | Enable basic blocked-pattern checks (File.Delete, Process.Start, infinite loops, etc). Not a full sandbox — advanced bypass is possible. Default: true. |
 | `index` | `int \| None` | — | History entry index to replay (for 'replay' action). |
 | `limit` | `int` | — | Number of history entries to return (for 'get_history' action, 1-50). Default: 10. |
-| `compiler` | `Literal['auto', 'roslyn', 'codedom']` | — | Compiler backend for 'execute' action. 'auto' uses Roslyn if Microsoft.CodeAnalysis is installed, else falls back to CodeDom. 'roslyn' forces Roslyn (C# 12+). 'codedom' forces legacy CSharpCodeProvider (C# 6). Default: auto. |
+| `compiler` | `Literal['auto', 'roslyn', 'codedom']` | — | Compiler backend for 'execute' action. 'auto' and 'roslyn' both load the Roslyn shipped with the editor, which caps the language at C# 9. 'codedom' forces the legacy CSharpCodeProvider (C# 6). Default: auto. |
 
 ## Returns
 


### PR DESCRIPTION
## Description

`execute_code` advertises a Roslyn backend, but on a stock editor
`Microsoft.CodeAnalysis` is not loaded, so `auto` silently falls through to the CodeDom
provider and the snippet is compiled as C# 6. Nothing reports this — the call just fails
on any newer syntax, and the caller has no way to tell why.

Unity already ships a Mono-loadable Roslyn at
`EditorApplication.applicationContentsPath/Tools/ScriptUpdater`, used by its own script
updater. Loading that gets a working Roslyn with nothing installed.

The `DotNetSdkRoslyn` copy sitting beside it is .NET Core and `BadImageFormat`s in the
editor domain, so it is deliberately not used.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made

`MCPForUnity/Editor/Tools/ExecuteCode.cs`
- `TryLoadUnityRoslyn()`: when `Microsoft.CodeAnalysis.CSharp` is absent, `Assembly.LoadFrom`
  the two assemblies out of Unity's `Tools/ScriptUpdater`.

`Server/src/services/tools/execute_code.py`
- The description promised `C# 12+` and told callers `Microsoft.CodeAnalysis` had to be
  installed. Neither holds now: nothing needs installing, and the editor's copy is Roslyn
  3.11, which caps the language at C# 9. Both the tool description and the `compiler`
  parameter annotation were corrected.

`website/docs/reference/tools/scripting_ext/execute_code.md`
- Regenerated with `tools/generate_docs_reference.py`. It is the only page that changed;
  `--check` is clean afterwards.

## Compatibility / Package Source

- Unity version(s) tested: 2022.3.62f2
- Package source used: `file:` (local checkout)
- Resolved commit hash from `Packages/packages-lock.json`: n/a (local package)

The load is best-effort and wrapped in try/catch. If the path is missing on some editor
version, the behaviour is exactly what it is today: the CodeDom fallback.

## Testing/Screenshots/Recordings

- [x] Python tests (`cd Server && uv run pytest tests/ -v`) — 1374 passed, 3 skipped
- [x] Unity EditMode tests
- [ ] Unity PlayMode tests
- [x] Package import/compile check
- [ ] Not applicable (explain why in Additional Notes)

`ExecuteCodeTests`: 46 total, 46 passed, on 2022.3.62f2. Two are new:

- `Execute_Auto_UsesRoslynLoadedFromUnity` — asserts `compiler == "roslyn"`, so a silent
  regression back to CodeDom fails the build instead of quietly capping the language.
- `Execute_UsingDeclaration_CompilesUnderRoslyn` — a C# 8 `using var`, unavailable on
  CodeDom, which pins the language version rather than just the backend name.

## Documentation Updates

- [x] I have added/removed/modified tools or resources
- [x] If yes, I have updated all documentation files using:
  - [x] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [x] Manual review of the generated changes

No tool was added or removed, so `manifest.json` and the README tool lists are unchanged.

## Related Issues

None.

## Additional Notes

`tools/UPDATE_DOCS_PROMPT.md` step 4 tells you to run `python3 tools/check_docs_sync.py`.
That script does not exist in the repo. `tools/generate_docs_reference.py --check` appears
to be the current gate — worth fixing that line separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `execute_code` tool can now use the Roslyn compiler bundled with the Unity Editor when using `auto` or `roslyn`.
  - C# language support is available through C# 9, including modern syntax such as using declarations.
  - The `codedom` option remains available for legacy C# 6 compilation.

- **Documentation**
  - Updated tool descriptions and compiler-option guidance to accurately reflect compiler behavior and supported language versions.

- **Tests**
  - Added coverage confirming automatic Roslyn selection and successful compilation of C# 8 using declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->