### PR TITLE
feat: Blender Bridge — drive BlenderMCP from the Unity Editor (tool + Asset Gen panel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ from services.registry import mcp_for_unity_tool
 
 @mcp_for_unity_tool(
     description="Does something in Unity.",
-    group="core",  # core (default), vfx, animation, ui, scripting_ext, testing, probuilder, profiling, docs
+    group="core",  # core (default), vfx, animation, ui, scripting_ext, testing, probuilder, profiling, docs, asset_gen
 )
 async def manage_something(
     ctx: Context,

--- a/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
+++ b/MCPForUnity/Editor/Constants/EditorPrefKeys.cs
@@ -86,5 +86,12 @@ namespace MCPForUnity.Editor.Constants
         internal const string AssetGenOutputRoot = "MCPForUnity.AssetGen.OutputRoot";
         internal const string AssetGenAutoNormalize = "MCPForUnity.AssetGen.AutoNormalize";
         internal const string AssetGenProviderEnabledPrefix = "MCPForUnity.AssetGen.Enabled.";
+
+        // Blender Bridge (Asset Gen tab). Machine-specific, non-secret. An empty ForkPath means the
+        // addon sync / update-check features are not configured; import and screenshot still work.
+        internal const string BlenderHost = "MCPForUnity.Blender.Host";
+        internal const string BlenderPort = "MCPForUnity.Blender.Port";
+        internal const string BlenderForkPath = "MCPForUnity.Blender.ForkPath";
+        internal const string BlenderAddonsDir = "MCPForUnity.Blender.AddonsDir";
     }
 }

--- a/MCPForUnity/Editor/Helpers/BlenderBridgePrefs.cs
+++ b/MCPForUnity/Editor/Helpers/BlenderBridgePrefs.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Services.Blender;
 using UnityEditor;
 
 namespace MCPForUnity.Editor.Helpers
@@ -8,7 +9,8 @@ namespace MCPForUnity.Editor.Helpers
     /// Per-user, NON-SECRET configuration for the Blender Bridge (Asset Gen tab): where the
     /// BlenderMCP addon socket listens, where the user's blender-mcp checkout lives, and where
     /// Blender keeps its user addons. Nothing here is required for the bridge to talk to Blender;
-    /// the checkout path only unlocks addon sync and update checks.
+    /// the checkout path only unlocks addon sync and update checks. EditorPrefs is main-thread
+    /// only, so callers capture what they need (e.g. <see cref="Endpoint"/>) before going async.
     /// </summary>
     public static class BlenderBridgePrefs
     {
@@ -27,6 +29,9 @@ namespace MCPForUnity.Editor.Helpers
             get => EditorPrefs.GetInt(EditorPrefKeys.BlenderPort, DefaultPort);
             set => EditorPrefs.SetInt(EditorPrefKeys.BlenderPort, value > 0 && value <= 65535 ? value : DefaultPort);
         }
+
+        /// <summary>Host and port as one value, safe to hand to a background thread.</summary>
+        public static BlenderEndpoint Endpoint => new BlenderEndpoint(Host, Port);
 
         /// <summary>Local checkout of the blender-mcp repository (contains addon.py). Empty = not configured.</summary>
         public static string ForkPath
@@ -49,6 +54,7 @@ namespace MCPForUnity.Editor.Helpers
 
         public static string ForkAddonPath => IsForkConfigured ? ForkPath + "/" + AddonFileName : null;
 
+        /// <summary>The override when set, otherwise the newest detected user addons folder; null if none.</summary>
         public static string ResolveAddonsDir()
         {
             string o = AddonsDirOverride;
@@ -71,11 +77,13 @@ namespace MCPForUnity.Editor.Helpers
             return !string.IsNullOrEmpty(p) && File.Exists(Path.Combine(p, AddonFileName));
         }
 
+        /// <summary>Trims, converts backslashes to slashes and drops a trailing slash.</summary>
         internal static string NormalizePath(string value)
         {
             return (value ?? string.Empty).Trim().Replace('\\', '/').TrimEnd('/');
         }
 
+        /// <summary>Stores a string pref, deleting the key when the value is blank so defaults apply.</summary>
         private static void SetOrDelete(string key, string value)
         {
             if (string.IsNullOrWhiteSpace(value)) EditorPrefs.DeleteKey(key);

--- a/MCPForUnity/Editor/Helpers/BlenderBridgePrefs.cs
+++ b/MCPForUnity/Editor/Helpers/BlenderBridgePrefs.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using MCPForUnity.Editor.Constants;
+using UnityEditor;
+
+namespace MCPForUnity.Editor.Helpers
+{
+    /// <summary>
+    /// Per-user, NON-SECRET configuration for the Blender Bridge (Asset Gen tab): where the
+    /// BlenderMCP addon socket listens, where the user's blender-mcp checkout lives, and where
+    /// Blender keeps its user addons. Nothing here is required for the bridge to talk to Blender;
+    /// the checkout path only unlocks addon sync and update checks.
+    /// </summary>
+    public static class BlenderBridgePrefs
+    {
+        public const string DefaultHost = "127.0.0.1";
+        public const int DefaultPort = 9876;
+        public const string AddonFileName = "addon.py";
+
+        public static string Host
+        {
+            get => EditorPrefs.GetString(EditorPrefKeys.BlenderHost, DefaultHost);
+            set => SetOrDelete(EditorPrefKeys.BlenderHost, value);
+        }
+
+        public static int Port
+        {
+            get => EditorPrefs.GetInt(EditorPrefKeys.BlenderPort, DefaultPort);
+            set => EditorPrefs.SetInt(EditorPrefKeys.BlenderPort, value > 0 && value <= 65535 ? value : DefaultPort);
+        }
+
+        /// <summary>Local checkout of the blender-mcp repository (contains addon.py). Empty = not configured.</summary>
+        public static string ForkPath
+        {
+            get => NormalizePath(EditorPrefs.GetString(EditorPrefKeys.BlenderForkPath, string.Empty));
+            set => SetOrDelete(EditorPrefKeys.BlenderForkPath, NormalizePath(value));
+        }
+
+        /// <summary>
+        /// Blender's user addons directory. Empty = auto-detect the newest
+        /// &lt;user config&gt;/Blender/&lt;version&gt;/scripts/addons that already has the addon installed.
+        /// </summary>
+        public static string AddonsDirOverride
+        {
+            get => NormalizePath(EditorPrefs.GetString(EditorPrefKeys.BlenderAddonsDir, string.Empty));
+            set => SetOrDelete(EditorPrefKeys.BlenderAddonsDir, NormalizePath(value));
+        }
+
+        public static bool IsForkConfigured => !string.IsNullOrEmpty(ForkPath);
+
+        public static string ForkAddonPath => IsForkConfigured ? ForkPath + "/" + AddonFileName : null;
+
+        public static string ResolveAddonsDir()
+        {
+            string o = AddonsDirOverride;
+            return !string.IsNullOrEmpty(o) ? o : BlenderDetection.FindUserAddonsDir(AddonFileName);
+        }
+
+        public static string InstalledAddonPath
+        {
+            get
+            {
+                string dir = ResolveAddonsDir();
+                return string.IsNullOrEmpty(dir) ? null : dir + "/" + AddonFileName;
+            }
+        }
+
+        /// <summary>True when the checkout path points at a folder that actually contains addon.py.</summary>
+        public static bool IsValidForkPath(string path)
+        {
+            string p = NormalizePath(path);
+            return !string.IsNullOrEmpty(p) && File.Exists(Path.Combine(p, AddonFileName));
+        }
+
+        internal static string NormalizePath(string value)
+        {
+            return (value ?? string.Empty).Trim().Replace('\\', '/').TrimEnd('/');
+        }
+
+        private static void SetOrDelete(string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) EditorPrefs.DeleteKey(key);
+            else EditorPrefs.SetString(key, value.Trim());
+        }
+    }
+}

--- a/MCPForUnity/Editor/Helpers/BlenderBridgePrefs.cs.meta
+++ b/MCPForUnity/Editor/Helpers/BlenderBridgePrefs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 029b420c97f34c738e98b875fe56bf73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Helpers/BlenderDetection.cs
+++ b/MCPForUnity/Editor/Helpers/BlenderDetection.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace MCPForUnity.Editor.Helpers
 {
     /// <summary>
-    /// Best-effort detection of a locally installed Blender application, for the Asset Gen tab's
-    /// "Blender → Unity handoff" hint. This finds the Blender APP only — it cannot tell whether the
-    /// BlenderMCP server is configured in the user's AI client (that lives outside Unity).
+    /// Best-effort detection of a locally installed Blender application and of Blender's per-user
+    /// addons folders, for the Asset Gen tab's Blender Bridge. This finds the Blender APP and its
+    /// config folders only — whether the BlenderMCP addon is running is a socket question answered
+    /// by the bridge itself.
     /// </summary>
     internal static class BlenderDetection
     {
@@ -75,6 +77,85 @@ namespace MCPForUnity.Editor.Helpers
                     break;
             }
             return list;
+        }
+
+        /// <summary>
+        /// Blender's per-user config roots (the folder that holds one subfolder per Blender version):
+        /// %APPDATA%/Blender Foundation/Blender on Windows, ~/Library/Application Support/Blender on
+        /// macOS, $XDG_CONFIG_HOME/blender or ~/.config/blender on Linux.
+        /// </summary>
+        internal static IEnumerable<string> UserConfigRoots()
+        {
+            var list = new List<string>();
+            switch (Application.platform)
+            {
+                case RuntimePlatform.WindowsEditor:
+                    string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                    if (!string.IsNullOrEmpty(appData))
+                        list.Add(Path.Combine(appData, "Blender Foundation", "Blender"));
+                    break;
+                case RuntimePlatform.OSXEditor:
+                    string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                    if (!string.IsNullOrEmpty(home))
+                        list.Add(Path.Combine(home, "Library", "Application Support", "Blender"));
+                    break;
+                case RuntimePlatform.LinuxEditor:
+                    string xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+                    string linuxHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                    if (!string.IsNullOrEmpty(xdg)) list.Add(Path.Combine(xdg, "blender"));
+                    else if (!string.IsNullOrEmpty(linuxHome)) list.Add(Path.Combine(linuxHome, ".config", "blender"));
+                    break;
+            }
+            return list;
+        }
+
+        /// <summary>&lt;root&gt;/&lt;X.Y&gt;/scripts/addons for every versioned config folder, newest version first.</summary>
+        internal static IEnumerable<string> UserAddonsDirs()
+        {
+            var found = new List<(Version Ver, string Dir)>();
+            foreach (string root in UserConfigRoots())
+            {
+                try
+                {
+                    if (!Directory.Exists(root)) continue;
+                    foreach (string d in Directory.GetDirectories(root))
+                    {
+                        Version v = ParseVersion(Path.GetFileName(d));
+                        if (v != null) found.Add((v, Path.Combine(d, "scripts", "addons")));
+                    }
+                }
+                catch { /* unreadable dir; ignore */ }
+            }
+            return found.OrderByDescending(x => x.Ver).Select(x => x.Dir.Replace('\\', '/')).ToList();
+        }
+
+        /// <summary>Newest user addons dir that already contains <paramref name="fileName"/>, else the newest one, else null.</summary>
+        internal static string FindUserAddonsDir(string fileName)
+        {
+            try { return PickAddonsDir(UserAddonsDirs(), File.Exists, fileName); }
+            catch { return null; }
+        }
+
+        /// <summary>Pure core of <see cref="FindUserAddonsDir"/>. Testable.</summary>
+        internal static string PickAddonsDir(IEnumerable<string> dirsNewestFirst, Func<string, bool> fileExists, string fileName)
+        {
+            if (dirsNewestFirst == null) return null;
+            string first = null;
+            foreach (string d in dirsNewestFirst)
+            {
+                if (string.IsNullOrEmpty(d)) continue;
+                first ??= d;
+                if (!string.IsNullOrEmpty(fileName) && fileExists != null && fileExists(d.TrimEnd('/') + "/" + fileName))
+                    return d;
+            }
+            return first;
+        }
+
+        /// <summary>Parses a Blender version folder name ("4.2", "5.2") into a comparable Version; null if it is not one.</summary>
+        internal static Version ParseVersion(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return null;
+            return Version.TryParse(name.Contains('.') ? name : name + ".0", out Version v) ? v : null;
         }
     }
 }

--- a/MCPForUnity/Editor/MenuItems/BlenderBridgeMenu.cs
+++ b/MCPForUnity/Editor/MenuItems/BlenderBridgeMenu.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using MCPForUnity.Editor.Constants;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Tools.Blender;
@@ -11,31 +12,36 @@ namespace MCPForUnity.Editor.MenuItems
     /// <summary>
     /// Menu entry points that drive the same code path as the blender_bridge tool, so the
     /// Blender handoff works without any AI client attached. Settings live in the Generative tab.
+    /// Actions are awaited so the editor stays responsive while Blender exports.
     /// </summary>
     public static class BlenderBridgeMenu
     {
         private const string Root = ProductInfo.MenuRoot + "/Blender Bridge/";
 
+        /// <summary>Exports Blender's current selection as GLB and places it in the open scene.</summary>
         [MenuItem(Root + "Import Selection From Blender (GLB)", priority = 20)]
-        private static void ImportSelection()
+        private static async void ImportSelection()
         {
-            Run(new JObject { ["action"] = "import_model", ["selection_only"] = true, ["format"] = "glb" });
+            await RunAsync(new JObject { ["action"] = "import_model", ["selection_only"] = true, ["format"] = "glb" });
         }
 
+        /// <summary>Exports Blender's whole scene as GLB and places it in the open scene.</summary>
         [MenuItem(Root + "Import Whole Scene From Blender (GLB)", priority = 21)]
-        private static void ImportScene()
+        private static async void ImportScene()
         {
-            Run(new JObject { ["action"] = "import_model", ["format"] = "glb", ["name"] = "BlenderScene" });
+            await RunAsync(new JObject { ["action"] = "import_model", ["format"] = "glb", ["name"] = "BlenderScene" });
         }
 
+        /// <summary>Captures Blender's viewport and reveals the PNG.</summary>
         [MenuItem(Root + "Blender Viewport Screenshot", priority = 22)]
-        private static void Screenshot()
+        private static async void Screenshot()
         {
-            JObject r = Run(new JObject { ["action"] = "screenshot" });
+            JObject r = await RunAsync(new JObject { ["action"] = "screenshot" });
             string path = r?["data"]?["path"]?.ToString();
             if (!string.IsNullOrEmpty(path)) EditorUtility.RevealInFinder(path);
         }
 
+        /// <summary>Opens the MCP for Unity window; the Blender Bridge panel is in its Generative tab.</summary>
         [MenuItem(Root + "Settings...", priority = 40)]
         private static void OpenSettings()
         {
@@ -43,9 +49,10 @@ namespace MCPForUnity.Editor.MenuItems
             McpLog.Info("Blender Bridge settings are in the Generative tab of the MCP for Unity window.");
         }
 
-        private static JObject Run(JObject parameters)
+        /// <summary>Runs one bridge action and logs its full result.</summary>
+        private static async Task<JObject> RunAsync(JObject parameters)
         {
-            object result = BlenderBridgeTool.HandleCommand(parameters);
+            object result = await BlenderBridgeTool.HandleCommand(parameters);
             JObject json = JObject.FromObject(result);
             bool ok = json.Value<bool?>("success") ?? false;
             string text = json.ToString(Formatting.Indented);

--- a/MCPForUnity/Editor/MenuItems/BlenderBridgeMenu.cs
+++ b/MCPForUnity/Editor/MenuItems/BlenderBridgeMenu.cs
@@ -1,0 +1,57 @@
+using MCPForUnity.Editor.Constants;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Tools.Blender;
+using MCPForUnity.Editor.Windows;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+
+namespace MCPForUnity.Editor.MenuItems
+{
+    /// <summary>
+    /// Menu entry points that drive the same code path as the blender_bridge tool, so the
+    /// Blender handoff works without any AI client attached. Settings live in the Generative tab.
+    /// </summary>
+    public static class BlenderBridgeMenu
+    {
+        private const string Root = ProductInfo.MenuRoot + "/Blender Bridge/";
+
+        [MenuItem(Root + "Import Selection From Blender (GLB)", priority = 20)]
+        private static void ImportSelection()
+        {
+            Run(new JObject { ["action"] = "import_model", ["selection_only"] = true, ["format"] = "glb" });
+        }
+
+        [MenuItem(Root + "Import Whole Scene From Blender (GLB)", priority = 21)]
+        private static void ImportScene()
+        {
+            Run(new JObject { ["action"] = "import_model", ["format"] = "glb", ["name"] = "BlenderScene" });
+        }
+
+        [MenuItem(Root + "Blender Viewport Screenshot", priority = 22)]
+        private static void Screenshot()
+        {
+            JObject r = Run(new JObject { ["action"] = "screenshot" });
+            string path = r?["data"]?["path"]?.ToString();
+            if (!string.IsNullOrEmpty(path)) EditorUtility.RevealInFinder(path);
+        }
+
+        [MenuItem(Root + "Settings...", priority = 40)]
+        private static void OpenSettings()
+        {
+            MCPForUnityEditorWindow.ShowWindow();
+            McpLog.Info("Blender Bridge settings are in the Generative tab of the MCP for Unity window.");
+        }
+
+        private static JObject Run(JObject parameters)
+        {
+            object result = BlenderBridgeTool.HandleCommand(parameters);
+            JObject json = JObject.FromObject(result);
+            bool ok = json.Value<bool?>("success") ?? false;
+            string text = json.ToString(Formatting.Indented);
+            if (ok) McpLog.Info($"[Blender Bridge] {parameters["action"]}: {json["message"]}\n{text}");
+            else McpLog.Error($"[Blender Bridge] {parameters["action"]} failed: {json["error"]}\n{text}");
+            return json;
+        }
+    }
+}

--- a/MCPForUnity/Editor/MenuItems/BlenderBridgeMenu.cs.meta
+++ b/MCPForUnity/Editor/MenuItems/BlenderBridgeMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf5a30eff9b34262b2e15cc23f196d12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Services/Blender.meta
+++ b/MCPForUnity/Editor/Services/Blender.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5171d93ea027470b96c8930306ca0c60
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Services/Blender/BlenderSocketClient.cs
+++ b/MCPForUnity/Editor/Services/Blender/BlenderSocketClient.cs
@@ -1,0 +1,130 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using MCPForUnity.Editor.Helpers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MCPForUnity.Editor.Services.Blender
+{
+    /// <summary>
+    /// Minimal client for the BlenderMCP addon socket. Protocol: one JSON object
+    /// {"type": ..., "params": {...}} per request and one JSON object
+    /// {"status": "success"|"error", "result"|"message": ...} back, with no length framing —
+    /// the addon parses whenever the accumulated bytes form valid JSON, so this does the same.
+    /// A fresh connection is used per command so it never interleaves with the AI client's
+    /// own BlenderMCP server talking to the same addon.
+    /// </summary>
+    public static class BlenderSocketClient
+    {
+        private const int ConnectTimeoutSeconds = 3;
+
+        public static JToken Send(string type, JObject @params = null, int timeoutSeconds = 60)
+        {
+            string host = BlenderBridgePrefs.Host;
+            int port = BlenderBridgePrefs.Port;
+
+            var request = new JObject { ["type"] = type, ["params"] = @params ?? new JObject() };
+            byte[] payload = Encoding.UTF8.GetBytes(request.ToString(Formatting.None));
+
+            using var client = new TcpClient();
+            IAsyncResult connect = client.BeginConnect(host, port, null, null);
+            if (!connect.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(ConnectTimeoutSeconds)) || !client.Connected)
+            {
+                throw new BlenderUnavailableException(
+                    $"Blender addon not reachable at {host}:{port}. Start Blender and press " +
+                    "'Connect to MCP server' in the BlenderMCP sidebar (N panel).");
+            }
+            client.EndConnect(connect);
+
+            using NetworkStream stream = client.GetStream();
+            stream.ReadTimeout = Math.Max(1, timeoutSeconds) * 1000;
+            stream.Write(payload, 0, payload.Length);
+            stream.Flush();
+
+            var buffer = new MemoryStream();
+            var chunk = new byte[65536];
+            DateTime deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+            while (true)
+            {
+                int n;
+                try
+                {
+                    n = stream.Read(chunk, 0, chunk.Length);
+                }
+                catch (IOException e)
+                {
+                    throw new TimeoutException(
+                        $"Timed out after {timeoutSeconds}s waiting for Blender to answer '{type}'.", e);
+                }
+
+                if (n <= 0) break;
+                buffer.Write(chunk, 0, n);
+
+                if (TryParseResponse(buffer.GetBuffer(), (int)buffer.Length, out JObject parsed)) return Unwrap(parsed, type);
+                if (DateTime.UtcNow > deadline)
+                    throw new TimeoutException($"Timed out after {timeoutSeconds}s waiting for Blender to answer '{type}'.");
+            }
+
+            if (TryParseResponse(buffer.GetBuffer(), (int)buffer.Length, out JObject final)) return Unwrap(final, type);
+            throw new IOException($"Blender closed the connection before a complete response to '{type}' arrived.");
+        }
+
+        /// <summary>Runs Python inside Blender and returns its captured stdout.</summary>
+        public static string RunPython(string code, int timeoutSeconds = 120)
+        {
+            JToken result = Send("execute_code", new JObject { ["code"] = code }, timeoutSeconds);
+            return result?["result"]?.ToString() ?? string.Empty;
+        }
+
+        public static bool IsReachable(out string error)
+        {
+            try
+            {
+                Send("get_scene_info", null, 10);
+                error = null;
+                return true;
+            }
+            catch (Exception e)
+            {
+                error = e.Message;
+                return false;
+            }
+        }
+
+        /// <summary>True once the bytes received so far form one complete JSON object.</summary>
+        internal static bool TryParseResponse(byte[] buffer, int length, out JObject obj)
+        {
+            try
+            {
+                obj = JObject.Parse(Encoding.UTF8.GetString(buffer, 0, length));
+                return true;
+            }
+            catch
+            {
+                obj = null;
+                return false;
+            }
+        }
+
+        /// <summary>Returns the addon's "result" payload, or throws when it reported an error.</summary>
+        internal static JToken Unwrap(JObject response, string type)
+        {
+            if (string.Equals((string)response["status"], "error", StringComparison.OrdinalIgnoreCase))
+                throw new BlenderCommandException($"Blender '{type}' failed: {(string)response["message"] ?? "unknown error"}");
+            return response["result"];
+        }
+    }
+
+    public class BlenderUnavailableException : Exception
+    {
+        public BlenderUnavailableException(string message) : base(message) { }
+    }
+
+    public class BlenderCommandException : Exception
+    {
+        public BlenderCommandException(string message) : base(message) { }
+    }
+}

--- a/MCPForUnity/Editor/Services/Blender/BlenderSocketClient.cs
+++ b/MCPForUnity/Editor/Services/Blender/BlenderSocketClient.cs
@@ -2,38 +2,53 @@ using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
-using MCPForUnity.Editor.Helpers;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace MCPForUnity.Editor.Services.Blender
 {
+    /// <summary>Where the BlenderMCP addon socket listens. Captured on the main thread so I/O can run elsewhere.</summary>
+    public readonly struct BlenderEndpoint
+    {
+        public string Host { get; }
+        public int Port { get; }
+
+        public BlenderEndpoint(string host, int port)
+        {
+            Host = host;
+            Port = port;
+        }
+
+        /// <summary>Formats the endpoint as host:port.</summary>
+        public override string ToString() => $"{Host}:{Port}";
+    }
+
     /// <summary>
     /// Minimal client for the BlenderMCP addon socket. Protocol: one JSON object
     /// {"type": ..., "params": {...}} per request and one JSON object
     /// {"status": "success"|"error", "result"|"message": ...} back, with no length framing —
     /// the addon parses whenever the accumulated bytes form valid JSON, so this does the same.
     /// A fresh connection is used per command so it never interleaves with the AI client's
-    /// own BlenderMCP server talking to the same addon.
+    /// own BlenderMCP server talking to the same addon. The synchronous methods block and touch
+    /// no Unity API, so callers run them through the *Async wrappers off the editor thread.
     /// </summary>
     public static class BlenderSocketClient
     {
         private const int ConnectTimeoutSeconds = 3;
 
-        public static JToken Send(string type, JObject @params = null, int timeoutSeconds = 60)
+        /// <summary>Sends one command and blocks until the addon answers or the timeout elapses.</summary>
+        public static JToken Send(BlenderEndpoint endpoint, string type, JObject @params = null, int timeoutSeconds = 60)
         {
-            string host = BlenderBridgePrefs.Host;
-            int port = BlenderBridgePrefs.Port;
-
             var request = new JObject { ["type"] = type, ["params"] = @params ?? new JObject() };
             byte[] payload = Encoding.UTF8.GetBytes(request.ToString(Formatting.None));
 
             using var client = new TcpClient();
-            IAsyncResult connect = client.BeginConnect(host, port, null, null);
+            IAsyncResult connect = client.BeginConnect(endpoint.Host, endpoint.Port, null, null);
             if (!connect.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(ConnectTimeoutSeconds)) || !client.Connected)
             {
                 throw new BlenderUnavailableException(
-                    $"Blender addon not reachable at {host}:{port}. Start Blender and press " +
+                    $"Blender addon not reachable at {endpoint}. Start Blender and press " +
                     "'Connect to MCP server' in the BlenderMCP sidebar (N panel).");
             }
             client.EndConnect(connect);
@@ -72,26 +87,43 @@ namespace MCPForUnity.Editor.Services.Blender
             throw new IOException($"Blender closed the connection before a complete response to '{type}' arrived.");
         }
 
-        /// <summary>Runs Python inside Blender and returns its captured stdout.</summary>
-        public static string RunPython(string code, int timeoutSeconds = 120)
+        /// <summary>Runs <see cref="Send"/> on the thread pool so the editor stays responsive.</summary>
+        public static Task<JToken> SendAsync(BlenderEndpoint endpoint, string type, JObject @params = null, int timeoutSeconds = 60)
         {
-            JToken result = Send("execute_code", new JObject { ["code"] = code }, timeoutSeconds);
+            return Task.Run(() => Send(endpoint, type, @params, timeoutSeconds));
+        }
+
+        /// <summary>Runs Python inside Blender (blocking) and returns its captured stdout.</summary>
+        public static string RunPython(BlenderEndpoint endpoint, string code, int timeoutSeconds = 120)
+        {
+            JToken result = Send(endpoint, "execute_code", new JObject { ["code"] = code }, timeoutSeconds);
             return result?["result"]?.ToString() ?? string.Empty;
         }
 
-        public static bool IsReachable(out string error)
+        /// <summary>Runs <see cref="RunPython"/> on the thread pool.</summary>
+        public static Task<string> RunPythonAsync(BlenderEndpoint endpoint, string code, int timeoutSeconds = 120)
+        {
+            return Task.Run(() => RunPython(endpoint, code, timeoutSeconds));
+        }
+
+        /// <summary>Probes the addon with get_scene_info; returns whether it answered and the error text if not.</summary>
+        public static (bool Ok, string Error) Probe(BlenderEndpoint endpoint, int timeoutSeconds = 10)
         {
             try
             {
-                Send("get_scene_info", null, 10);
-                error = null;
-                return true;
+                Send(endpoint, "get_scene_info", null, timeoutSeconds);
+                return (true, null);
             }
             catch (Exception e)
             {
-                error = e.Message;
-                return false;
+                return (false, e.Message);
             }
+        }
+
+        /// <summary>Runs <see cref="Probe"/> on the thread pool.</summary>
+        public static Task<(bool Ok, string Error)> ProbeAsync(BlenderEndpoint endpoint, int timeoutSeconds = 10)
+        {
+            return Task.Run(() => Probe(endpoint, timeoutSeconds));
         }
 
         /// <summary>True once the bytes received so far form one complete JSON object.</summary>
@@ -109,20 +141,29 @@ namespace MCPForUnity.Editor.Services.Blender
             }
         }
 
-        /// <summary>Returns the addon's "result" payload, or throws when it reported an error.</summary>
+        /// <summary>
+        /// Returns the addon's "result" payload for a success response, throws
+        /// <see cref="BlenderCommandException"/> for an error response, and rejects anything else
+        /// so a malformed reply never surfaces as a successful command with a null payload.
+        /// </summary>
         internal static JToken Unwrap(JObject response, string type)
         {
-            if (string.Equals((string)response["status"], "error", StringComparison.OrdinalIgnoreCase))
+            string status = (string)response?["status"];
+            if (string.Equals(status, "success", StringComparison.OrdinalIgnoreCase))
+                return response["result"];
+            if (string.Equals(status, "error", StringComparison.OrdinalIgnoreCase))
                 throw new BlenderCommandException($"Blender '{type}' failed: {(string)response["message"] ?? "unknown error"}");
-            return response["result"];
+            throw new InvalidDataException($"Blender returned an invalid status '{status ?? "(none)"}' for '{type}'.");
         }
     }
 
+    /// <summary>The addon socket could not be reached (Blender closed or the addon not connected).</summary>
     public class BlenderUnavailableException : Exception
     {
         public BlenderUnavailableException(string message) : base(message) { }
     }
 
+    /// <summary>The addon accepted the command but reported an error while running it.</summary>
     public class BlenderCommandException : Exception
     {
         public BlenderCommandException(string message) : base(message) { }

--- a/MCPForUnity/Editor/Services/Blender/BlenderSocketClient.cs.meta
+++ b/MCPForUnity/Editor/Services/Blender/BlenderSocketClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c83ed8aaae34a829fc59df7c1a53948
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Tools/Blender.meta
+++ b/MCPForUnity/Editor/Tools/Blender.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d61fccfc880e4bd38412f8705fc73104
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
@@ -151,7 +151,7 @@ namespace MCPForUnity.Editor.Tools.Blender
 
             string dir = Path.Combine(ProjectRoot(), "Library", "BlenderBridge");
             Directory.CreateDirectory(dir);
-            string file = Path.Combine(dir, $"blender_viewport_{DateTime.Now:yyyyMMdd_HHmmss}.png").Replace('\\', '/');
+            string file = Path.Combine(dir, $"blender_viewport_{UniqueSuffix()}.png").Replace('\\', '/');
 
             JToken result = await BlenderSocketClient.SendAsync(BlenderBridgePrefs.Endpoint, "get_viewport_screenshot",
                 new JObject { ["max_size"] = maxSize, ["filepath"] = file, ["format"] = "png" }, timeout);
@@ -203,7 +203,7 @@ namespace MCPForUnity.Editor.Tools.Blender
             // 1. Export from Blender to a temp file (off the editor thread).
             string exportDir = Path.Combine(Path.GetTempPath(), "BlenderBridge");
             Directory.CreateDirectory(exportDir);
-            string exportPath = Path.Combine(exportDir, $"{name}_{DateTime.Now:yyyyMMdd_HHmmss}.{fmt}").Replace('\\', '/');
+            string exportPath = Path.Combine(exportDir, $"{name}_{UniqueSuffix()}.{fmt}").Replace('\\', '/');
 
             string script = BuildExportScript(exportPath, names, selectionOnly, applyModifiers, fmt);
             string stdout = await BlenderSocketClient.RunPythonAsync(BlenderBridgePrefs.Endpoint, script, timeout);
@@ -379,7 +379,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             {
                 var entry = new JObject { ["remote"] = remote };
                 TryGit(fork, $"remote get-url {remote}", out string url, out _);
-                entry["url"] = url.Trim();
+                entry["url"] = RedactRemoteUrl(url.Trim());
 
                 bool fetched = TryGit(fork, $"fetch --quiet {remote}", out _, out string fetchErr, 90000);
                 entry["fetched"] = fetched;
@@ -509,6 +509,30 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
                 stderr = e.Message;
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Timestamp plus a random tail for temp file names, so concurrent commands (menu + MCP) started
+        /// in the same second never share a screenshot or export path.
+        /// </summary>
+        private static string UniqueSuffix()
+            => $"{DateTime.Now:yyyyMMdd_HHmmss}_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+
+        /// <summary>
+        /// Strips user info (tokens, passwords) from a remote URL so credentials embedded in
+        /// https://user:token@host/... never reach the MCP response or the editor log.
+        /// </summary>
+        internal static string RedactRemoteUrl(string url)
+        {
+            if (string.IsNullOrEmpty(url)) return url ?? string.Empty;
+            if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri) && !string.IsNullOrEmpty(uri.UserInfo))
+                return new UriBuilder(uri) { UserName = string.Empty, Password = string.Empty }.Uri.ToString();
+            // scp-style git@host:path carries no secret; anything else with "user:secret@" is masked.
+            int at = url.IndexOf('@');
+            int scheme = url.IndexOf("://", StringComparison.Ordinal);
+            if (at > 0 && scheme >= 0 && at > scheme && url.IndexOf(':', scheme + 3) is int colon && colon > 0 && colon < at)
+                return url.Substring(0, scheme + 3) + "***@" + url.Substring(at + 1);
+            return url;
         }
 
         /// <summary>Absolute project folder (parent of Assets/), forward slashes.</summary>

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
 using MCPForUnity.Editor.Services.Blender;
@@ -22,6 +23,8 @@ namespace MCPForUnity.Editor.Tools.Blender
     /// handoff is one call (export → import through the shared model pipeline → place → normalize)
     /// instead of an AI-orchestrated multi-step dance. Also drives the Blender Bridge panel in the
     /// Asset Gen tab and the Window/MCP for Unity/Blender Bridge menu. Carries no API keys.
+    /// Socket and git work runs on the thread pool; Unity API calls happen after the await, back on
+    /// the editor thread (the bridge awaits handlers on Unity's synchronization context).
     /// </summary>
     [McpForUnityTool("blender_bridge", AutoRegister = false, Group = "asset_gen",
         Description = "Bridge to a running Blender with the BlenderMCP addon: status, scene/object info, viewport " +
@@ -36,7 +39,8 @@ namespace MCPForUnity.Editor.Tools.Blender
             "The blender-mcp checkout is not set. Open Window > MCP for Unity > Generative > Blender Bridge " +
             "and pick the folder that contains addon.py.";
 
-        public static object HandleCommand(JObject @params)
+        /// <summary>Entry point for the bridge: validates parameters, dispatches by action, and never throws.</summary>
+        public static async Task<object> HandleCommand(JObject @params)
         {
             if (@params == null) return new ErrorResponse("Parameters cannot be null.");
             var p = new ToolParams(@params);
@@ -47,28 +51,29 @@ namespace MCPForUnity.Editor.Tools.Blender
             {
                 switch (action)
                 {
-                    case "status": return Status();
+                    case "status": return await StatusAsync();
                     case "scene_info":
                         return new SuccessResponse("Retrieved Blender scene info.",
-                            BlenderSocketClient.Send("get_scene_info", null, timeout));
+                            await BlenderSocketClient.SendAsync(BlenderBridgePrefs.Endpoint, "get_scene_info", null, timeout));
                     case "object_info":
                     {
                         string objectName = p.Get("object_name");
                         if (string.IsNullOrWhiteSpace(objectName))
                             return new ErrorResponse("'object_name' is required for object_info.");
-                        return new SuccessResponse($"Retrieved info for '{objectName}'.",
-                            BlenderSocketClient.Send("get_object_info", new JObject { ["object_name"] = objectName }, timeout));
+                        JToken info = await BlenderSocketClient.SendAsync(BlenderBridgePrefs.Endpoint, "get_object_info",
+                            new JObject { ["object_name"] = objectName }, timeout);
+                        return new SuccessResponse($"Retrieved info for '{objectName}'.", info);
                     }
-                    case "screenshot": return Screenshot(p, timeout);
+                    case "screenshot": return await ScreenshotAsync(p, timeout);
                     case "run_python":
                     {
                         string code = p.Get("code");
                         if (string.IsNullOrWhiteSpace(code)) return new ErrorResponse("'code' is required for run_python.");
-                        string stdout = BlenderSocketClient.RunPython(code, timeout);
+                        string stdout = await BlenderSocketClient.RunPythonAsync(BlenderBridgePrefs.Endpoint, code, timeout);
                         return new SuccessResponse("Executed Python in Blender.", new { stdout });
                     }
-                    case "import_model": return ImportModel(p, timeout);
-                    case "check_updates": return CheckUpdates();
+                    case "import_model": return await ImportModelAsync(p, timeout);
+                    case "check_updates": return await CheckUpdatesAsync();
                     case "sync_addon": return SyncAddon(p.GetBool("force", false));
                     default:
                         return new ErrorResponse($"Unknown action '{action}'. Valid: {string.Join(", ", ValidActions)}.");
@@ -86,31 +91,37 @@ namespace MCPForUnity.Editor.Tools.Blender
 
         // ------------------------------------------------------------------ status
 
-        private static object Status()
+        /// <summary>Probes the addon socket and reports checkout / installed-addon state without failing.</summary>
+        private static async Task<object> StatusAsync()
         {
-            bool reachable = BlenderSocketClient.IsReachable(out string error);
+            BlenderEndpoint endpoint = BlenderBridgePrefs.Endpoint;
+            string forkAddon = BlenderBridgePrefs.ForkAddonPath;
+            string installedAddon = BlenderBridgePrefs.InstalledAddonPath;
+            bool forkConfigured = BlenderBridgePrefs.IsForkConfigured;
+            string forkPath = BlenderBridgePrefs.ForkPath;
+            bool blenderInstalled = BlenderDetection.IsInstalled();
+
+            var (reachable, error) = await BlenderSocketClient.ProbeAsync(endpoint);
             JToken scene = null;
             if (reachable)
             {
-                try { scene = BlenderSocketClient.Send("get_scene_info", null, 10); }
+                try { scene = await BlenderSocketClient.SendAsync(endpoint, "get_scene_info", null, 10); }
                 catch (Exception e) { error = e.Message; }
             }
 
-            string forkAddon = BlenderBridgePrefs.ForkAddonPath;
-            string installedAddon = BlenderBridgePrefs.InstalledAddonPath;
             string forkMd5 = forkAddon != null && File.Exists(forkAddon) ? FileMd5(forkAddon) : null;
             string installedMd5 = installedAddon != null && File.Exists(installedAddon) ? FileMd5(installedAddon) : null;
 
             var data = new JObject
             {
                 ["blender_reachable"] = reachable,
-                ["blender_installed"] = BlenderDetection.IsInstalled(),
-                ["endpoint"] = $"{BlenderBridgePrefs.Host}:{BlenderBridgePrefs.Port}",
+                ["blender_installed"] = blenderInstalled,
+                ["endpoint"] = endpoint.ToString(),
                 ["error"] = reachable ? null : error,
                 ["scene_name"] = scene?["name"],
                 ["object_count"] = scene?["object_count"],
-                ["fork_configured"] = BlenderBridgePrefs.IsForkConfigured,
-                ["fork_path"] = BlenderBridgePrefs.ForkPath,
+                ["fork_configured"] = forkConfigured,
+                ["fork_path"] = forkPath,
                 ["fork_addon_found"] = forkMd5 != null,
                 ["installed_addon_path"] = installedAddon,
                 ["installed_addon_found"] = installedMd5 != null,
@@ -124,30 +135,37 @@ namespace MCPForUnity.Editor.Tools.Blender
 
         // -------------------------------------------------------------- screenshot
 
-        private static object Screenshot(ToolParams p, int timeout)
+        /// <summary>Asks Blender for an offscreen viewport render and optionally copies it under Assets/.</summary>
+        private static async Task<object> ScreenshotAsync(ToolParams p, int timeout)
         {
             int maxSize = Math.Max(64, p.GetInt("max_size", 1000) ?? 1000);
             string outputFolder = p.Get("output_folder");
+
+            string assetsRelativeFolder = null;
+            if (!string.IsNullOrWhiteSpace(outputFolder))
+            {
+                // Canonicalizes and rejects anything that does not resolve under Assets/ (e.g. "Assets/../x").
+                if (!AssetGenPaths.NormalizeOutputFolder(outputFolder, out assetsRelativeFolder, out string folderError))
+                    return new ErrorResponse(folderError);
+            }
 
             string dir = Path.Combine(ProjectRoot(), "Library", "BlenderBridge");
             Directory.CreateDirectory(dir);
             string file = Path.Combine(dir, $"blender_viewport_{DateTime.Now:yyyyMMdd_HHmmss}.png").Replace('\\', '/');
 
-            JToken result = BlenderSocketClient.Send("get_viewport_screenshot",
+            JToken result = await BlenderSocketClient.SendAsync(BlenderBridgePrefs.Endpoint, "get_viewport_screenshot",
                 new JObject { ["max_size"] = maxSize, ["filepath"] = file, ["format"] = "png" }, timeout);
 
             if (!File.Exists(file))
                 return new ErrorResponse($"Blender did not write a screenshot to {file}. Response: {result}");
 
             string assetPath = null;
-            if (!string.IsNullOrWhiteSpace(outputFolder))
+            if (assetsRelativeFolder != null)
             {
-                string rel = outputFolder.Replace('\\', '/').TrimEnd('/');
-                if (!rel.StartsWith("Assets/") && rel != "Assets")
-                    return new ErrorResponse("'output_folder' must be under Assets/.");
-                Directory.CreateDirectory(Path.Combine(ProjectRoot(), rel));
-                assetPath = $"{rel}/{Path.GetFileName(file)}";
-                File.Copy(file, Path.Combine(ProjectRoot(), assetPath), true);
+                string absDir = AssetGenPaths.ToAbsolute(assetsRelativeFolder);
+                Directory.CreateDirectory(absDir);
+                assetPath = $"{assetsRelativeFolder}/{Path.GetFileName(file)}";
+                File.Copy(file, Path.Combine(absDir, Path.GetFileName(file)), true);
                 AssetDatabase.ImportAsset(assetPath);
             }
 
@@ -163,7 +181,8 @@ namespace MCPForUnity.Editor.Tools.Blender
 
         // ------------------------------------------------------------ import_model
 
-        private static object ImportModel(ToolParams p, int timeout)
+        /// <summary>Exports from Blender, imports through the shared pipeline, then places and normalizes the instance.</summary>
+        private static async Task<object> ImportModelAsync(ToolParams p, int timeout)
         {
             string fmt = (p.Get("format") ?? "glb").Trim().ToLowerInvariant();
             if (fmt != "glb" && fmt != "fbx") return new ErrorResponse("'format' must be glb or fbx.");
@@ -172,7 +191,7 @@ namespace MCPForUnity.Editor.Tools.Blender
             bool selectionOnly = p.GetBool("selection_only", false);
             bool applyModifiers = p.GetBool("apply_modifiers", true);
             bool place = p.GetBool("place_in_scene", true);
-            float target = p.GetFloat("target_size", 0f) ?? 0f;
+            float target = Mathf.Max(0f, p.GetFloat("target_size", 0f) ?? 0f);
             string outputFolder = p.Get("output_folder");
             string animationType = p.Get("animation_type");
 
@@ -181,23 +200,24 @@ namespace MCPForUnity.Editor.Tools.Blender
                 name = names != null && names.Length == 1 ? names[0] : "BlenderModel";
             name = SanitizeName(name);
 
-            // 1. Export from Blender to a temp file.
+            // 1. Export from Blender to a temp file (off the editor thread).
             string exportDir = Path.Combine(Path.GetTempPath(), "BlenderBridge");
             Directory.CreateDirectory(exportDir);
             string exportPath = Path.Combine(exportDir, $"{name}_{DateTime.Now:yyyyMMdd_HHmmss}.{fmt}").Replace('\\', '/');
 
             string script = BuildExportScript(exportPath, names, selectionOnly, applyModifiers, fmt);
-            string stdout = BlenderSocketClient.RunPython(script, timeout);
+            string stdout = await BlenderSocketClient.RunPythonAsync(BlenderBridgePrefs.Endpoint, script, timeout);
 
             if (!File.Exists(exportPath))
                 return new ErrorResponse($"Blender did not produce {exportPath}. Blender output: {Truncate(stdout, 800)}");
 
             // 2. Import through the shared pipeline (staging under Assets/, glTFast/FBX, material setup).
+            // target_size 0 is passed through: the pipeline only rescales when it is > 0.
             var importParams = new JObject
             {
                 ["sourcePath"] = exportPath,
                 ["name"] = name,
-                ["targetSize"] = target > 0f ? target : 1f,
+                ["targetSize"] = target,
             };
             if (!string.IsNullOrWhiteSpace(outputFolder)) importParams["outputFolder"] = outputFolder;
             if (!string.IsNullOrWhiteSpace(animationType)) importParams["animationType"] = animationType;
@@ -260,19 +280,33 @@ namespace MCPForUnity.Editor.Tools.Blender
             return new SuccessResponse($"Imported {assetPath} and placed '{go.name}' in the scene.", data);
         }
 
-        private static string BuildExportScript(string outPath, string[] names, bool selectionOnly, bool applyModifiers, string fmt)
+        /// <summary>
+        /// Builds the Python that Blender runs to export. All caller-controlled values travel inside one
+        /// JSON document embedded as a single Python string literal, so names with quotes or
+        /// placeholder-looking text can never alter the program.
+        /// </summary>
+        internal static string BuildExportScript(string outPath, string[] names, bool selectionOnly, bool applyModifiers, string fmt)
         {
-            string namesLiteral = names == null || names.Length == 0
-                ? "[]"
-                : new JArray(names.Cast<object>().ToArray()).ToString(Formatting.None);
+            var config = new JObject
+            {
+                ["out"] = outPath,
+                ["names"] = names == null ? new JArray() : new JArray(names.Cast<object>().ToArray()),
+                ["selection_only"] = selectionOnly,
+                ["apply_modifiers"] = applyModifiers,
+                ["format"] = fmt,
+            };
+            // JSON string escaping is a subset of Python string-literal escaping, so the encoded
+            // document is a valid double-quoted Python literal.
+            string configLiteral = JsonConvert.ToString(config.ToString(Formatting.None));
 
             const string template = @"
 import bpy, os, json
-out = r'__OUT__'
-names = __NAMES__
-selection_only = __SELONLY__
-apply_mods = __APPLY__
-fmt = '__FMT__'
+cfg = json.loads(__CFG__)
+out = cfg['out']
+names = cfg['names']
+selection_only = cfg['selection_only']
+apply_mods = cfg['apply_modifiers']
+fmt = cfg['format']
 os.makedirs(os.path.dirname(out), exist_ok=True)
 try:
     if bpy.context.object and bpy.context.object.mode != 'OBJECT':
@@ -308,23 +342,28 @@ else:
 print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': use_sel,
                   'exported': [o.name for o in (bpy.context.selected_objects if use_sel else bpy.context.scene.objects)]}))
 ";
-            return template
-                .Replace("__OUT__", outPath)
-                .Replace("__NAMES__", namesLiteral)
-                .Replace("__SELONLY__", selectionOnly ? "True" : "False")
-                .Replace("__APPLY__", applyModifiers ? "True" : "False")
-                .Replace("__FMT__", fmt);
+            int at = template.IndexOf("__CFG__", StringComparison.Ordinal);
+            return template.Substring(0, at) + configLiteral + template.Substring(at + "__CFG__".Length);
         }
 
         // ----------------------------------------------------------- check_updates
 
-        private static object CheckUpdates()
+        /// <summary>Fetches the checkout's remotes on the thread pool and reports how far behind it is.</summary>
+        private static async Task<object> CheckUpdatesAsync()
         {
             if (!BlenderBridgePrefs.IsForkConfigured) return new ErrorResponse(NotConfiguredMessage);
             string fork = BlenderBridgePrefs.ForkPath;
+            string forkAddon = BlenderBridgePrefs.ForkAddonPath;
+            string installedAddon = BlenderBridgePrefs.InstalledAddonPath;
             if (!Directory.Exists(Path.Combine(fork, ".git")))
                 return new ErrorResponse($"'{fork}' is not a git checkout (no .git folder); check_updates needs one.");
 
+            return await Task.Run(() => CheckUpdatesBlocking(fork, forkAddon, installedAddon));
+        }
+
+        /// <summary>Git and file work for check_updates; touches no Unity API so it can run on any thread.</summary>
+        private static object CheckUpdatesBlocking(string fork, string forkAddon, string installedAddon)
+        {
             if (!TryGit(fork, "--version", out _, out string gitErr, 10000))
                 return new ErrorResponse($"git is not available: {gitErr}");
 
@@ -373,8 +412,6 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
                 perRemote.Add(entry);
             }
 
-            string forkAddon = BlenderBridgePrefs.ForkAddonPath;
-            string installedAddon = BlenderBridgePrefs.InstalledAddonPath;
             string forkMd5 = File.Exists(forkAddon) ? FileMd5(forkAddon) : null;
             string installedMd5 = installedAddon != null && File.Exists(installedAddon) ? FileMd5(installedAddon) : null;
             bool addonInSync = forkMd5 != null && forkMd5 == installedMd5;
@@ -403,6 +440,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
 
         // -------------------------------------------------------------- sync_addon
 
+        /// <summary>Copies the checkout's addon.py over Blender's installed copy, keeping a .bak of the old file.</summary>
         private static object SyncAddon(bool force)
         {
             if (!BlenderBridgePrefs.IsForkConfigured) return new ErrorResponse(NotConfiguredMessage);
@@ -434,6 +472,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
 
         // ------------------------------------------------------------------ helpers
 
+        /// <summary>Runs one git command with no prompts; false on non-zero exit, timeout, or missing git.</summary>
         private static bool TryGit(string workingDir, string args, out string stdout, out string stderr, int timeoutMs = 30000)
         {
             stdout = string.Empty;
@@ -472,6 +511,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             }
         }
 
+        /// <summary>Absolute project folder (parent of Assets/), forward slashes.</summary>
         private static string ProjectRoot() => Path.GetDirectoryName(Application.dataPath).Replace('\\', '/');
 
         /// <summary>Lower-case hex MD5 of a file; shared with the Asset Gen panel's addon-sync indicator.</summary>
@@ -482,6 +522,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             return BitConverter.ToString(md5.ComputeHash(fs)).Replace("-", "").ToLowerInvariant();
         }
 
+        /// <summary>Makes a caller-supplied name safe to use as a file and GameObject name.</summary>
         private static string SanitizeName(string raw)
         {
             var invalid = Path.GetInvalidFileNameChars();
@@ -492,6 +533,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             return string.IsNullOrEmpty(s) ? "BlenderModel" : s;
         }
 
+        /// <summary>Reads a [x, y, z] position from a JSON array or a stringified array; origin when absent.</summary>
         private static Vector3 ParsePosition(JToken token)
         {
             if (token == null || token.Type == JTokenType.Null) return Vector3.zero;
@@ -504,6 +546,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             return new Vector3(arr[0].Value<float>(), arr[1].Value<float>(), arr[2].Value<float>());
         }
 
+        /// <summary>World-space bounds over every renderer in the hierarchy; false when it has none.</summary>
         private static bool TryGetWorldBounds(GameObject go, out Bounds bounds)
         {
             var renderers = go.GetComponentsInChildren<Renderer>(true);
@@ -517,6 +560,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             return true;
         }
 
+        /// <summary>Trims and caps a string for inclusion in messages.</summary>
         private static string Truncate(string s, int max)
         {
             if (string.IsNullOrEmpty(s)) return s ?? string.Empty;

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
@@ -33,7 +33,7 @@ namespace MCPForUnity.Editor.Tools.Blender
     public static class BlenderBridgeTool
     {
         private static readonly string[] ValidActions =
-            { "status", "scene_info", "object_info", "screenshot", "run_python", "import_model", "check_updates", "sync_addon" };
+            { "status", "scene_info", "object_info", "screenshot", "run_python", "import_model", "compare_screenshot", "setup_bloom", "check_updates", "sync_addon" };
 
         private const string NotConfiguredMessage =
             "The blender-mcp checkout is not set. Open Window > MCP for Unity > Generative > Blender Bridge " +
@@ -73,6 +73,12 @@ namespace MCPForUnity.Editor.Tools.Blender
                         return new SuccessResponse("Executed Python in Blender.", new { stdout });
                     }
                     case "import_model": return await ImportModelAsync(p, timeout);
+                    case "compare_screenshot": return await CompareScreenshotAsync(p, timeout);
+                    case "setup_bloom":
+                    {
+                        JObject bloom = await SetupBloomAsync();
+                        return new SuccessResponse(bloom["message"]?.ToString() ?? "Bloom configured.", bloom);
+                    }
                     case "check_updates": return await CheckUpdatesAsync();
                     case "sync_addon": return SyncAddon(p.GetBool("force", false));
                     default:
@@ -194,6 +200,9 @@ namespace MCPForUnity.Editor.Tools.Blender
             float target = Mathf.Max(0f, p.GetFloat("target_size", 0f) ?? 0f);
             string outputFolder = p.Get("output_folder");
             string animationType = p.Get("animation_type");
+            bool autoAnimate = p.GetBool("auto_animate", true);
+            bool savePrefab = p.GetBool("save_prefab", false);
+            bool ensureBloom = p.GetBool("ensure_bloom", false);
 
             string name = p.Get("name");
             if (string.IsNullOrWhiteSpace(name))
@@ -205,8 +214,7 @@ namespace MCPForUnity.Editor.Tools.Blender
             Directory.CreateDirectory(exportDir);
             string exportPath = Path.Combine(exportDir, $"{name}_{UniqueSuffix()}.{fmt}").Replace('\\', '/');
 
-            string script = BuildExportScript(exportPath, names, selectionOnly, applyModifiers, fmt);
-            string stdout = await BlenderSocketClient.RunPythonAsync(BlenderBridgePrefs.Endpoint, script, timeout);
+            string stdout = await ExportFromBlenderAsync(BlenderBridgePrefs.Endpoint, exportPath, names, selectionOnly, applyModifiers, fmt, timeout);
 
             if (!File.Exists(exportPath))
                 return new ErrorResponse($"Blender did not produce {exportPath}. Blender output: {Truncate(stdout, 800)}");
@@ -239,6 +247,8 @@ namespace MCPForUnity.Editor.Tools.Blender
 
             if (!place || string.IsNullOrEmpty(assetPath))
                 return new SuccessResponse($"Imported {assetPath} (not placed).", data);
+
+            if (fmt == "fbx" && autoAnimate) ConfigureFbxClipLooping(assetPath);
 
             // 3. Place in the open scene and normalize size from measured bounds. Blender exports
             // commonly land far off scale, so measuring the placed instance beats trusting the importer.
@@ -277,11 +287,50 @@ namespace MCPForUnity.Editor.Tools.Blender
                 data["bounds_size"] = new JArray(b1.size.x, b1.size.y, b1.size.z);
                 data["bounds_center"] = new JArray(b1.center.x, b1.center.y, b1.center.z);
             }
+
+            // 4. Optional finishing touches: play imported clips, keep a prefab, make emission glow.
+            if (autoAnimate)
+            {
+                JObject animation = SetupAnimation(go, assetPath, name);
+                if (animation != null) data["animation"] = animation;
+            }
+            if (savePrefab) data["prefab_path"] = SavePrefab(go, assetPath, name);
+            if (ensureBloom && HasEmissiveMaterial(go)) data["bloom"] = await SetupBloomAsync();
+
             return new SuccessResponse($"Imported {assetPath} and placed '{go.name}' in the scene.", data);
         }
 
         /// <summary>
-        /// Builds the Python that Blender runs to export. All caller-controlled values travel inside one
+        /// Asks the addon to export. Prefers its first-class <c>export_scene</c> command (validated
+        /// parameters, no code execution); addons that predate it answer "Unknown command type", in
+        /// which case the equivalent Python is sent through <c>execute_code</c>.
+        /// </summary>
+        private static async Task<string> ExportFromBlenderAsync(BlenderEndpoint endpoint, string exportPath, string[] names,
+            bool selectionOnly, bool applyModifiers, string fmt, int timeout)
+        {
+            var args = new JObject
+            {
+                ["filepath"] = exportPath,
+                ["format"] = fmt,
+                ["object_names"] = names == null ? new JArray() : new JArray(names.Cast<object>().ToArray()),
+                ["selection_only"] = selectionOnly,
+                ["apply_modifiers"] = applyModifiers,
+            };
+            try
+            {
+                JToken result = await BlenderSocketClient.SendAsync(endpoint, "export_scene", args, timeout);
+                if (result?["error"] != null) throw new BlenderCommandException($"Blender export_scene failed: {result["error"]}");
+                return result?.ToString(Formatting.None) ?? string.Empty;
+            }
+            catch (BlenderCommandException e) when (e.Message.Contains("Unknown command type"))
+            {
+                string script = BuildExportScript(exportPath, names, selectionOnly, applyModifiers, fmt);
+                return await BlenderSocketClient.RunPythonAsync(endpoint, script, timeout);
+            }
+        }
+
+        /// <summary>
+        /// Builds the Python that Blender runs to export on addons without <c>export_scene</c>. All caller-controlled values travel inside one
         /// JSON document embedded as a single Python string literal, so names with quotes or
         /// placeholder-looking text can never alter the program.
         /// </summary>
@@ -344,6 +393,273 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
 ";
             int at = template.IndexOf("__CFG__", StringComparison.Ordinal);
             return template.Substring(0, at) + configLiteral + template.Substring(at + "__CFG__".Length);
+        }
+
+        // ---------------------------------------------------------- finishing touches
+
+        /// <summary>Marks every clip in an FBX as looping so the imported animation cycles once a controller drives it.</summary>
+        private static void ConfigureFbxClipLooping(string assetPath)
+        {
+            if (!(AssetImporter.GetAtPath(assetPath) is ModelImporter importer)) return;
+            ModelImporterClipAnimation[] clips = importer.clipAnimations.Length > 0 ? importer.clipAnimations : importer.defaultClipAnimations;
+            if (clips.Length == 0) return;
+            foreach (ModelImporterClipAnimation clip in clips) clip.loopTime = true;
+            importer.clipAnimations = clips;
+            importer.SaveAndReimport();
+        }
+
+        /// <summary>
+        /// An imported clip does nothing until an AnimatorController drives it, so the placed model looks frozen.
+        /// Creates a controller next to the asset with one looping state per clip and assigns it to the instance.
+        /// </summary>
+        private static JObject SetupAnimation(GameObject go, string assetPath, string name)
+        {
+            AnimationClip[] clips = AssetDatabase.LoadAllAssetRepresentationsAtPath(assetPath)
+                .OfType<AnimationClip>()
+                .Where(c => !c.name.StartsWith("__preview__", StringComparison.Ordinal))
+                .ToArray();
+            if (clips.Length == 0) return null;
+
+            Animator animator = go.GetComponentInChildren<Animator>(true) ?? go.AddComponent<Animator>();
+            string controllerPath = AssetDatabase.GenerateUniqueAssetPath(
+                Path.Combine(Path.GetDirectoryName(assetPath) ?? "Assets", $"{name}_Controller.controller").Replace('\\', '/'));
+            var controller = UnityEditor.Animations.AnimatorController.CreateAnimatorControllerAtPath(controllerPath);
+            var stateMachine = controller.layers[0].stateMachine;
+            foreach (AnimationClip clip in clips)
+            {
+                AnimationClipSettings settings = AnimationUtility.GetAnimationClipSettings(clip);
+                if (!settings.loopTime)
+                {
+                    settings.loopTime = true;
+                    AnimationUtility.SetAnimationClipSettings(clip, settings);
+                }
+                var state = stateMachine.AddState(clip.name);
+                state.motion = clip;
+                if (stateMachine.defaultState == null) stateMachine.defaultState = state;
+            }
+            animator.runtimeAnimatorController = controller;
+            EditorUtility.SetDirty(controller);
+            EditorUtility.SetDirty(animator);
+            AssetDatabase.SaveAssets();
+            return new JObject
+            {
+                ["clips"] = new JArray(clips.Select(c => c.name).Cast<object>().ToArray()),
+                ["controller_path"] = controllerPath,
+                ["animator_on"] = animator.gameObject.name,
+                ["loops"] = true,
+            };
+        }
+
+        /// <summary>Saves the placed instance as a prefab under &lt;asset folder&gt;/Prefabs and connects the instance to it.</summary>
+        private static string SavePrefab(GameObject go, string assetPath, string name)
+        {
+            string parent = (Path.GetDirectoryName(assetPath) ?? "Assets").Replace('\\', '/');
+            string dir = $"{parent}/Prefabs";
+            if (!AssetDatabase.IsValidFolder(dir)) AssetDatabase.CreateFolder(parent, "Prefabs");
+            string prefabPath = AssetDatabase.GenerateUniqueAssetPath($"{dir}/{name}.prefab");
+            PrefabUtility.SaveAsPrefabAssetAndConnect(go, prefabPath, InteractionMode.AutomatedAction);
+            return prefabPath;
+        }
+
+        /// <summary>True when any material on the hierarchy has a non-black emission (glTFast or URP Lit naming).</summary>
+        private static bool HasEmissiveMaterial(GameObject go)
+        {
+            foreach (Renderer r in go.GetComponentsInChildren<Renderer>(true))
+            {
+                foreach (Material m in r.sharedMaterials)
+                {
+                    if (m == null) continue;
+                    if (m.HasProperty("emissiveFactor") && m.GetColor("emissiveFactor").maxColorComponent > 0.01f) return true;
+                    if (m.HasProperty("_EmissionColor") && m.IsKeywordEnabled("_EMISSION") && m.GetColor("_EmissionColor").maxColorComponent > 0.01f) return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Makes emissive materials actually glow: enables post-processing on the main camera and ensures a
+        /// global Volume with a Bloom override exists (reusing the scene's global volume when it has one).
+        /// Goes through manage_graphics so the Volume/Bloom reflection lives in one place.
+        /// </summary>
+        private static async Task<JObject> SetupBloomAsync()
+        {
+            var result = new JObject();
+            Type volumeType = Type.GetType("UnityEngine.Rendering.Volume, Unity.RenderPipelines.Core.Runtime");
+            if (volumeType == null)
+            {
+                result["message"] = "Volume system (URP/HDRP) not available; nothing to do.";
+                return result;
+            }
+
+            Camera cam = Camera.main;
+            Type camDataType = Type.GetType("UnityEngine.Rendering.Universal.UniversalAdditionalCameraData, Unity.RenderPipelines.Universal.Runtime");
+            if (cam != null && camDataType != null)
+            {
+                Component camData = cam.GetComponent(camDataType) ?? cam.gameObject.AddComponent(camDataType);
+                System.Reflection.PropertyInfo post = camDataType.GetProperty("renderPostProcessing");
+                if (post != null && !(bool)post.GetValue(camData))
+                {
+                    post.SetValue(camData, true);
+                    EditorUtility.SetDirty(camData);
+                    result["camera_post_processing_enabled"] = cam.name;
+                }
+            }
+
+            System.Reflection.PropertyInfo isGlobal = volumeType.GetProperty("isGlobal");
+            System.Reflection.FieldInfo sharedProfile = volumeType.GetField("sharedProfile");
+            Component globalVolume = null;
+            foreach (UnityEngine.Object v in UnityEngine.Object.FindObjectsByType(volumeType, FindObjectsSortMode.None))
+            {
+                var comp = v as Component;
+                if (comp == null || (isGlobal != null && !(bool)isGlobal.GetValue(comp))) continue;
+                globalVolume ??= comp;
+                object profile = sharedProfile?.GetValue(comp);
+                var components = profile?.GetType().GetField("components")?.GetValue(profile) as System.Collections.IEnumerable;
+                if (components != null && components.Cast<object>().Any(c => c != null && c.GetType().Name == "Bloom"))
+                {
+                    result["volume"] = comp.gameObject.name;
+                    result["message"] = $"Bloom already present on global volume '{comp.gameObject.name}'.";
+                    return result;
+                }
+            }
+
+            JObject graphics;
+            if (globalVolume != null)
+            {
+                graphics = JObject.FromObject(await CommandRegistry.InvokeCommandAsync("manage_graphics", new JObject
+                {
+                    ["action"] = "volume_add_effect", ["target"] = globalVolume.gameObject.name, ["effect"] = "Bloom",
+                }));
+                if (graphics.Value<bool?>("success") ?? false)
+                {
+                    await CommandRegistry.InvokeCommandAsync("manage_graphics", new JObject
+                    {
+                        ["action"] = "volume_set_effect", ["target"] = globalVolume.gameObject.name, ["effect"] = "Bloom",
+                        ["parameters"] = new JObject { ["intensity"] = 1.0f, ["threshold"] = 0.9f },
+                    });
+                }
+                result["volume"] = globalVolume.gameObject.name;
+            }
+            else
+            {
+                graphics = JObject.FromObject(await CommandRegistry.InvokeCommandAsync("manage_graphics", new JObject
+                {
+                    ["action"] = "volume_create", ["name"] = "Global Volume (Blender Bridge)", ["is_global"] = true,
+                    ["effects"] = new JArray(new JObject { ["type"] = "Bloom", ["intensity"] = 1.0f, ["threshold"] = 0.9f }),
+                }));
+                result["volume"] = "Global Volume (Blender Bridge)";
+            }
+            bool ok = graphics.Value<bool?>("success") ?? false;
+            result["message"] = ok ? $"Bloom added to '{result["volume"]}'." : $"Could not add Bloom: {graphics["error"] ?? graphics["message"]}";
+            result["success"] = ok;
+            return result;
+        }
+
+        // -------------------------------------------------------- compare_screenshot
+
+        /// <summary>Puts a Blender viewport capture and a Unity capture of a placed object side by side in one PNG.</summary>
+        private static async Task<object> CompareScreenshotAsync(ToolParams p, int timeout)
+        {
+            string target = p.Get("game_object");
+            if (string.IsNullOrWhiteSpace(target)) return new ErrorResponse("'game_object' is required for compare_screenshot.");
+            if (GameObject.Find(target) == null) return new ErrorResponse($"GameObject '{target}' not found in the open scene.");
+            int maxSize = Math.Max(128, p.GetInt("max_size", 800) ?? 800);
+            string outputFolder = p.Get("output_folder");
+            string assetsRelativeFolder = null;
+            if (!string.IsNullOrWhiteSpace(outputFolder)
+                && !AssetGenPaths.NormalizeOutputFolder(outputFolder, out assetsRelativeFolder, out string folderError))
+                return new ErrorResponse(folderError);
+
+            string dir = Path.Combine(ProjectRoot(), "Library", "BlenderBridge");
+            Directory.CreateDirectory(dir);
+            string blenderPng = Path.Combine(dir, $"compare_blender_{UniqueSuffix()}.png").Replace('\\', '/');
+            await BlenderSocketClient.SendAsync(BlenderBridgePrefs.Endpoint, "get_viewport_screenshot",
+                new JObject { ["max_size"] = maxSize, ["filepath"] = blenderPng, ["format"] = "png" }, timeout);
+            if (!File.Exists(blenderPng)) return new ErrorResponse("Blender did not write a viewport screenshot.");
+
+            JObject shot = JObject.FromObject(await CommandRegistry.InvokeCommandAsync("manage_scene", new JObject
+            {
+                ["action"] = "screenshot", ["view_target"] = target, ["max_resolution"] = maxSize,
+                ["screenshot_file_name"] = $"blender_bridge_compare_{UniqueSuffix()}",
+            }));
+            string unityPng = shot["data"]?["fullPath"]?.ToString();
+            if (!(shot.Value<bool?>("success") ?? false) || string.IsNullOrEmpty(unityPng) || !File.Exists(unityPng))
+                return new ErrorResponse($"Unity screenshot failed: {shot["error"] ?? shot["message"]}");
+
+            string outPath = Path.Combine(dir, $"compare_{UniqueSuffix()}.png").Replace('\\', '/');
+            (int width, int height) = CompositeSideBySide(blenderPng, unityPng, outPath);
+
+            // The Unity capture is written under Assets/ by manage_scene; keep the project clean.
+            string unityAssetPath = shot["data"]?["path"]?.ToString();
+            if (!string.IsNullOrEmpty(unityAssetPath) && unityAssetPath.StartsWith("Assets/", StringComparison.Ordinal))
+                AssetDatabase.DeleteAsset(unityAssetPath);
+
+            string assetPath = null;
+            if (assetsRelativeFolder != null)
+            {
+                string absDir = AssetGenPaths.ToAbsolute(assetsRelativeFolder);
+                Directory.CreateDirectory(absDir);
+                assetPath = $"{assetsRelativeFolder}/{Path.GetFileName(outPath)}";
+                File.Copy(outPath, Path.Combine(absDir, Path.GetFileName(outPath)), true);
+                AssetDatabase.ImportAsset(assetPath);
+            }
+
+            return new SuccessResponse("Composited Blender (left) and Unity (right).", new JObject
+            {
+                ["path"] = outPath, ["asset_path"] = assetPath, ["width"] = width, ["height"] = height,
+                ["blender_path"] = blenderPng, ["game_object"] = target,
+            });
+        }
+
+        /// <summary>Scales both images to the smaller height and writes them side by side. Returns the output size.</summary>
+        internal static (int Width, int Height) CompositeSideBySide(string leftPng, string rightPng, string outPath)
+        {
+            Texture2D left = LoadPng(leftPng), right = LoadPng(rightPng);
+            Texture2D l = null, r = null, outTex = null;
+            try
+            {
+                int h = Math.Min(left.height, right.height);
+                l = ScaleToHeight(left, h);
+                r = ScaleToHeight(right, h);
+                outTex = new Texture2D(l.width + r.width, h, TextureFormat.RGBA32, false);
+                outTex.SetPixels(0, 0, l.width, h, l.GetPixels());
+                outTex.SetPixels(l.width, 0, r.width, h, r.GetPixels());
+                outTex.Apply();
+                File.WriteAllBytes(outPath, outTex.EncodeToPNG());
+                return (outTex.width, h);
+            }
+            finally
+            {
+                foreach (Texture2D t in new[] { outTex, l == left ? null : l, r == right ? null : r, left, right })
+                    if (t != null) UnityEngine.Object.DestroyImmediate(t);
+            }
+        }
+
+        /// <summary>Decodes a PNG from disk into a readable texture.</summary>
+        private static Texture2D LoadPng(string path)
+        {
+            var tex = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+            if (!ImageConversion.LoadImage(tex, File.ReadAllBytes(path)))
+            {
+                UnityEngine.Object.DestroyImmediate(tex);
+                throw new IOException($"Could not decode PNG: {path}");
+            }
+            return tex;
+        }
+
+        /// <summary>Bilinear resample to a target height, keeping the aspect ratio. Returns the source when already right.</summary>
+        private static Texture2D ScaleToHeight(Texture2D src, int height)
+        {
+            if (src.height == height) return src;
+            int width = Mathf.Max(1, Mathf.RoundToInt(src.width * (float)height / src.height));
+            var dst = new Texture2D(width, height, TextureFormat.RGBA32, false);
+            var pixels = new Color[width * height];
+            for (int y = 0; y < height; y++)
+                for (int x = 0; x < width; x++)
+                    pixels[y * width + x] = src.GetPixelBilinear((x + 0.5f) / width, (y + 0.5f) / height);
+            dst.SetPixels(pixels);
+            dst.Apply();
+            return dst;
         }
 
         // ----------------------------------------------------------- check_updates

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
@@ -1,0 +1,527 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Security;
+using MCPForUnity.Editor.Services.Blender;
+using MCPForUnity.Editor.Tools.AssetGen;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace MCPForUnity.Editor.Tools.Blender
+{
+    /// <summary>
+    /// Lets the Unity Editor talk straight to the BlenderMCP addon socket, so a Blender → Unity
+    /// handoff is one call (export → import through the shared model pipeline → place → normalize)
+    /// instead of an AI-orchestrated multi-step dance. Also drives the Blender Bridge panel in the
+    /// Asset Gen tab and the Window/MCP for Unity/Blender Bridge menu. Carries no API keys.
+    /// </summary>
+    [McpForUnityTool("blender_bridge", AutoRegister = false, Group = "asset_gen",
+        Description = "Bridge to a running Blender with the BlenderMCP addon: status, scene/object info, viewport " +
+                      "screenshot, run Python in Blender, import a model (export → import → place → normalize), " +
+                      "check the blender-mcp checkout for updates, and sync its addon into Blender.")]
+    public static class BlenderBridgeTool
+    {
+        private static readonly string[] ValidActions =
+            { "status", "scene_info", "object_info", "screenshot", "run_python", "import_model", "check_updates", "sync_addon" };
+
+        private const string NotConfiguredMessage =
+            "The blender-mcp checkout is not set. Open Window > MCP for Unity > Generative > Blender Bridge " +
+            "and pick the folder that contains addon.py.";
+
+        public static object HandleCommand(JObject @params)
+        {
+            if (@params == null) return new ErrorResponse("Parameters cannot be null.");
+            var p = new ToolParams(@params);
+            string action = (p.Get("action") ?? "status").Trim().ToLowerInvariant();
+            int timeout = Math.Max(5, p.GetInt("timeout_seconds", 180) ?? 180);
+
+            try
+            {
+                switch (action)
+                {
+                    case "status": return Status();
+                    case "scene_info":
+                        return new SuccessResponse("Retrieved Blender scene info.",
+                            BlenderSocketClient.Send("get_scene_info", null, timeout));
+                    case "object_info":
+                    {
+                        string objectName = p.Get("object_name");
+                        if (string.IsNullOrWhiteSpace(objectName))
+                            return new ErrorResponse("'object_name' is required for object_info.");
+                        return new SuccessResponse($"Retrieved info for '{objectName}'.",
+                            BlenderSocketClient.Send("get_object_info", new JObject { ["object_name"] = objectName }, timeout));
+                    }
+                    case "screenshot": return Screenshot(p, timeout);
+                    case "run_python":
+                    {
+                        string code = p.Get("code");
+                        if (string.IsNullOrWhiteSpace(code)) return new ErrorResponse("'code' is required for run_python.");
+                        string stdout = BlenderSocketClient.RunPython(code, timeout);
+                        return new SuccessResponse("Executed Python in Blender.", new { stdout });
+                    }
+                    case "import_model": return ImportModel(p, timeout);
+                    case "check_updates": return CheckUpdates();
+                    case "sync_addon": return SyncAddon(p.GetBool("force", false));
+                    default:
+                        return new ErrorResponse($"Unknown action '{action}'. Valid: {string.Join(", ", ValidActions)}.");
+                }
+            }
+            catch (BlenderUnavailableException e)
+            {
+                return new ErrorResponse(e.Message);
+            }
+            catch (Exception e)
+            {
+                return new ErrorResponse(SecretRedactor.Scrub($"blender_bridge '{action}' failed: {e.Message}"));
+            }
+        }
+
+        // ------------------------------------------------------------------ status
+
+        private static object Status()
+        {
+            bool reachable = BlenderSocketClient.IsReachable(out string error);
+            JToken scene = null;
+            if (reachable)
+            {
+                try { scene = BlenderSocketClient.Send("get_scene_info", null, 10); }
+                catch (Exception e) { error = e.Message; }
+            }
+
+            string forkAddon = BlenderBridgePrefs.ForkAddonPath;
+            string installedAddon = BlenderBridgePrefs.InstalledAddonPath;
+            string forkMd5 = forkAddon != null && File.Exists(forkAddon) ? FileMd5(forkAddon) : null;
+            string installedMd5 = installedAddon != null && File.Exists(installedAddon) ? FileMd5(installedAddon) : null;
+
+            var data = new JObject
+            {
+                ["blender_reachable"] = reachable,
+                ["blender_installed"] = BlenderDetection.IsInstalled(),
+                ["endpoint"] = $"{BlenderBridgePrefs.Host}:{BlenderBridgePrefs.Port}",
+                ["error"] = reachable ? null : error,
+                ["scene_name"] = scene?["name"],
+                ["object_count"] = scene?["object_count"],
+                ["fork_configured"] = BlenderBridgePrefs.IsForkConfigured,
+                ["fork_path"] = BlenderBridgePrefs.ForkPath,
+                ["fork_addon_found"] = forkMd5 != null,
+                ["installed_addon_path"] = installedAddon,
+                ["installed_addon_found"] = installedMd5 != null,
+                ["addon_in_sync"] = forkMd5 != null && installedMd5 != null && forkMd5 == installedMd5,
+            };
+            string msg = reachable
+                ? $"Blender reachable. Scene '{scene?["name"]}' with {scene?["object_count"]} objects."
+                : "Blender not reachable.";
+            return new SuccessResponse(msg, data);
+        }
+
+        // -------------------------------------------------------------- screenshot
+
+        private static object Screenshot(ToolParams p, int timeout)
+        {
+            int maxSize = Math.Max(64, p.GetInt("max_size", 1000) ?? 1000);
+            string outputFolder = p.Get("output_folder");
+
+            string dir = Path.Combine(ProjectRoot(), "Library", "BlenderBridge");
+            Directory.CreateDirectory(dir);
+            string file = Path.Combine(dir, $"blender_viewport_{DateTime.Now:yyyyMMdd_HHmmss}.png").Replace('\\', '/');
+
+            JToken result = BlenderSocketClient.Send("get_viewport_screenshot",
+                new JObject { ["max_size"] = maxSize, ["filepath"] = file, ["format"] = "png" }, timeout);
+
+            if (!File.Exists(file))
+                return new ErrorResponse($"Blender did not write a screenshot to {file}. Response: {result}");
+
+            string assetPath = null;
+            if (!string.IsNullOrWhiteSpace(outputFolder))
+            {
+                string rel = outputFolder.Replace('\\', '/').TrimEnd('/');
+                if (!rel.StartsWith("Assets/") && rel != "Assets")
+                    return new ErrorResponse("'output_folder' must be under Assets/.");
+                Directory.CreateDirectory(Path.Combine(ProjectRoot(), rel));
+                assetPath = $"{rel}/{Path.GetFileName(file)}";
+                File.Copy(file, Path.Combine(ProjectRoot(), assetPath), true);
+                AssetDatabase.ImportAsset(assetPath);
+            }
+
+            return new SuccessResponse("Captured Blender viewport.", new JObject
+            {
+                ["path"] = file,
+                ["asset_path"] = assetPath,
+                ["width"] = result?["width"],
+                ["height"] = result?["height"],
+                ["method"] = result?["method"],
+            });
+        }
+
+        // ------------------------------------------------------------ import_model
+
+        private static object ImportModel(ToolParams p, int timeout)
+        {
+            string fmt = (p.Get("format") ?? "glb").Trim().ToLowerInvariant();
+            if (fmt != "glb" && fmt != "fbx") return new ErrorResponse("'format' must be glb or fbx.");
+
+            string[] names = p.GetStringArray("object_names")?.Where(n => !string.IsNullOrWhiteSpace(n)).ToArray();
+            bool selectionOnly = p.GetBool("selection_only", false);
+            bool applyModifiers = p.GetBool("apply_modifiers", true);
+            bool place = p.GetBool("place_in_scene", true);
+            float target = p.GetFloat("target_size", 0f) ?? 0f;
+            string outputFolder = p.Get("output_folder");
+            string animationType = p.Get("animation_type");
+
+            string name = p.Get("name");
+            if (string.IsNullOrWhiteSpace(name))
+                name = names != null && names.Length == 1 ? names[0] : "BlenderModel";
+            name = SanitizeName(name);
+
+            // 1. Export from Blender to a temp file.
+            string exportDir = Path.Combine(Path.GetTempPath(), "BlenderBridge");
+            Directory.CreateDirectory(exportDir);
+            string exportPath = Path.Combine(exportDir, $"{name}_{DateTime.Now:yyyyMMdd_HHmmss}.{fmt}").Replace('\\', '/');
+
+            string script = BuildExportScript(exportPath, names, selectionOnly, applyModifiers, fmt);
+            string stdout = BlenderSocketClient.RunPython(script, timeout);
+
+            if (!File.Exists(exportPath))
+                return new ErrorResponse($"Blender did not produce {exportPath}. Blender output: {Truncate(stdout, 800)}");
+
+            // 2. Import through the shared pipeline (staging under Assets/, glTFast/FBX, material setup).
+            var importParams = new JObject
+            {
+                ["sourcePath"] = exportPath,
+                ["name"] = name,
+                ["targetSize"] = target > 0f ? target : 1f,
+            };
+            if (!string.IsNullOrWhiteSpace(outputFolder)) importParams["outputFolder"] = outputFolder;
+            if (!string.IsNullOrWhiteSpace(animationType)) importParams["animationType"] = animationType;
+
+            JObject importResult = JObject.FromObject(ImportModelFile.HandleCommand(importParams));
+            if (!(importResult.Value<bool?>("success") ?? false))
+                return new ErrorResponse($"Import failed: {importResult["error"] ?? importResult["message"]}");
+
+            string assetPath = importResult["data"]?["asset_path"]?.ToString();
+            var data = new JObject
+            {
+                ["asset_path"] = assetPath,
+                ["asset_guid"] = importResult["data"]?["asset_guid"],
+                ["export_path"] = exportPath,
+                ["format"] = fmt,
+                ["blender_output"] = Truncate(stdout, 400),
+                ["placed"] = false,
+            };
+
+            if (!place || string.IsNullOrEmpty(assetPath))
+                return new SuccessResponse($"Imported {assetPath} (not placed).", data);
+
+            // 3. Place in the open scene and normalize size from measured bounds. Blender exports
+            // commonly land far off scale, so measuring the placed instance beats trusting the importer.
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(assetPath);
+            if (prefab == null)
+            {
+                data["note"] = "Asset has no GameObject root to instantiate.";
+                return new SuccessResponse($"Imported {assetPath} but could not instantiate it.", data);
+            }
+
+            GameObject go = PrefabUtility.InstantiatePrefab(prefab) as GameObject ?? UnityEngine.Object.Instantiate(prefab);
+            go.name = name;
+            Undo.RegisterCreatedObjectUndo(go, "Import from Blender");
+            go.transform.position = ParsePosition(p.GetRaw("position"));
+
+            float scaleFactor = 1f;
+            if (target > 0f && TryGetWorldBounds(go, out Bounds b0))
+            {
+                float maxDim = Mathf.Max(b0.size.x, Mathf.Max(b0.size.y, b0.size.z));
+                if (maxDim > 1e-4f)
+                {
+                    scaleFactor = target / maxDim;
+                    go.transform.localScale *= scaleFactor;
+                }
+            }
+
+            EditorSceneManager.MarkSceneDirty(go.scene);
+            Selection.activeGameObject = go;
+
+            data["placed"] = true;
+            data["game_object"] = go.name;
+            data["scene"] = go.scene.name;
+            data["scale_factor_applied"] = scaleFactor;
+            if (TryGetWorldBounds(go, out Bounds b1))
+            {
+                data["bounds_size"] = new JArray(b1.size.x, b1.size.y, b1.size.z);
+                data["bounds_center"] = new JArray(b1.center.x, b1.center.y, b1.center.z);
+            }
+            return new SuccessResponse($"Imported {assetPath} and placed '{go.name}' in the scene.", data);
+        }
+
+        private static string BuildExportScript(string outPath, string[] names, bool selectionOnly, bool applyModifiers, string fmt)
+        {
+            string namesLiteral = names == null || names.Length == 0
+                ? "[]"
+                : new JArray(names.Cast<object>().ToArray()).ToString(Formatting.None);
+
+            const string template = @"
+import bpy, os, json
+out = r'__OUT__'
+names = __NAMES__
+selection_only = __SELONLY__
+apply_mods = __APPLY__
+fmt = '__FMT__'
+os.makedirs(os.path.dirname(out), exist_ok=True)
+try:
+    if bpy.context.object and bpy.context.object.mode != 'OBJECT':
+        bpy.ops.object.mode_set(mode='OBJECT')
+except Exception:
+    pass
+use_sel = False
+if names:
+    missing = [n for n in names if bpy.data.objects.get(n) is None]
+    if missing:
+        raise Exception('Objects not found in Blender: ' + ', '.join(missing))
+    bpy.ops.object.select_all(action='DESELECT')
+    for n in names:
+        o = bpy.data.objects[n]
+        o.select_set(True)
+        for c in o.children_recursive:
+            c.select_set(True)
+    bpy.context.view_layer.objects.active = bpy.data.objects[names[0]]
+    use_sel = True
+elif selection_only:
+    if not bpy.context.selected_objects:
+        raise Exception('Nothing is selected in Blender and no object_names were given.')
+    use_sel = True
+if fmt == 'glb':
+    bpy.ops.export_scene.gltf(filepath=out, export_format='GLB', use_selection=use_sel,
+                              use_active_scene=True, export_apply=apply_mods,
+                              export_animations=True, export_skins=True, export_morph=True,
+                              export_yup=True)
+else:
+    bpy.ops.export_scene.fbx(filepath=out, use_selection=use_sel, apply_unit_scale=True,
+                             bake_space_transform=apply_mods, use_mesh_modifiers=apply_mods,
+                             path_mode='COPY', embed_textures=True)
+print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': use_sel,
+                  'exported': [o.name for o in (bpy.context.selected_objects if use_sel else bpy.context.scene.objects)]}))
+";
+            return template
+                .Replace("__OUT__", outPath)
+                .Replace("__NAMES__", namesLiteral)
+                .Replace("__SELONLY__", selectionOnly ? "True" : "False")
+                .Replace("__APPLY__", applyModifiers ? "True" : "False")
+                .Replace("__FMT__", fmt);
+        }
+
+        // ----------------------------------------------------------- check_updates
+
+        private static object CheckUpdates()
+        {
+            if (!BlenderBridgePrefs.IsForkConfigured) return new ErrorResponse(NotConfiguredMessage);
+            string fork = BlenderBridgePrefs.ForkPath;
+            if (!Directory.Exists(Path.Combine(fork, ".git")))
+                return new ErrorResponse($"'{fork}' is not a git checkout (no .git folder); check_updates needs one.");
+
+            if (!TryGit(fork, "--version", out _, out string gitErr, 10000))
+                return new ErrorResponse($"git is not available: {gitErr}");
+
+            TryGit(fork, "log -1 --format=%h%x09%ad%x09%s --date=short", out string head, out _);
+            TryGit(fork, "status --porcelain", out string porcelain, out _);
+            TryGit(fork, "remote", out string remotesRaw, out _);
+            var remotes = remotesRaw.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(r => r.Trim()).Where(r => r.Length > 0).ToList();
+
+            var perRemote = new JArray();
+            int totalBehind = 0;
+            foreach (string remote in remotes.OrderBy(r => r == "upstream" ? 0 : r == "origin" ? 1 : 2))
+            {
+                var entry = new JObject { ["remote"] = remote };
+                TryGit(fork, $"remote get-url {remote}", out string url, out _);
+                entry["url"] = url.Trim();
+
+                bool fetched = TryGit(fork, $"fetch --quiet {remote}", out _, out string fetchErr, 90000);
+                entry["fetched"] = fetched;
+                if (!fetched) entry["fetch_error"] = Truncate(fetchErr, 300);
+
+                string branch = "main";
+                if (TryGit(fork, $"symbolic-ref --short refs/remotes/{remote}/HEAD", out string sym, out _) && sym.Trim().Contains('/'))
+                    branch = sym.Trim().Substring(sym.Trim().IndexOf('/') + 1);
+                else if (!TryGit(fork, $"rev-parse --verify --quiet refs/remotes/{remote}/main", out _, out _)
+                         && TryGit(fork, $"rev-parse --verify --quiet refs/remotes/{remote}/master", out _, out _))
+                    branch = "master";
+                entry["branch"] = branch;
+
+                if (TryGit(fork, $"rev-list --left-right --count HEAD...{remote}/{branch}", out string counts, out string cErr))
+                {
+                    var parts = counts.Trim().Split('\t', ' ');
+                    int ahead = parts.Length > 0 && int.TryParse(parts[0], out int a) ? a : 0;
+                    int behind = parts.Length > 1 && int.TryParse(parts[1], out int bb) ? bb : 0;
+                    entry["local_ahead"] = ahead;
+                    entry["behind"] = behind;
+                    if (remote == "upstream" || remotes.Count == 1) totalBehind += behind;
+
+                    TryGit(fork, $"log --format=%h%x20%ad%x20%s --date=short -n 20 HEAD..{remote}/{branch}", out string log, out _);
+                    entry["new_commits"] = new JArray(log.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries));
+                }
+                else
+                {
+                    entry["error"] = Truncate(cErr, 300);
+                }
+                perRemote.Add(entry);
+            }
+
+            string forkAddon = BlenderBridgePrefs.ForkAddonPath;
+            string installedAddon = BlenderBridgePrefs.InstalledAddonPath;
+            string forkMd5 = File.Exists(forkAddon) ? FileMd5(forkAddon) : null;
+            string installedMd5 = installedAddon != null && File.Exists(installedAddon) ? FileMd5(installedAddon) : null;
+            bool addonInSync = forkMd5 != null && forkMd5 == installedMd5;
+
+            int dirty = porcelain.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).Length;
+            var recommendations = new List<string>();
+            if (totalBehind > 0) recommendations.Add($"Checkout is {totalBehind} commit(s) behind upstream: merge upstream into it.");
+            if (!addonInSync) recommendations.Add("Installed Blender addon differs from the checkout's addon.py: run sync_addon, then restart Blender.");
+            if (dirty > 0) recommendations.Add($"Checkout has {dirty} uncommitted change(s).");
+            if (recommendations.Count == 0) recommendations.Add("Everything is up to date.");
+
+            var data = new JObject
+            {
+                ["fork_path"] = fork,
+                ["head"] = head.Trim(),
+                ["uncommitted_changes"] = dirty,
+                ["remotes"] = perRemote,
+                ["fork_addon_md5"] = forkMd5,
+                ["installed_addon_path"] = installedAddon,
+                ["installed_addon_md5"] = installedMd5,
+                ["addon_in_sync"] = addonInSync,
+                ["recommendations"] = new JArray(recommendations),
+            };
+            return new SuccessResponse(string.Join(" ", recommendations), data);
+        }
+
+        // -------------------------------------------------------------- sync_addon
+
+        private static object SyncAddon(bool force)
+        {
+            if (!BlenderBridgePrefs.IsForkConfigured) return new ErrorResponse(NotConfiguredMessage);
+            string src = BlenderBridgePrefs.ForkAddonPath;
+            string dst = BlenderBridgePrefs.InstalledAddonPath;
+            if (!File.Exists(src)) return new ErrorResponse($"addon.py not found in the checkout at {src}.");
+            if (dst == null)
+                return new ErrorResponse("Could not locate Blender's user addons directory. Set it in Window > MCP for Unity > Generative > Blender Bridge.");
+
+            string srcMd5 = FileMd5(src);
+            string dstMd5 = File.Exists(dst) ? FileMd5(dst) : null;
+            if (!force && srcMd5 == dstMd5)
+                return new SuccessResponse("Installed addon already matches the checkout; nothing copied.",
+                    new { source = src, destination = dst, md5 = srcMd5, copied = false });
+
+            Directory.CreateDirectory(Path.GetDirectoryName(dst));
+            string backup = null;
+            if (File.Exists(dst))
+            {
+                backup = dst + ".bak";
+                File.Copy(dst, backup, true);
+            }
+            File.Copy(src, dst, true);
+
+            return new SuccessResponse(
+                "Copied addon.py into Blender. Restart Blender (or Reload Scripts) and press 'Connect to MCP server' again.",
+                new { source = src, destination = dst, backup, previous_md5 = dstMd5, new_md5 = srcMd5, copied = true });
+        }
+
+        // ------------------------------------------------------------------ helpers
+
+        private static bool TryGit(string workingDir, string args, out string stdout, out string stderr, int timeoutMs = 30000)
+        {
+            stdout = string.Empty;
+            stderr = string.Empty;
+            try
+            {
+                var psi = new ProcessStartInfo("git", args)
+                {
+                    WorkingDirectory = workingDir,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    StandardOutputEncoding = Encoding.UTF8,
+                    StandardErrorEncoding = Encoding.UTF8,
+                };
+                psi.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
+                using var proc = Process.Start(psi);
+                if (proc == null) { stderr = "failed to start git"; return false; }
+                var outTask = proc.StandardOutput.ReadToEndAsync();
+                var errTask = proc.StandardError.ReadToEndAsync();
+                if (!proc.WaitForExit(timeoutMs))
+                {
+                    try { proc.Kill(); } catch { /* already gone */ }
+                    stderr = $"git {args} timed out after {timeoutMs} ms";
+                    return false;
+                }
+                stdout = outTask.Result;
+                stderr = errTask.Result;
+                return proc.ExitCode == 0;
+            }
+            catch (Exception e)
+            {
+                stderr = e.Message;
+                return false;
+            }
+        }
+
+        private static string ProjectRoot() => Path.GetDirectoryName(Application.dataPath).Replace('\\', '/');
+
+        /// <summary>Lower-case hex MD5 of a file; shared with the Asset Gen panel's addon-sync indicator.</summary>
+        internal static string FileMd5(string path)
+        {
+            using var md5 = MD5.Create();
+            using var fs = File.OpenRead(path);
+            return BitConverter.ToString(md5.ComputeHash(fs)).Replace("-", "").ToLowerInvariant();
+        }
+
+        private static string SanitizeName(string raw)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            var sb = new StringBuilder();
+            foreach (char c in raw.Trim())
+                sb.Append(invalid.Contains(c) || c == '/' || c == '\\' ? '_' : c);
+            string s = sb.ToString().Trim('_', '.', ' ');
+            return string.IsNullOrEmpty(s) ? "BlenderModel" : s;
+        }
+
+        private static Vector3 ParsePosition(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null) return Vector3.zero;
+            JArray arr = token as JArray;
+            if (arr == null && token.Type == JTokenType.String)
+            {
+                try { arr = JArray.Parse(token.ToString()); } catch { return Vector3.zero; }
+            }
+            if (arr == null || arr.Count < 3) return Vector3.zero;
+            return new Vector3(arr[0].Value<float>(), arr[1].Value<float>(), arr[2].Value<float>());
+        }
+
+        private static bool TryGetWorldBounds(GameObject go, out Bounds bounds)
+        {
+            var renderers = go.GetComponentsInChildren<Renderer>(true);
+            if (renderers.Length == 0)
+            {
+                bounds = default;
+                return false;
+            }
+            bounds = renderers[0].bounds;
+            for (int i = 1; i < renderers.Length; i++) bounds.Encapsulate(renderers[i].bounds);
+            return true;
+        }
+
+        private static string Truncate(string s, int max)
+        {
+            if (string.IsNullOrEmpty(s)) return s ?? string.Empty;
+            s = s.Trim();
+            return s.Length <= max ? s : s.Substring(0, max) + "…";
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
@@ -74,11 +74,7 @@ namespace MCPForUnity.Editor.Tools.Blender
                     }
                     case "import_model": return await ImportModelAsync(p, timeout);
                     case "compare_screenshot": return await CompareScreenshotAsync(p, timeout);
-                    case "setup_bloom":
-                    {
-                        JObject bloom = await SetupBloomAsync();
-                        return new SuccessResponse(bloom["message"]?.ToString() ?? "Bloom configured.", bloom);
-                    }
+                    case "setup_bloom": return ToBloomResponse(await SetupBloomAsync());
                     case "check_updates": return await CheckUpdatesAsync();
                     case "sync_addon": return SyncAddon(p.GetBool("force", false));
                     default:
@@ -555,6 +551,14 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             return result;
         }
 
+        /// <summary>Maps the Bloom setup report to a tool response: an error when manage_graphics could not add Bloom.</summary>
+        internal static object ToBloomResponse(JObject bloom)
+        {
+            string message = bloom?["message"]?.ToString() ?? "Bloom configured.";
+            bool failed = bloom != null && bloom.Value<bool?>("success") == false;
+            return failed ? new ErrorResponse(message) : new SuccessResponse(message, bloom);
+        }
+
         // -------------------------------------------------------- compare_screenshot
 
         /// <summary>Puts a Blender viewport capture and a Unity capture of a placed object side by side in one PNG.</summary>
@@ -835,18 +839,26 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             => $"{DateTime.Now:yyyyMMdd_HHmmss}_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
 
         /// <summary>
-        /// Strips user info (tokens, passwords) from a remote URL so credentials embedded in
-        /// https://user:token@host/... never reach the MCP response or the editor log.
+        /// Strips user info, query and fragment from a remote URL so credentials embedded as
+        /// https://user:token@host/..., ?token=... or #access_token=... never reach the MCP response
+        /// or the editor log. scp-style git@host:path is returned unchanged (no secret there).
         /// </summary>
         internal static string RedactRemoteUrl(string url)
         {
             if (string.IsNullOrEmpty(url)) return url ?? string.Empty;
-            if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri) && !string.IsNullOrEmpty(uri.UserInfo))
-                return new UriBuilder(uri) { UserName = string.Empty, Password = string.Empty }.Uri.ToString();
-            // scp-style git@host:path carries no secret; anything else with "user:secret@" is masked.
-            int at = url.IndexOf('@');
+            if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri) && !string.IsNullOrEmpty(uri.Host))
+            {
+                bool clean = string.IsNullOrEmpty(uri.UserInfo) && string.IsNullOrEmpty(uri.Query) && string.IsNullOrEmpty(uri.Fragment);
+                if (clean) return url;
+                return new UriBuilder(uri) { UserName = string.Empty, Password = string.Empty, Query = string.Empty, Fragment = string.Empty }
+                    .Uri.ToString();
+            }
+            // Not a parseable absolute URI: drop anything after ? or # and mask a user:secret@ prefix.
+            int cut = url.IndexOfAny(new[] { '?', '#' });
+            if (cut >= 0) url = url.Substring(0, cut);
             int scheme = url.IndexOf("://", StringComparison.Ordinal);
-            if (at > 0 && scheme >= 0 && at > scheme && url.IndexOf(':', scheme + 3) is int colon && colon > 0 && colon < at)
+            int at = url.IndexOf('@');
+            if (scheme >= 0 && at > scheme)
                 return url.Substring(0, scheme + 3) + "***@" + url.Substring(at + 1);
             return url;
         }

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
@@ -388,8 +388,11 @@ else:
 print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': use_sel,
                   'exported': [o.name for o in (bpy.context.selected_objects if use_sel else bpy.context.scene.objects)]}))
 ";
-            int at = template.IndexOf("__CFG__", StringComparison.Ordinal);
-            return template.Substring(0, at) + configLiteral + template.Substring(at + "__CFG__".Length);
+            // Verbatim strings take the checkout's line endings; normalize so the script (and tests) are
+            // byte-identical whether the file was checked out with LF or CRLF.
+            string body = template.Replace("\r\n", "\n");
+            int at = body.IndexOf("__CFG__", StringComparison.Ordinal);
+            return body.Substring(0, at) + configLiteral + body.Substring(at + "__CFG__".Length);
         }
 
         // ---------------------------------------------------------- finishing touches

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs
@@ -10,6 +10,7 @@ using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Security;
 using MCPForUnity.Editor.Services.Blender;
 using MCPForUnity.Editor.Tools.AssetGen;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
@@ -504,7 +505,7 @@ print(json.dumps({'path': out, 'bytes': os.path.getsize(out), 'selection_only': 
             System.Reflection.PropertyInfo isGlobal = volumeType.GetProperty("isGlobal");
             System.Reflection.FieldInfo sharedProfile = volumeType.GetField("sharedProfile");
             Component globalVolume = null;
-            foreach (UnityEngine.Object v in UnityEngine.Object.FindObjectsByType(volumeType, FindObjectsSortMode.None))
+            foreach (UnityEngine.Object v in UnityFindObjectsCompat.FindAll(volumeType))
             {
                 var comp = v as Component;
                 if (comp == null || (isGlobal != null && !(bool)isGlobal.GetValue(comp))) continue;

--- a/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs.meta
+++ b/MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b800c597408744668544a1b31f757ddd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.cs
@@ -13,7 +13,9 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
     /// Controller for the AI Asset Generation settings tab. This tab is CONFIG ONLY:
     /// it lets users enter/clear per-provider API keys, toggle providers on/off,
     /// presence-check a key, and set non-secret generation preferences.
-    /// Generation itself is never triggered here — only via MCP tools / CLI.
+    /// Generation itself is never triggered here — only via MCP tools / CLI. The one exception is
+    /// the Blender Bridge block (<see cref="McpBlenderBridgePanel"/>): its buttons run local socket
+    /// and file operations against a Blender on this machine, never a paid provider call.
     ///
     /// Keys are written to the OS secure store (<see cref="SecureKeyStore"/>), never to
     /// EditorPrefs or the project. The stored key is never read back into the field; only
@@ -44,6 +46,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         private Toggle autoNormalizeToggle;
         private Button refreshButton;
         private Label refreshStatusLabel;
+        private McpBlenderBridgePanel blenderPanel;
 
         // Per-provider enable toggles for the GLB-capable (model) providers, used to
         // recompute the glTFast notice when a toggle changes.
@@ -68,6 +71,9 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             autoNormalizeToggle = Root.Q<Toggle>("assetgen-auto-normalize");
             refreshButton = Root.Q<Button>("assetgen-refresh");
             refreshStatusLabel = Root.Q<Label>("assetgen-refresh-status");
+
+            var blenderRoot = Root.Q<VisualElement>("blender-bridge-panel");
+            if (blenderRoot != null) blenderPanel = new McpBlenderBridgePanel(blenderRoot);
         }
 
         private void InitializeUI()
@@ -146,7 +152,11 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         /// Re-reads secure-store presence and prefs and rebuilds the rows. Called when the
         /// tab becomes visible so keys set elsewhere (e.g. via CLI) are reflected.
         /// </summary>
-        public void Refresh() => SyncFromPrefs();
+        public void Refresh()
+        {
+            SyncFromPrefs();
+            blenderPanel?.Refresh();
+        }
 
         /// <summary>Rebuild the provider rows and reflect current prefs into the fields.</summary>
         private void SyncFromPrefs()
@@ -183,8 +193,6 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
 
             var audioPanel = AddCategoryPanel("Sound (fal.ai)");
             AddAudioRow(audioPanel);
-
-            AddBlenderHandoffRow();
         }
 
         /// <summary>
@@ -212,42 +220,6 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
 
             providersContainer.Add(panel);
             return panel;
-        }
-
-        private void AddGroupLabel(string text)
-        {
-            var label = new Label(text);
-            label.AddToClassList("config-label");
-            providersContainer.Add(label);
-        }
-
-        /// <summary>
-        /// Informational handoff row (not a keyed provider): best-effort "is Blender installed"
-        /// status + a pointer to the blender-to-unity workflow. BlenderMCP itself runs in the AI
-        /// client and isn't detectable from Unity, so this only reports the local Blender app.
-        /// </summary>
-        private void AddBlenderHandoffRow()
-        {
-            AddGroupLabel("Blender → Unity Handoff");
-
-            var row = new VisualElement();
-            row.style.marginBottom = 8;
-
-            bool blender = BlenderDetection.IsInstalled();
-            var status = new Label(blender ? "Blender app detected ✓" : "Blender app not found on this machine");
-            status.AddToClassList("help-text");
-            status.style.color = blender ? new Color(0.4f, 0.8f, 0.4f) : new Color(0.7f, 0.7f, 0.7f);
-            row.Add(status);
-
-            var help = new Label(
-                "Pair Blender with the BlenderMCP server in your AI client, then run the blender-to-unity " +
-                "skill to export the current model — it imports via the import_model_file tool. (BlenderMCP " +
-                "is configured in your AI client and can't be detected here.)");
-            help.AddToClassList("help-text");
-            help.style.whiteSpace = WhiteSpace.Normal;
-            row.Add(help);
-
-            providersContainer.Add(row);
         }
 
         private Toggle AddProviderRow(VisualElement parent, string id, string displayName, string kind)

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.uxml
@@ -12,6 +12,46 @@
                 <ui:Label name="assetgen-refresh-status" class="help-text" />
             </ui:VisualElement>
             <ui:VisualElement name="assetgen-providers-container" style="margin-top: 8px;" />
+            <ui:VisualElement name="blender-bridge-panel" style="background-color: rgba(0, 0, 0, 0.2); padding: 8px; margin-bottom: 10px; border-radius: 4px;">
+                <ui:VisualElement class="override-row" style="margin-top: 0;">
+                    <ui:Label text="Blender Bridge" class="config-label" style="margin-top: 0;" />
+                    <ui:VisualElement name="blender-status-dot" class="status-indicator-small" />
+                    <ui:Label name="blender-status-label" class="help-text" style="margin-left: 6px; margin-bottom: 0; flex-grow: 1;" />
+                </ui:VisualElement>
+                <ui:Label class="help-text" style="white-space: normal;" text="Talks directly to the BlenderMCP addon socket in a running Blender (N panel &#8594; Connect to MCP server). Powers the blender_bridge tool and Window &#8594; MCP for Unity &#8594; Blender Bridge. No API keys involved." />
+                <ui:VisualElement name="blender-not-configured" class="warning-banner">
+                    <ui:Label class="warning-banner-text" text="Pick your blender-mcp checkout below to enable Sync Addon and Check Updates. Import and screenshot work without it." />
+                </ui:VisualElement>
+                <ui:VisualElement class="setting-row">
+                    <ui:Label text="Addon Socket:" class="setting-label" />
+                    <ui:TextField name="blender-host" style="width: 140px;" />
+                    <ui:IntegerField name="blender-port" style="width: 70px; margin-left: 4px;" />
+                    <ui:Button name="blender-test-button" text="Test Connection" class="icon-button" style="margin-left: 8px;" />
+                </ui:VisualElement>
+                <ui:VisualElement class="override-row">
+                    <ui:Label text="blender-mcp Checkout:" class="override-label" />
+                </ui:VisualElement>
+                <ui:VisualElement class="path-override-controls">
+                    <ui:TextField name="blender-fork-path" placeholder-text="/path/to/blender-mcp (contains addon.py)" class="override-field" />
+                    <ui:Button name="blender-fork-select-button" text="Select" class="icon-button" />
+                    <ui:Button name="blender-fork-clear-button" text="Clear" class="icon-button" />
+                </ui:VisualElement>
+                <ui:VisualElement class="override-row">
+                    <ui:Label text="Blender Addons Dir:" class="override-label" />
+                </ui:VisualElement>
+                <ui:VisualElement class="path-override-controls">
+                    <ui:TextField name="blender-addons-dir" placeholder-text="auto-detect newest Blender user addons folder" class="override-field" />
+                    <ui:Button name="blender-addons-select-button" text="Select" class="icon-button" />
+                    <ui:Button name="blender-addons-clear-button" text="Clear" class="icon-button" />
+                </ui:VisualElement>
+                <ui:Label name="blender-addons-resolved" class="help-text" style="white-space: normal;" />
+                <ui:VisualElement class="path-override-controls" style="margin-top: 4px; margin-bottom: 4px;">
+                    <ui:Button name="blender-sync-button" text="Sync Addon" class="icon-button" />
+                    <ui:Button name="blender-updates-button" text="Check Updates" class="icon-button" />
+                    <ui:Button name="blender-import-button" text="Import Selection (GLB)" class="icon-button" />
+                </ui:VisualElement>
+                <ui:Label name="blender-action-status" class="help-text" style="white-space: normal;" />
+            </ui:VisualElement>
             <ui:Label text="Preferences" class="config-label" />
             <ui:VisualElement class="setting-row">
                 <ui:Label text="Default 3D Format:" class="setting-label" />

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.uxml
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpAssetGenSection.uxml
@@ -25,7 +25,7 @@
                 <ui:VisualElement class="setting-row">
                     <ui:Label text="Addon Socket:" class="setting-label" />
                     <ui:TextField name="blender-host" style="width: 140px;" />
-                    <ui:IntegerField name="blender-port" style="width: 70px; margin-left: 4px;" />
+                    <ui:TextField name="blender-port" style="width: 70px; margin-left: 4px;" />
                     <ui:Button name="blender-test-button" text="Test Connection" class="icon-button" style="margin-left: 8px;" />
                 </ui:VisualElement>
                 <ui:VisualElement class="override-row">

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Services.Blender;
 using MCPForUnity.Editor.Tools.Blender;
@@ -14,8 +15,9 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
     /// <summary>
     /// Controller for the "Blender Bridge" block of the Asset Gen tab: addon socket host/port,
     /// the user's blender-mcp checkout, Blender's addons folder, plus Test Connection / Sync Addon /
-    /// Check Updates / Import Selection buttons that call <see cref="BlenderBridgeTool"/> directly.
-    /// Unlike the provider rows, nothing here is a paid API call — it is local file and socket I/O.
+    /// Check Updates / Import Selection buttons that call <see cref="BlenderBridgeTool"/>.
+    /// Unlike the provider rows, nothing here is a paid API call — it is local file and socket I/O,
+    /// awaited off the editor thread so the window never freezes while Blender works.
     /// </summary>
     public class McpBlenderBridgePanel
     {
@@ -36,6 +38,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         private Button syncButton;
         private Button updatesButton;
         private Button importButton;
+        private bool busy;
 
         public VisualElement Root { get; }
 
@@ -47,6 +50,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             RegisterCallbacks();
         }
 
+        /// <summary>Looks up the UXML elements by name.</summary>
         private void CacheUIElements()
         {
             hostField = Root.Q<TextField>("blender-host");
@@ -68,6 +72,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             importButton = Root.Q<Button>("blender-import-button");
         }
 
+        /// <summary>Sets tooltips and populates the fields from prefs.</summary>
         private void InitializeUI()
         {
             if (hostField != null) hostField.tooltip = "Host the BlenderMCP addon socket listens on (Blender's N panel > BlenderMCP).";
@@ -84,6 +89,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             SyncFromPrefs();
         }
 
+        /// <summary>Wires field persistence and the action buttons.</summary>
         private void RegisterCallbacks()
         {
             hostField?.RegisterCallback<FocusOutEvent>(_ =>
@@ -109,19 +115,21 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             if (addonsClearButton != null) addonsClearButton.clicked += () => SetAddonsDir(string.Empty);
 
             if (testButton != null) testButton.clicked += OnTestConnection;
-            if (syncButton != null) syncButton.clicked += () =>
+            if (syncButton != null) syncButton.clicked += async () =>
             {
-                RunAction(new JObject { ["action"] = "sync_addon" });
+                await RunActionAsync(new JObject { ["action"] = "sync_addon" });
                 UpdateAddonStatus();
             };
-            if (updatesButton != null) updatesButton.clicked += () => RunAction(new JObject { ["action"] = "check_updates" });
-            if (importButton != null) importButton.clicked += () =>
-                RunAction(new JObject { ["action"] = "import_model", ["selection_only"] = true, ["format"] = "glb" });
+            if (updatesButton != null) updatesButton.clicked += async () =>
+                await RunActionAsync(new JObject { ["action"] = "check_updates" });
+            if (importButton != null) importButton.clicked += async () =>
+                await RunActionAsync(new JObject { ["action"] = "import_model", ["selection_only"] = true, ["format"] = "glb" });
         }
 
         /// <summary>Re-reads prefs and the on-disk addon state. Never touches the socket.</summary>
         public void Refresh() => SyncFromPrefs();
 
+        /// <summary>Reflects prefs into the fields, banner, button states and addon status line.</summary>
         private void SyncFromPrefs()
         {
             hostField?.SetValueWithoutNotify(BlenderBridgePrefs.Host);
@@ -129,17 +137,15 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             forkField?.SetValueWithoutNotify(BlenderBridgePrefs.ForkPath);
             addonsField?.SetValueWithoutNotify(BlenderBridgePrefs.AddonsDirOverride);
 
-            bool configured = BlenderBridgePrefs.IsForkConfigured;
-            notConfiguredBanner?.EnableInClassList("visible", !configured);
-            syncButton?.SetEnabled(configured);
-            updatesButton?.SetEnabled(configured);
-
+            notConfiguredBanner?.EnableInClassList("visible", !BlenderBridgePrefs.IsForkConfigured);
+            UpdateButtonStates();
             UpdateAddonStatus();
             SetConnectionStatus(null, BlenderDetection.IsInstalled()
                 ? "Blender app detected — press Test Connection"
                 : "Blender app not found on this machine — press Test Connection if it runs elsewhere");
         }
 
+        /// <summary>Validates and persists the checkout folder; rejects folders without addon.py.</summary>
         private void SetForkPath(string path)
         {
             string normalized = BlenderBridgePrefs.NormalizePath(path);
@@ -154,6 +160,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             SyncFromPrefs();
         }
 
+        /// <summary>Opens a folder picker for the checkout.</summary>
         private void OnSelectFork()
         {
             string picked = EditorUtility.OpenFolderPanel("Select blender-mcp checkout (folder containing addon.py)",
@@ -161,6 +168,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             if (!string.IsNullOrEmpty(picked)) SetForkPath(picked);
         }
 
+        /// <summary>Validates and persists the addons folder override.</summary>
         private void SetAddonsDir(string path)
         {
             string normalized = BlenderBridgePrefs.NormalizePath(path);
@@ -174,6 +182,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             SyncFromPrefs();
         }
 
+        /// <summary>Opens a folder picker for the addons folder.</summary>
         private void OnSelectAddonsDir()
         {
             string picked = EditorUtility.OpenFolderPanel("Select Blender user addons folder (…/scripts/addons)",
@@ -181,6 +190,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             if (!string.IsNullOrEmpty(picked)) SetAddonsDir(picked);
         }
 
+        /// <summary>Shows the resolved addons folder and whether the installed addon matches the checkout.</summary>
         private void UpdateAddonStatus()
         {
             if (addonsResolvedLabel == null) return;
@@ -210,14 +220,29 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             addonsResolvedLabel.style.color = ok ? new Color(0.4f, 0.8f, 0.4f) : new Color(0.7f, 0.7f, 0.7f);
         }
 
-        private void OnTestConnection()
+        /// <summary>Probes the addon socket off the editor thread and shows the result on the status dot.</summary>
+        private async void OnTestConnection()
         {
-            bool ok = BlenderSocketClient.IsReachable(out string error);
-            SetConnectionStatus(ok, ok
-                ? $"Blender reachable at {BlenderBridgePrefs.Host}:{BlenderBridgePrefs.Port}"
-                : Truncate(error, 160));
+            if (busy) return;
+            BlenderEndpoint endpoint = BlenderBridgePrefs.Endpoint;
+            SetBusy(true);
+            SetConnectionStatus(null, $"Testing {endpoint}…");
+            try
+            {
+                var (ok, error) = await BlenderSocketClient.ProbeAsync(endpoint);
+                SetConnectionStatus(ok, ok ? $"Blender reachable at {endpoint}" : Truncate(error, 160));
+            }
+            catch (Exception e)
+            {
+                SetConnectionStatus(false, Truncate(e.Message, 160));
+            }
+            finally
+            {
+                SetBusy(false);
+            }
         }
 
+        /// <summary>Colours the status dot: green for reachable, red for failed, amber for unknown.</summary>
         private void SetConnectionStatus(bool? ok, string text)
         {
             if (statusLabel != null) statusLabel.text = text;
@@ -230,16 +255,24 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             else statusDot.AddToClassList("warning");
         }
 
-        private JObject RunAction(JObject parameters)
+        /// <summary>Runs one bridge action without blocking the editor and reports its message.</summary>
+        private async Task<JObject> RunActionAsync(JObject parameters)
         {
+            if (busy) return null;
+            SetBusy(true);
+            SetActionStatus($"Running {parameters["action"]}…", false);
             JObject json;
             try
             {
-                json = JObject.FromObject(BlenderBridgeTool.HandleCommand(parameters));
+                json = JObject.FromObject(await BlenderBridgeTool.HandleCommand(parameters));
             }
             catch (Exception e)
             {
                 json = new JObject { ["success"] = false, ["error"] = e.Message };
+            }
+            finally
+            {
+                SetBusy(false);
             }
 
             bool ok = json.Value<bool?>("success") ?? false;
@@ -252,6 +285,24 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             return json;
         }
 
+        /// <summary>Disables the action buttons while a bridge call is in flight.</summary>
+        private void SetBusy(bool value)
+        {
+            busy = value;
+            UpdateButtonStates();
+        }
+
+        /// <summary>Applies busy state and checkout-dependent availability to the buttons.</summary>
+        private void UpdateButtonStates()
+        {
+            bool configured = BlenderBridgePrefs.IsForkConfigured;
+            testButton?.SetEnabled(!busy);
+            importButton?.SetEnabled(!busy);
+            syncButton?.SetEnabled(!busy && configured);
+            updatesButton?.SetEnabled(!busy && configured);
+        }
+
+        /// <summary>Writes the last action's outcome under the buttons, red on error.</summary>
         private void SetActionStatus(string text, bool isError)
         {
             if (actionStatusLabel == null) return;
@@ -260,6 +311,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
             else actionStatusLabel.style.color = StyleKeyword.Null;
         }
 
+        /// <summary>Caps a message for the status labels.</summary>
         private static string Truncate(string s, int max)
         {
             if (string.IsNullOrEmpty(s)) return string.Empty;

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs
@@ -1,0 +1,269 @@
+using System;
+using System.IO;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Services.Blender;
+using MCPForUnity.Editor.Tools.Blender;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace MCPForUnity.Editor.Windows.Components.AssetGen
+{
+    /// <summary>
+    /// Controller for the "Blender Bridge" block of the Asset Gen tab: addon socket host/port,
+    /// the user's blender-mcp checkout, Blender's addons folder, plus Test Connection / Sync Addon /
+    /// Check Updates / Import Selection buttons that call <see cref="BlenderBridgeTool"/> directly.
+    /// Unlike the provider rows, nothing here is a paid API call — it is local file and socket I/O.
+    /// </summary>
+    public class McpBlenderBridgePanel
+    {
+        private TextField hostField;
+        private IntegerField portField;
+        private Button testButton;
+        private TextField forkField;
+        private Button forkSelectButton;
+        private Button forkClearButton;
+        private TextField addonsField;
+        private Button addonsSelectButton;
+        private Button addonsClearButton;
+        private Label addonsResolvedLabel;
+        private Label statusLabel;
+        private Label actionStatusLabel;
+        private VisualElement statusDot;
+        private VisualElement notConfiguredBanner;
+        private Button syncButton;
+        private Button updatesButton;
+        private Button importButton;
+
+        public VisualElement Root { get; }
+
+        public McpBlenderBridgePanel(VisualElement root)
+        {
+            Root = root;
+            CacheUIElements();
+            InitializeUI();
+            RegisterCallbacks();
+        }
+
+        private void CacheUIElements()
+        {
+            hostField = Root.Q<TextField>("blender-host");
+            portField = Root.Q<IntegerField>("blender-port");
+            testButton = Root.Q<Button>("blender-test-button");
+            forkField = Root.Q<TextField>("blender-fork-path");
+            forkSelectButton = Root.Q<Button>("blender-fork-select-button");
+            forkClearButton = Root.Q<Button>("blender-fork-clear-button");
+            addonsField = Root.Q<TextField>("blender-addons-dir");
+            addonsSelectButton = Root.Q<Button>("blender-addons-select-button");
+            addonsClearButton = Root.Q<Button>("blender-addons-clear-button");
+            addonsResolvedLabel = Root.Q<Label>("blender-addons-resolved");
+            statusLabel = Root.Q<Label>("blender-status-label");
+            actionStatusLabel = Root.Q<Label>("blender-action-status");
+            statusDot = Root.Q<VisualElement>("blender-status-dot");
+            notConfiguredBanner = Root.Q<VisualElement>("blender-not-configured");
+            syncButton = Root.Q<Button>("blender-sync-button");
+            updatesButton = Root.Q<Button>("blender-updates-button");
+            importButton = Root.Q<Button>("blender-import-button");
+        }
+
+        private void InitializeUI()
+        {
+            if (hostField != null) hostField.tooltip = "Host the BlenderMCP addon socket listens on (Blender's N panel > BlenderMCP).";
+            if (portField != null) portField.tooltip = $"Addon socket port. Default {BlenderBridgePrefs.DefaultPort}.";
+            if (testButton != null) testButton.tooltip = "Send get_scene_info to the addon socket. Blender must be running with the addon connected.";
+            if (forkField != null)
+                forkField.tooltip = "Folder of your blender-mcp checkout (the one containing addon.py). Enables Sync Addon and Check Updates.";
+            if (addonsField != null)
+                addonsField.tooltip = "Blender's user addons folder. Leave empty to auto-detect the newest Blender version's scripts/addons.";
+            if (syncButton != null) syncButton.tooltip = "Copy the checkout's addon.py into Blender's addons folder (backs up the old file).";
+            if (updatesButton != null) updatesButton.tooltip = "git fetch the checkout and report how far behind its remotes it is.";
+            if (importButton != null) importButton.tooltip = "Export what is selected in Blender as GLB, import it and place it in the open scene.";
+
+            SyncFromPrefs();
+        }
+
+        private void RegisterCallbacks()
+        {
+            hostField?.RegisterCallback<FocusOutEvent>(_ =>
+            {
+                BlenderBridgePrefs.Host = hostField.text;
+                hostField.SetValueWithoutNotify(BlenderBridgePrefs.Host);
+                SetConnectionStatus(null, "Unknown — press Test Connection");
+            });
+
+            portField?.RegisterValueChangedCallback(evt =>
+            {
+                BlenderBridgePrefs.Port = evt.newValue;
+                portField.SetValueWithoutNotify(BlenderBridgePrefs.Port);
+                SetConnectionStatus(null, "Unknown — press Test Connection");
+            });
+
+            forkField?.RegisterCallback<FocusOutEvent>(_ => SetForkPath(forkField.text));
+            if (forkSelectButton != null) forkSelectButton.clicked += OnSelectFork;
+            if (forkClearButton != null) forkClearButton.clicked += () => SetForkPath(string.Empty);
+
+            addonsField?.RegisterCallback<FocusOutEvent>(_ => SetAddonsDir(addonsField.text));
+            if (addonsSelectButton != null) addonsSelectButton.clicked += OnSelectAddonsDir;
+            if (addonsClearButton != null) addonsClearButton.clicked += () => SetAddonsDir(string.Empty);
+
+            if (testButton != null) testButton.clicked += OnTestConnection;
+            if (syncButton != null) syncButton.clicked += () =>
+            {
+                RunAction(new JObject { ["action"] = "sync_addon" });
+                UpdateAddonStatus();
+            };
+            if (updatesButton != null) updatesButton.clicked += () => RunAction(new JObject { ["action"] = "check_updates" });
+            if (importButton != null) importButton.clicked += () =>
+                RunAction(new JObject { ["action"] = "import_model", ["selection_only"] = true, ["format"] = "glb" });
+        }
+
+        /// <summary>Re-reads prefs and the on-disk addon state. Never touches the socket.</summary>
+        public void Refresh() => SyncFromPrefs();
+
+        private void SyncFromPrefs()
+        {
+            hostField?.SetValueWithoutNotify(BlenderBridgePrefs.Host);
+            portField?.SetValueWithoutNotify(BlenderBridgePrefs.Port);
+            forkField?.SetValueWithoutNotify(BlenderBridgePrefs.ForkPath);
+            addonsField?.SetValueWithoutNotify(BlenderBridgePrefs.AddonsDirOverride);
+
+            bool configured = BlenderBridgePrefs.IsForkConfigured;
+            notConfiguredBanner?.EnableInClassList("visible", !configured);
+            syncButton?.SetEnabled(configured);
+            updatesButton?.SetEnabled(configured);
+
+            UpdateAddonStatus();
+            SetConnectionStatus(null, BlenderDetection.IsInstalled()
+                ? "Blender app detected — press Test Connection"
+                : "Blender app not found on this machine — press Test Connection if it runs elsewhere");
+        }
+
+        private void SetForkPath(string path)
+        {
+            string normalized = BlenderBridgePrefs.NormalizePath(path);
+            if (!string.IsNullOrEmpty(normalized) && !BlenderBridgePrefs.IsValidForkPath(normalized))
+            {
+                EditorUtility.DisplayDialog("Invalid blender-mcp checkout",
+                    $"No {BlenderBridgePrefs.AddonFileName} found in:\n{normalized}\n\nPick the folder that contains addon.py.", "OK");
+                forkField?.SetValueWithoutNotify(BlenderBridgePrefs.ForkPath);
+                return;
+            }
+            BlenderBridgePrefs.ForkPath = normalized;
+            SyncFromPrefs();
+        }
+
+        private void OnSelectFork()
+        {
+            string picked = EditorUtility.OpenFolderPanel("Select blender-mcp checkout (folder containing addon.py)",
+                BlenderBridgePrefs.ForkPath, "");
+            if (!string.IsNullOrEmpty(picked)) SetForkPath(picked);
+        }
+
+        private void SetAddonsDir(string path)
+        {
+            string normalized = BlenderBridgePrefs.NormalizePath(path);
+            if (!string.IsNullOrEmpty(normalized) && !Directory.Exists(normalized))
+            {
+                EditorUtility.DisplayDialog("Folder not found", $"Blender addons folder does not exist:\n{normalized}", "OK");
+                addonsField?.SetValueWithoutNotify(BlenderBridgePrefs.AddonsDirOverride);
+                return;
+            }
+            BlenderBridgePrefs.AddonsDirOverride = normalized;
+            SyncFromPrefs();
+        }
+
+        private void OnSelectAddonsDir()
+        {
+            string picked = EditorUtility.OpenFolderPanel("Select Blender user addons folder (…/scripts/addons)",
+                BlenderBridgePrefs.ResolveAddonsDir() ?? "", "");
+            if (!string.IsNullOrEmpty(picked)) SetAddonsDir(picked);
+        }
+
+        private void UpdateAddonStatus()
+        {
+            if (addonsResolvedLabel == null) return;
+
+            string dir = BlenderBridgePrefs.ResolveAddonsDir();
+            string text = string.IsNullOrEmpty(dir) ? "Addons folder: not found" : $"Addons folder: {dir}";
+            bool ok = !string.IsNullOrEmpty(dir);
+
+            if (BlenderBridgePrefs.IsForkConfigured && ok)
+            {
+                string src = BlenderBridgePrefs.ForkAddonPath;
+                string dst = BlenderBridgePrefs.InstalledAddonPath;
+                try
+                {
+                    if (!File.Exists(dst)) { text += " · addon not installed (Sync Addon)"; ok = false; }
+                    else if (BlenderBridgeTool.FileMd5(src) == BlenderBridgeTool.FileMd5(dst)) text += " · addon in sync ✓";
+                    else { text += " · addon differs from checkout (Sync Addon)"; ok = false; }
+                }
+                catch (Exception e)
+                {
+                    text += $" · could not compare addon files: {e.Message}";
+                    ok = false;
+                }
+            }
+
+            addonsResolvedLabel.text = text;
+            addonsResolvedLabel.style.color = ok ? new Color(0.4f, 0.8f, 0.4f) : new Color(0.7f, 0.7f, 0.7f);
+        }
+
+        private void OnTestConnection()
+        {
+            bool ok = BlenderSocketClient.IsReachable(out string error);
+            SetConnectionStatus(ok, ok
+                ? $"Blender reachable at {BlenderBridgePrefs.Host}:{BlenderBridgePrefs.Port}"
+                : Truncate(error, 160));
+        }
+
+        private void SetConnectionStatus(bool? ok, string text)
+        {
+            if (statusLabel != null) statusLabel.text = text;
+            if (statusDot == null) return;
+            statusDot.RemoveFromClassList("valid");
+            statusDot.RemoveFromClassList("invalid");
+            statusDot.RemoveFromClassList("warning");
+            if (ok == true) statusDot.AddToClassList("valid");
+            else if (ok == false) statusDot.AddToClassList("invalid");
+            else statusDot.AddToClassList("warning");
+        }
+
+        private JObject RunAction(JObject parameters)
+        {
+            JObject json;
+            try
+            {
+                json = JObject.FromObject(BlenderBridgeTool.HandleCommand(parameters));
+            }
+            catch (Exception e)
+            {
+                json = new JObject { ["success"] = false, ["error"] = e.Message };
+            }
+
+            bool ok = json.Value<bool?>("success") ?? false;
+            string message = ok ? json["message"]?.ToString() : json["error"]?.ToString();
+            SetActionStatus(message ?? (ok ? "done" : "failed"), !ok);
+
+            string details = json.ToString(Formatting.Indented);
+            if (ok) McpLog.Info($"[Blender Bridge] {parameters["action"]}: {message}\n{details}");
+            else McpLog.Warn($"[Blender Bridge] {parameters["action"]} failed: {message}\n{details}");
+            return json;
+        }
+
+        private void SetActionStatus(string text, bool isError)
+        {
+            if (actionStatusLabel == null) return;
+            actionStatusLabel.text = Truncate(text, 240);
+            if (isError) actionStatusLabel.style.color = new StyleColor(new Color(0.85f, 0.2f, 0.2f));
+            else actionStatusLabel.style.color = StyleKeyword.Null;
+        }
+
+        private static string Truncate(string s, int max)
+        {
+            if (string.IsNullOrEmpty(s)) return string.Empty;
+            return s.Length <= max ? s : s.Substring(0, max) + "…";
+        }
+    }
+}

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs
@@ -22,7 +22,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
     public class McpBlenderBridgePanel
     {
         private TextField hostField;
-        private IntegerField portField;
+        private TextField portField;
         private Button testButton;
         private TextField forkField;
         private Button forkSelectButton;
@@ -54,7 +54,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         private void CacheUIElements()
         {
             hostField = Root.Q<TextField>("blender-host");
-            portField = Root.Q<IntegerField>("blender-port");
+            portField = Root.Q<TextField>("blender-port");
             testButton = Root.Q<Button>("blender-test-button");
             forkField = Root.Q<TextField>("blender-fork-path");
             forkSelectButton = Root.Q<Button>("blender-fork-select-button");
@@ -99,10 +99,13 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
                 SetConnectionStatus(null, "Unknown — press Test Connection");
             });
 
-            portField?.RegisterValueChangedCallback(evt =>
+            // A TextField rather than IntegerField: the latter is editor-only (UnityEditor.UIElements) on the
+            // 2021.3 floor and lives in UnityEngine.UIElements from 2022.1, so a plain text field is the one
+            // control that resolves identically across the supported range.
+            portField?.RegisterCallback<FocusOutEvent>(_ =>
             {
-                BlenderBridgePrefs.Port = evt.newValue;
-                portField.SetValueWithoutNotify(BlenderBridgePrefs.Port);
+                if (int.TryParse(portField.text?.Trim(), out int port)) BlenderBridgePrefs.Port = port;
+                portField.SetValueWithoutNotify(BlenderBridgePrefs.Port.ToString());
                 SetConnectionStatus(null, "Unknown — press Test Connection");
             });
 
@@ -133,7 +136,7 @@ namespace MCPForUnity.Editor.Windows.Components.AssetGen
         private void SyncFromPrefs()
         {
             hostField?.SetValueWithoutNotify(BlenderBridgePrefs.Host);
-            portField?.SetValueWithoutNotify(BlenderBridgePrefs.Port);
+            portField?.SetValueWithoutNotify(BlenderBridgePrefs.Port.ToString());
             forkField?.SetValueWithoutNotify(BlenderBridgePrefs.ForkPath);
             addonsField?.SetValueWithoutNotify(BlenderBridgePrefs.AddonsDirOverride);
 

--- a/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs.meta
+++ b/MCPForUnity/Editor/Windows/Components/AssetGen/McpBlenderBridgePanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb0ac8bff43b4c8ca550ee35720fea37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Full history: [Release Notes](https://coplaydev.github.io/unity-mcp/releases).
 
 ## What it does
 
-Control the Unity Editor in natural language from any MCP client — create scenes & GameObjects, edit C# scripts, manage assets, run tests, profile, and build. 47 focused MCP tool entrypoints, any client, free & MIT.
+Control the Unity Editor in natural language from any MCP client — create scenes & GameObjects, edit C# scripts, manage assets, run tests, profile, and build. 48 focused MCP tool entrypoints, any client, free & MIT.
 
 **[Browse the full tool catalog →](https://coplaydev.github.io/unity-mcp/reference/tools/)**
 

--- a/Server/src/cli/commands/blender.py
+++ b/Server/src/cli/commands/blender.py
@@ -20,6 +20,7 @@ def blender():
 
 
 def _run(action: str, params: Optional[dict[str, Any]] = None) -> None:
+    """Send one blender_bridge action to Unity (None-valued params dropped) and print the result."""
     config = get_config()
     payload: dict[str, Any] = {"action": action}
     payload.update({k: v for k, v in (params or {}).items() if v is not None})

--- a/Server/src/cli/commands/blender.py
+++ b/Server/src/cli/commands/blender.py
@@ -1,0 +1,140 @@
+"""Blender Bridge CLI commands (drive a running Blender from the Unity Editor).
+
+Thin pass-through to Unity over HTTP: Unity opens the BlenderMCP addon socket itself and
+runs the export/import/placement. These commands carry NO API keys and NO file bytes.
+"""
+
+from typing import Any, Optional
+
+import click
+
+from cli.utils.config import get_config
+from cli.utils.connection import handle_unity_errors, run_command
+from cli.utils.output import format_output
+
+
+@click.group(name="blender")
+def blender():
+    """Blender Bridge - talk to a running Blender (BlenderMCP addon) from Unity."""
+    pass
+
+
+def _run(action: str, params: Optional[dict[str, Any]] = None) -> None:
+    config = get_config()
+    payload: dict[str, Any] = {"action": action}
+    payload.update({k: v for k, v in (params or {}).items() if v is not None})
+    result = run_command("blender_bridge", payload, config)
+    click.echo(format_output(result, config.format))
+
+
+@blender.command("status")
+@handle_unity_errors
+def status():
+    """Report whether Blender is reachable and whether the installed addon matches the checkout."""
+    _run("status")
+
+
+@blender.command("scene-info")
+@handle_unity_errors
+def scene_info():
+    """Print Blender's current scene summary."""
+    _run("scene_info")
+
+
+@blender.command("object-info")
+@click.option("--object-name", "object_name", required=True, help="Blender object name.")
+@handle_unity_errors
+def object_info(object_name: str):
+    """Print details about one Blender object."""
+    _run("object_info", {"objectName": object_name})
+
+
+@blender.command("screenshot")
+@click.option("--max-size", "max_size", default=None, type=int, help="Max pixels on the longest side.")
+@click.option("--output-folder", "output_folder", default=None, help="Copy the PNG under this Assets/ folder.")
+@handle_unity_errors
+def screenshot(max_size: Optional[int], output_folder: Optional[str]):
+    """Capture Blender's viewport to a PNG."""
+    _run("screenshot", {"maxSize": max_size, "outputFolder": output_folder})
+
+
+@blender.command("run-python")
+@click.option("--code", default=None, help="Python source to run inside Blender.")
+@click.option("--file", "file_path", default=None, type=click.Path(exists=True, dir_okay=False),
+              help="Read the Python source from this file instead of --code.")
+@handle_unity_errors
+def run_python(code: Optional[str], file_path: Optional[str]):
+    """Execute Python inside Blender and print its stdout."""
+    if not code and not file_path:
+        raise click.UsageError("Pass --code or --file.")
+    if file_path:
+        with open(file_path, encoding="utf-8") as fh:
+            code = fh.read()
+    _run("run_python", {"code": code})
+
+
+@blender.command("import-model")
+@click.option("--object", "object_names", multiple=True, help="Blender object to export (repeatable). Children included.")
+@click.option("--selection-only", "selection_only", is_flag=True, default=False,
+              help="Export only what is selected in Blender.")
+@click.option("--format", "fmt", default=None, type=click.Choice(["glb", "fbx"]), help="Export format (default glb).")
+@click.option("--name", default=None, help="Asset and GameObject name.")
+@click.option("--target-size", "target_size", default=None, type=float,
+              help="Final size in meters of the largest dimension (0 keeps the imported scale).")
+@click.option("--position", default=None, nargs=3, type=float, metavar="X Y Z", help="World position of the placed instance.")
+@click.option("--no-place", "no_place", is_flag=True, default=False, help="Import only; do not place in the scene.")
+@click.option("--keep-modifiers", "keep_modifiers", is_flag=True, default=False,
+              help="Do not bake modifiers (use for rigs / shape keys).")
+@click.option("--output-folder", "output_folder", default=None, help="Destination folder under Assets/.")
+@click.option("--animation-type", "animation_type", default=None,
+              type=click.Choice(["none", "generic", "humanoid", "legacy"]), help="FBX only: rig/animation import mode.")
+@click.option("--timeout", "timeout_seconds", default=None, type=int, help="Seconds to wait for Blender.")
+@handle_unity_errors
+def import_model(
+    object_names: tuple[str, ...],
+    selection_only: bool,
+    fmt: Optional[str],
+    name: Optional[str],
+    target_size: Optional[float],
+    position: Optional[tuple[float, float, float]],
+    no_place: bool,
+    keep_modifiers: bool,
+    output_folder: Optional[str],
+    animation_type: Optional[str],
+    timeout_seconds: Optional[int],
+):
+    """Export from Blender, import into the project, and place the model in the open scene.
+
+    \b
+    Examples:
+        unity-mcp blender import-model --selection-only --target-size 2
+        unity-mcp blender import-model --object House --format glb --position 0 0 0
+    """
+    _run("import_model", {
+        "objectNames": list(object_names) or None,
+        "selectionOnly": True if selection_only else None,
+        "format": fmt,
+        "name": name,
+        "targetSize": target_size,
+        "position": list(position) if position else None,
+        "placeInScene": False if no_place else None,
+        "applyModifiers": False if keep_modifiers else None,
+        "outputFolder": output_folder,
+        "animationType": animation_type,
+        "timeoutSeconds": timeout_seconds,
+    })
+
+
+@blender.command("check-updates")
+@handle_unity_errors
+def check_updates():
+    """git fetch the blender-mcp checkout and report how far behind its remotes it is."""
+    _run("check_updates")
+
+
+@blender.command("sync-addon")
+@click.option("--force", is_flag=True, default=False, help="Overwrite even when the installed addon already matches.")
+@handle_unity_errors
+def sync_addon(force: bool):
+    """Copy the checkout's addon.py into Blender's addons folder."""
+    _run("sync_addon", {"force": True if force else None})

--- a/Server/src/cli/commands/blender.py
+++ b/Server/src/cli/commands/blender.py
@@ -89,6 +89,11 @@ def run_python(code: Optional[str], file_path: Optional[str]):
 @click.option("--output-folder", "output_folder", default=None, help="Destination folder under Assets/.")
 @click.option("--animation-type", "animation_type", default=None,
               type=click.Choice(["none", "generic", "humanoid", "legacy"]), help="FBX only: rig/animation import mode.")
+@click.option("--no-animate", "no_animate", is_flag=True, default=False,
+              help="Do not create a looping AnimatorController for imported clips.")
+@click.option("--save-prefab", "save_prefab", is_flag=True, default=False, help="Save the placed instance as a prefab.")
+@click.option("--ensure-bloom", "ensure_bloom", is_flag=True, default=False,
+              help="Add a Bloom volume when the model has emissive materials.")
 @click.option("--timeout", "timeout_seconds", default=None, type=int, help="Seconds to wait for Blender.")
 @handle_unity_errors
 def import_model(
@@ -102,6 +107,9 @@ def import_model(
     keep_modifiers: bool,
     output_folder: Optional[str],
     animation_type: Optional[str],
+    no_animate: bool,
+    save_prefab: bool,
+    ensure_bloom: bool,
     timeout_seconds: Optional[int],
 ):
     """Export from Blender, import into the project, and place the model in the open scene.
@@ -122,8 +130,28 @@ def import_model(
         "applyModifiers": False if keep_modifiers else None,
         "outputFolder": output_folder,
         "animationType": animation_type,
+        "autoAnimate": False if no_animate else None,
+        "savePrefab": True if save_prefab else None,
+        "ensureBloom": True if ensure_bloom else None,
         "timeoutSeconds": timeout_seconds,
     })
+
+
+@blender.command("compare-screenshot")
+@click.option("--game-object", "game_object", required=True, help="Placed GameObject to frame in Unity.")
+@click.option("--max-size", "max_size", default=None, type=int, help="Max pixels on the longest side of each half.")
+@click.option("--output-folder", "output_folder", default=None, help="Copy the PNG under this Assets/ folder.")
+@handle_unity_errors
+def compare_screenshot(game_object: str, max_size: Optional[int], output_folder: Optional[str]):
+    """Composite Blender's viewport and a Unity capture of the placed object side by side."""
+    _run("compare_screenshot", {"gameObject": game_object, "maxSize": max_size, "outputFolder": output_folder})
+
+
+@blender.command("setup-bloom")
+@handle_unity_errors
+def setup_bloom():
+    """Enable camera post-processing and add a Bloom override to the global volume."""
+    _run("setup_bloom")
 
 
 @blender.command("check-updates")

--- a/Server/src/cli/main.py
+++ b/Server/src/cli/main.py
@@ -253,6 +253,7 @@ def register_commands():
         ("cli.commands.scene", "scene"),
         ("cli.commands.asset", "asset"),
         ("cli.commands.asset_gen", "asset_gen"),
+        ("cli.commands.blender", "blender"),
         ("cli.commands.script", "script"),
         ("cli.commands.code", "code"),
         ("cli.commands.editor", "editor"),

--- a/Server/src/services/tools/blender_bridge.py
+++ b/Server/src/services/tools/blender_bridge.py
@@ -60,7 +60,7 @@ async def blender_bridge(
         list[str], "import_model: Blender objects to export (children included). Omit for selection_only or the whole scene."
     ] | None = None,
     selection_only: Annotated[bool, "import_model: export only what is currently selected in Blender."] | None = None,
-    format: Annotated[Literal["glb", "fbx"], "import_model: export format (default glb)."] | None = None,
+    format: Annotated[Literal["glb", "fbx"], "import_model: export format (default glb)."] | None = None,  # noqa: A002
     name: Annotated[str, "import_model: asset and GameObject name (defaults to the single exported object)."] | None = None,
     target_size: Annotated[float, "import_model: final size in meters of the largest dimension; 0 keeps the imported scale."] | None = None,
     position: Annotated[list[float], "import_model: world position [x, y, z] for the placed instance."] | None = None,
@@ -76,6 +76,7 @@ async def blender_bridge(
     force: Annotated[bool, "sync_addon: overwrite even when the installed addon already matches."] | None = None,
     timeout_seconds: Annotated[int, "Seconds to wait for Blender (default 180; big exports can be slow)."] | None = None,
 ) -> dict[str, Any]:
+    """Forward one Blender Bridge action to the Unity Editor and return its response."""
     unity_instance = await get_unity_instance_from_context(ctx)
 
     params_dict = {

--- a/Server/src/services/tools/blender_bridge.py
+++ b/Server/src/services/tools/blender_bridge.py
@@ -35,7 +35,13 @@ from transport.legacy.unity_connection import async_send_command_with_retry
         "through the shared model pipeline, place it in the open scene at position, and scale it so "
         "its largest dimension equals target_size meters (0 keeps the imported scale). Set "
         "apply_modifiers=false for rigs / shape keys. animation_type applies to FBX only. "
-        "Returns asset_path, asset_guid, game_object, bounds.\n"
+        "auto_animate (default true) creates a looping AnimatorController for imported clips so the "
+        "model actually moves; save_prefab stores the placed instance as a prefab; ensure_bloom adds a "
+        "Bloom volume when the model has emissive materials. "
+        "Returns asset_path, asset_guid, game_object, bounds, and animation / prefab_path / bloom when applicable.\n"
+        "- compare_screenshot(game_object, max_size, output_folder): Blender viewport (left) and a Unity capture "
+        "framed on the placed object (right) composited into one PNG, for eyeballing fidelity.\n"
+        "- setup_bloom: enable post-processing on the main camera and add a Bloom override to the global volume.\n"
         "- check_updates: git fetch the blender-mcp checkout and report how far behind its remotes "
         "it is, plus whether Blender's installed addon.py matches the checkout.\n"
         "- sync_addon(force): copy the checkout's addon.py into Blender's addons folder (backs up "
@@ -52,7 +58,7 @@ async def blender_bridge(
     ctx: Context,
     action: Annotated[
         Literal["status", "scene_info", "object_info", "screenshot", "run_python",
-                "import_model", "check_updates", "sync_addon"],
+                "import_model", "compare_screenshot", "setup_bloom", "check_updates", "sync_addon"],
         "Operation to perform.",
     ],
     object_name: Annotated[str, "object_info: name of the Blender object to inspect."] | None = None,
@@ -71,6 +77,10 @@ async def blender_bridge(
         Literal["none", "generic", "humanoid", "legacy"],
         "import_model, FBX only: rig/animation import mode (FBX imports zero clips unless set).",
     ] | None = None,
+    auto_animate: Annotated[bool, "import_model: create a looping AnimatorController for imported clips (default true)."] | None = None,
+    save_prefab: Annotated[bool, "import_model: save the placed instance as a prefab next to the asset."] | None = None,
+    ensure_bloom: Annotated[bool, "import_model: add a Bloom volume when the model has emissive materials."] | None = None,
+    game_object: Annotated[str, "compare_screenshot: name of the placed GameObject to frame in Unity."] | None = None,
     code: Annotated[str, "run_python: Python source to execute inside Blender."] | None = None,
     max_size: Annotated[int, "screenshot: max pixels on the longest side (default 1000)."] | None = None,
     force: Annotated[bool, "sync_addon: overwrite even when the installed addon already matches."] | None = None,
@@ -92,6 +102,10 @@ async def blender_bridge(
         "applyModifiers": apply_modifiers,
         "outputFolder": output_folder,
         "animationType": animation_type,
+        "autoAnimate": auto_animate,
+        "savePrefab": save_prefab,
+        "ensureBloom": ensure_bloom,
+        "gameObject": game_object,
         "code": code,
         "maxSize": max_size,
         "force": force,

--- a/Server/src/services/tools/blender_bridge.py
+++ b/Server/src/services/tools/blender_bridge.py
@@ -1,0 +1,108 @@
+"""
+Defines the blender_bridge tool: drive a running Blender (BlenderMCP addon socket) from the
+Unity Editor so a Blender → Unity handoff is a single call.
+
+Thin pass-through: the C# side (Editor/Tools/Blender/BlenderBridgeTool.cs) opens the addon
+socket itself, exports/imports through the shared model pipeline, and places the result in the
+open scene. No API keys and no file bytes cross the MCP bridge. Socket host/port and the
+blender-mcp checkout path are configured in Window > MCP for Unity > Generative > Blender Bridge.
+"""
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+
+from services.registry import mcp_for_unity_tool
+from services.tools import get_unity_instance_from_context
+from transport.unity_transport import send_with_unity_instance
+from transport.legacy.unity_connection import async_send_command_with_retry
+
+
+@mcp_for_unity_tool(
+    group="asset_gen",
+    description=(
+        "Bridge to a running Blender that has the BlenderMCP addon connected (socket, default "
+        "127.0.0.1:9876; configured in Window > MCP for Unity > Generative > Blender Bridge). "
+        "Unity talks to the addon directly, so no BlenderMCP client is needed.\n\n"
+        "Actions:\n"
+        "- status: is Blender reachable, is the checkout configured, does the installed addon match it.\n"
+        "- scene_info / object_info(object_name): read Blender scene / one object.\n"
+        "- screenshot(max_size, output_folder): Blender viewport → PNG under Library/BlenderBridge "
+        "(or copied under Assets/ when output_folder is given). Returns the path.\n"
+        "- run_python(code): execute Python inside Blender; returns stdout.\n"
+        "- import_model: export from Blender (object_names with their children, or selection_only, "
+        "else the whole scene) as glb (default; keeps PBR, emission, animation) or fbx, import it "
+        "through the shared model pipeline, place it in the open scene at position, and scale it so "
+        "its largest dimension equals target_size meters (0 keeps the imported scale). Set "
+        "apply_modifiers=false for rigs / shape keys. animation_type applies to FBX only. "
+        "Returns asset_path, asset_guid, game_object, bounds.\n"
+        "- check_updates: git fetch the blender-mcp checkout and report how far behind its remotes "
+        "it is, plus whether Blender's installed addon.py matches the checkout.\n"
+        "- sync_addon(force): copy the checkout's addon.py into Blender's addons folder (backs up "
+        "the old file); restart Blender afterwards.\n\n"
+        "check_updates and sync_addon need the checkout path to be set; the other actions only need "
+        "Blender running with the addon connected."
+    ),
+    annotations=ToolAnnotations(
+        title="Blender Bridge",
+        destructiveHint=True,
+    ),
+)
+async def blender_bridge(
+    ctx: Context,
+    action: Annotated[
+        Literal["status", "scene_info", "object_info", "screenshot", "run_python",
+                "import_model", "check_updates", "sync_addon"],
+        "Operation to perform.",
+    ],
+    object_name: Annotated[str, "object_info: name of the Blender object to inspect."] | None = None,
+    object_names: Annotated[
+        list[str], "import_model: Blender objects to export (children included). Omit for selection_only or the whole scene."
+    ] | None = None,
+    selection_only: Annotated[bool, "import_model: export only what is currently selected in Blender."] | None = None,
+    format: Annotated[Literal["glb", "fbx"], "import_model: export format (default glb)."] | None = None,
+    name: Annotated[str, "import_model: asset and GameObject name (defaults to the single exported object)."] | None = None,
+    target_size: Annotated[float, "import_model: final size in meters of the largest dimension; 0 keeps the imported scale."] | None = None,
+    position: Annotated[list[float], "import_model: world position [x, y, z] for the placed instance."] | None = None,
+    place_in_scene: Annotated[bool, "import_model: instantiate the imported asset into the open scene (default true)."] | None = None,
+    apply_modifiers: Annotated[bool, "import_model: bake modifiers on export (default true; false for skinned meshes / shape keys)."] | None = None,
+    output_folder: Annotated[str, "import_model / screenshot: destination folder under Assets/."] | None = None,
+    animation_type: Annotated[
+        Literal["none", "generic", "humanoid", "legacy"],
+        "import_model, FBX only: rig/animation import mode (FBX imports zero clips unless set).",
+    ] | None = None,
+    code: Annotated[str, "run_python: Python source to execute inside Blender."] | None = None,
+    max_size: Annotated[int, "screenshot: max pixels on the longest side (default 1000)."] | None = None,
+    force: Annotated[bool, "sync_addon: overwrite even when the installed addon already matches."] | None = None,
+    timeout_seconds: Annotated[int, "Seconds to wait for Blender (default 180; big exports can be slow)."] | None = None,
+) -> dict[str, Any]:
+    unity_instance = await get_unity_instance_from_context(ctx)
+
+    params_dict = {
+        "action": action,
+        "objectName": object_name,
+        "objectNames": object_names,
+        "selectionOnly": selection_only,
+        "format": format,
+        "name": name,
+        "targetSize": target_size,
+        "position": position,
+        "placeInScene": place_in_scene,
+        "applyModifiers": apply_modifiers,
+        "outputFolder": output_folder,
+        "animationType": animation_type,
+        "code": code,
+        "maxSize": max_size,
+        "force": force,
+        "timeoutSeconds": timeout_seconds,
+    }
+    params_dict = {k: v for k, v in params_dict.items() if v is not None}
+
+    result = await send_with_unity_instance(
+        async_send_command_with_retry,
+        unity_instance,
+        "blender_bridge",
+        params_dict,
+    )
+
+    return result if isinstance(result, dict) else {"success": False, "message": str(result)}

--- a/Server/tests/test_blender_bridge.py
+++ b/Server/tests/test_blender_bridge.py
@@ -1,0 +1,141 @@
+"""Tests for the blender_bridge tool and CLI command.
+
+Pass-through tool: NO API keys, NO file bytes. Unity transport fully mocked.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from click.testing import CliRunner
+
+from cli.commands.blender import blender
+from cli.utils.config import CLIConfig
+from services.registry import get_registered_tools
+
+from services.tools import blender_bridge as mod
+from services.tools.blender_bridge import blender_bridge
+
+
+COMMAND = "blender_bridge"
+
+
+def _call_tool(**kwargs):
+    ctx = MagicMock()
+    with patch.object(mod, "get_unity_instance_from_context",
+                      new=AsyncMock(return_value="unity-1")):
+        with patch.object(mod, "send_with_unity_instance",
+                          new=AsyncMock(return_value={"success": True, "data": {}})) as mock_send:
+            result = asyncio.run(blender_bridge(ctx, **kwargs))
+    return result, mock_send.call_args.args
+
+
+def _sent_command(sent_args):
+    return sent_args[2]
+
+
+def _sent_params(sent_args):
+    return sent_args[3]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_config():
+    return CLIConfig(host="127.0.0.1", port=8080, timeout=30, format="text", unity_instance=None)
+
+
+@pytest.fixture
+def cli_runner(runner, mock_config):
+    def _invoke(args):
+        with patch("cli.commands.blender.get_config", return_value=mock_config):
+            with patch("cli.commands.blender.run_command",
+                       return_value={"success": True, "message": "OK", "data": {}}) as mock_run:
+                result = runner.invoke(blender, args)
+                return result, mock_run
+    return _invoke
+
+
+class TestBlenderBridgeRegistration:
+    def test_tool_registered_under_asset_gen_group(self):
+        tools = get_registered_tools()
+        tool = next((t for t in tools if t["name"] == COMMAND), None)
+        assert tool is not None
+        assert tool["group"] == "asset_gen"
+
+
+class TestBlenderBridgeRouting:
+    def test_status_sends_action_only(self):
+        _, sent = _call_tool(action="status")
+        assert _sent_command(sent) == COMMAND
+        assert _sent_params(sent) == {"action": "status"}
+
+    def test_import_model_maps_snake_case_to_camel_case(self):
+        _, sent = _call_tool(
+            action="import_model", object_names=["Cube"], target_size=2.0,
+            place_in_scene=False, apply_modifiers=False, position=[0.0, 1.0, 0.0],
+            animation_type="generic", output_folder="Assets/Generated/Imported",
+        )
+        assert _sent_command(sent) == COMMAND
+        assert _sent_params(sent) == {
+            "action": "import_model",
+            "objectNames": ["Cube"],
+            "targetSize": 2.0,
+            "placeInScene": False,
+            "applyModifiers": False,
+            "position": [0.0, 1.0, 0.0],
+            "animationType": "generic",
+            "outputFolder": "Assets/Generated/Imported",
+        }
+
+    def test_run_python_and_screenshot_params(self):
+        _, sent = _call_tool(action="run_python", code="print(1)", timeout_seconds=30)
+        assert _sent_params(sent) == {"action": "run_python", "code": "print(1)", "timeoutSeconds": 30}
+
+        _, sent = _call_tool(action="screenshot", max_size=800)
+        assert _sent_params(sent) == {"action": "screenshot", "maxSize": 800}
+
+    def test_non_dict_result_becomes_error(self):
+        ctx = MagicMock()
+        with patch.object(mod, "get_unity_instance_from_context", new=AsyncMock(return_value="unity-1")):
+            with patch.object(mod, "send_with_unity_instance", new=AsyncMock(return_value="boom")):
+                result = asyncio.run(blender_bridge(ctx, action="status"))
+        assert result == {"success": False, "message": "boom"}
+
+
+class TestBlenderCli:
+    def test_status(self, cli_runner):
+        result, mock_run = cli_runner(["status"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[0] == COMMAND
+        assert mock_run.call_args.args[1] == {"action": "status"}
+
+    def test_import_model_flags(self, cli_runner):
+        result, mock_run = cli_runner([
+            "import-model", "--object", "House", "--object", "Tree", "--format", "fbx",
+            "--target-size", "2", "--position", "0", "1", "0", "--no-place", "--keep-modifiers",
+            "--animation-type", "generic",
+        ])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {
+            "action": "import_model",
+            "objectNames": ["House", "Tree"],
+            "format": "fbx",
+            "targetSize": 2.0,
+            "position": [0.0, 1.0, 0.0],
+            "placeInScene": False,
+            "applyModifiers": False,
+            "animationType": "generic",
+        }
+
+    def test_run_python_requires_code_or_file(self, cli_runner):
+        result, mock_run = cli_runner(["run-python"])
+        assert result.exit_code != 0
+        assert not mock_run.called
+
+    def test_sync_addon_force(self, cli_runner):
+        result, mock_run = cli_runner(["sync-addon", "--force"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {"action": "sync_addon", "force": True}

--- a/Server/tests/test_blender_bridge.py
+++ b/Server/tests/test_blender_bridge.py
@@ -97,6 +97,18 @@ class TestBlenderBridgeRouting:
         _, sent = _call_tool(action="screenshot", max_size=800)
         assert _sent_params(sent) == {"action": "screenshot", "maxSize": 800}
 
+    def test_finishing_touch_flags_and_compare_params(self):
+        _, sent = _call_tool(action="import_model", selection_only=True, auto_animate=False,
+                             save_prefab=True, ensure_bloom=True)
+        assert _sent_params(sent) == {"action": "import_model", "selectionOnly": True, "autoAnimate": False,
+                                      "savePrefab": True, "ensureBloom": True}
+
+        _, sent = _call_tool(action="compare_screenshot", game_object="House", max_size=600)
+        assert _sent_params(sent) == {"action": "compare_screenshot", "gameObject": "House", "maxSize": 600}
+
+        _, sent = _call_tool(action="setup_bloom")
+        assert _sent_params(sent) == {"action": "setup_bloom"}
+
     def test_non_dict_result_becomes_error(self):
         ctx = MagicMock()
         with patch.object(mod, "get_unity_instance_from_context", new=AsyncMock(return_value="unity-1")):
@@ -129,6 +141,20 @@ class TestBlenderCli:
             "applyModifiers": False,
             "animationType": "generic",
         }
+
+    def test_import_model_finishing_flags(self, cli_runner):
+        result, mock_run = cli_runner(["import-model", "--selection-only", "--no-animate", "--save-prefab", "--ensure-bloom"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {"action": "import_model", "selectionOnly": True,
+                                              "autoAnimate": False, "savePrefab": True, "ensureBloom": True}
+
+    def test_compare_and_bloom_commands(self, cli_runner):
+        result, mock_run = cli_runner(["compare-screenshot", "--game-object", "House", "--max-size", "600"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {"action": "compare_screenshot", "gameObject": "House", "maxSize": 600}
+        result, mock_run = cli_runner(["setup-bloom"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {"action": "setup_bloom"}
 
     def test_run_python_requires_code_or_file(self, cli_runner):
         result, mock_run = cli_runner(["run-python"])

--- a/Server/tests/test_blender_bridge.py
+++ b/Server/tests/test_blender_bridge.py
@@ -156,6 +156,36 @@ class TestBlenderCli:
         assert result.exit_code == 0, result.output
         assert mock_run.call_args.args[1] == {"action": "setup_bloom"}
 
+    def test_read_only_commands(self, cli_runner):
+        for args, expected in (
+            (["scene-info"], {"action": "scene_info"}),
+            (["object-info", "--object-name", "Cube"], {"action": "object_info", "objectName": "Cube"}),
+            (["check-updates"], {"action": "check_updates"}),
+            (["screenshot"], {"action": "screenshot"}),
+            (["screenshot", "--max-size", "400", "--output-folder", "Assets/Shots"],
+             {"action": "screenshot", "maxSize": 400, "outputFolder": "Assets/Shots"}),
+        ):
+            result, mock_run = cli_runner(args)
+            assert result.exit_code == 0, result.output
+            assert mock_run.call_args.args[0] == COMMAND
+            assert mock_run.call_args.args[1] == expected
+
+    def test_run_python_from_inline_code_and_from_file(self, cli_runner, tmp_path):
+        result, mock_run = cli_runner(["run-python", "--code", "print(1)"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {"action": "run_python", "code": "print(1)"}
+
+        script = tmp_path / "snippet.py"
+        script.write_text("print(2)", encoding="utf-8")
+        result, mock_run = cli_runner(["run-python", "--file", str(script)])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {"action": "run_python", "code": "print(2)"}
+
+    def test_sync_addon_without_force_omits_the_flag(self, cli_runner):
+        result, mock_run = cli_runner(["sync-addon"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.args[1] == {"action": "sync_addon"}
+
     def test_run_python_requires_code_or_file(self, cli_runner):
         result, mock_run = cli_runner(["run-python"])
         assert result.exit_code != 0

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/BlenderDetectionTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/AssetGen/BlenderDetectionTests.cs
@@ -36,5 +36,36 @@ namespace MCPForUnityTests.Editor.AssetGen
         {
             CollectionAssert.IsNotEmpty(new List<string>(BlenderDetection.CandidatePaths()));
         }
+
+        [Test]
+        public void PickAddonsDir_PrefersNewestDirThatHasTheFile()
+        {
+            var dirs = new List<string> { "/cfg/5.2/scripts/addons", "/cfg/4.2/scripts/addons" };
+            string picked = BlenderDetection.PickAddonsDir(dirs, p => p == "/cfg/4.2/scripts/addons/addon.py", "addon.py");
+            Assert.AreEqual("/cfg/4.2/scripts/addons", picked);
+        }
+
+        [Test]
+        public void PickAddonsDir_FallsBackToNewest_WhenFileIsNowhere()
+        {
+            var dirs = new List<string> { "/cfg/5.2/scripts/addons", "/cfg/4.2/scripts/addons" };
+            Assert.AreEqual("/cfg/5.2/scripts/addons", BlenderDetection.PickAddonsDir(dirs, _ => false, "addon.py"));
+        }
+
+        [Test]
+        public void PickAddonsDir_ReturnsNull_WhenNoDirs()
+        {
+            Assert.IsNull(BlenderDetection.PickAddonsDir(new List<string>(), _ => true, "addon.py"));
+            Assert.IsNull(BlenderDetection.PickAddonsDir(null, _ => true, "addon.py"));
+        }
+
+        [Test]
+        public void ParseVersion_AcceptsBlenderFolderNames()
+        {
+            Assert.AreEqual(new System.Version(5, 2), BlenderDetection.ParseVersion("5.2"));
+            Assert.AreEqual(new System.Version(4, 0), BlenderDetection.ParseVersion("4"));
+            Assert.IsNull(BlenderDetection.ParseVersion("config"));
+            Assert.IsNull(BlenderDetection.ParseVersion(""));
+        }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 789b7a474ac3433f86adf256d5a1b28f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
@@ -113,6 +113,33 @@ namespace MCPForUnityTests.Editor.Blender
         }
 
         [Test]
+        public void RedactRemoteUrl_StripsQueryAndFragmentCredentials()
+        {
+            Assert.AreEqual("https://github.com/o/r.git",
+                BlenderBridgeTool.RedactRemoteUrl("https://github.com/o/r.git?token=ghp_secret"));
+            Assert.AreEqual("https://github.com/o/r.git",
+                BlenderBridgeTool.RedactRemoteUrl("https://github.com/o/r.git#access_token=ghp_secret"));
+            Assert.AreEqual("https://github.com/o/r.git",
+                BlenderBridgeTool.RedactRemoteUrl("https://user:pw@github.com/o/r.git?x=1#y"));
+        }
+
+        [Test]
+        public void SetupBloom_FailureReportBecomesAnError()
+        {
+            JObject failed = JObject.Parse("{\"success\": false, \"message\": \"Could not add Bloom: no volume\"}");
+            JObject resp = JObject.Parse(JsonConvert.SerializeObject(BlenderBridgeTool.ToBloomResponse(failed)));
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("Could not add Bloom", (string)resp["error"]);
+
+            JObject ok = JObject.Parse("{\"success\": true, \"message\": \"Bloom added to 'Global Volume'.\"}");
+            JObject okResp = JObject.Parse(JsonConvert.SerializeObject(BlenderBridgeTool.ToBloomResponse(ok)));
+            Assert.AreEqual(true, (bool)okResp["success"]);
+
+            JObject skipped = JObject.Parse("{\"message\": \"Volume system (URP/HDRP) not available; nothing to do.\"}");
+            Assert.AreEqual(true, (bool)JObject.Parse(JsonConvert.SerializeObject(BlenderBridgeTool.ToBloomResponse(skipped)))["success"]);
+        }
+
+        [Test]
         public void ExportScript_WithoutNames_UsesEmptyList()
         {
             string script = BlenderBridgeTool.BuildExportScript("C:/tmp/x.fbx", null, true, false, "fbx");

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
@@ -6,12 +6,13 @@ using NUnit.Framework;
 namespace MCPForUnityTests.Editor.Blender
 {
     /// <summary>
-    /// Parameter validation that happens before any socket or file I/O, so these run without Blender.
+    /// Parameter validation that happens before any socket or file I/O, plus the export-script
+    /// builder, so these run without Blender.
     /// </summary>
     public class BlenderBridgeToolTests
     {
         private static JObject Call(JObject p)
-            => JObject.Parse(JsonConvert.SerializeObject(BlenderBridgeTool.HandleCommand(p)));
+            => JObject.Parse(JsonConvert.SerializeObject(BlenderBridgeTool.HandleCommand(p).GetAwaiter().GetResult()));
 
         [Test]
         public void NullParams_ReturnsError()
@@ -56,11 +57,57 @@ namespace MCPForUnityTests.Editor.Blender
         }
 
         [Test]
+        public void Screenshot_RejectsOutputFolderOutsideAssets()
+        {
+            JObject resp = Call(new JObject { ["action"] = "screenshot", ["output_folder"] = "Assets/../../outside" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("Assets", (string)resp["error"]);
+        }
+
+        [Test]
         public void ActionIsCaseInsensitive()
         {
             JObject resp = Call(new JObject { ["action"] = "RUN_PYTHON" });
             Assert.AreEqual(false, (bool)resp["success"]);
             StringAssert.Contains("'code'", (string)resp["error"]);
+        }
+
+        [Test]
+        public void ExportScript_EmbedsValuesAsOneJsonLiteral()
+        {
+            string script = BlenderBridgeTool.BuildExportScript(
+                "C:/tmp/O'Brien_1.glb", new[] { "O'Brien", "__APPLY__" }, false, true, "glb");
+
+            StringAssert.Contains("cfg = json.loads(\"", script);
+            Assert.IsFalse(script.Contains("__CFG__"), "placeholder must be replaced exactly once");
+            StringAssert.Contains("O'Brien", script);
+            StringAssert.Contains("__APPLY__", script);
+
+            // The literal between json.loads(" and ") must be the JSON-escaped config, so an
+            // apostrophe or a placeholder-looking name never changes the program text.
+            int start = script.IndexOf("json.loads(", System.StringComparison.Ordinal) + "json.loads(".Length;
+            int end = script.IndexOf(")\n", start, System.StringComparison.Ordinal);
+            string literal = script.Substring(start, end - start);
+            string decoded = JsonConvert.DeserializeObject<string>(literal);
+            JObject cfg = JObject.Parse(decoded);
+            Assert.AreEqual("C:/tmp/O'Brien_1.glb", (string)cfg["out"]);
+            Assert.AreEqual("O'Brien", (string)cfg["names"][0]);
+            Assert.AreEqual("__APPLY__", (string)cfg["names"][1]);
+            Assert.AreEqual(true, (bool)cfg["apply_modifiers"]);
+            Assert.AreEqual(false, (bool)cfg["selection_only"]);
+            Assert.AreEqual("glb", (string)cfg["format"]);
+        }
+
+        [Test]
+        public void ExportScript_WithoutNames_UsesEmptyList()
+        {
+            string script = BlenderBridgeTool.BuildExportScript("C:/tmp/x.fbx", null, true, false, "fbx");
+            int start = script.IndexOf("json.loads(", System.StringComparison.Ordinal) + "json.loads(".Length;
+            int end = script.IndexOf(")\n", start, System.StringComparison.Ordinal);
+            JObject cfg = JObject.Parse(JsonConvert.DeserializeObject<string>(script.Substring(start, end - start)));
+            Assert.AreEqual(0, ((JArray)cfg["names"]).Count);
+            Assert.AreEqual(true, (bool)cfg["selection_only"]);
+            Assert.AreEqual(false, (bool)cfg["apply_modifiers"]);
         }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
@@ -1,0 +1,66 @@
+using MCPForUnity.Editor.Tools.Blender;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.Blender
+{
+    /// <summary>
+    /// Parameter validation that happens before any socket or file I/O, so these run without Blender.
+    /// </summary>
+    public class BlenderBridgeToolTests
+    {
+        private static JObject Call(JObject p)
+            => JObject.Parse(JsonConvert.SerializeObject(BlenderBridgeTool.HandleCommand(p)));
+
+        [Test]
+        public void NullParams_ReturnsError()
+        {
+            JObject resp = Call(null);
+            Assert.AreEqual(false, (bool)resp["success"]);
+        }
+
+        [Test]
+        public void UnknownAction_ListsValidActions()
+        {
+            JObject resp = Call(new JObject { ["action"] = "nope" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            string error = (string)resp["error"];
+            StringAssert.Contains("nope", error);
+            StringAssert.Contains("import_model", error);
+            StringAssert.Contains("sync_addon", error);
+        }
+
+        [Test]
+        public void RunPython_WithoutCode_ReturnsError()
+        {
+            JObject resp = Call(new JObject { ["action"] = "run_python" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("'code'", (string)resp["error"]);
+        }
+
+        [Test]
+        public void ObjectInfo_WithoutName_ReturnsError()
+        {
+            JObject resp = Call(new JObject { ["action"] = "object_info" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("'object_name'", (string)resp["error"]);
+        }
+
+        [Test]
+        public void ImportModel_RejectsUnsupportedFormat()
+        {
+            JObject resp = Call(new JObject { ["action"] = "import_model", ["format"] = "obj" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("glb or fbx", (string)resp["error"]);
+        }
+
+        [Test]
+        public void ActionIsCaseInsensitive()
+        {
+            JObject resp = Call(new JObject { ["action"] = "RUN_PYTHON" });
+            Assert.AreEqual(false, (bool)resp["success"]);
+            StringAssert.Contains("'code'", (string)resp["error"]);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs
@@ -99,6 +99,20 @@ namespace MCPForUnityTests.Editor.Blender
         }
 
         [Test]
+        public void RedactRemoteUrl_StripsEmbeddedCredentials()
+        {
+            Assert.AreEqual("https://github.com/o/r.git",
+                BlenderBridgeTool.RedactRemoteUrl("https://user:ghp_secret@github.com/o/r.git"));
+            Assert.AreEqual("https://github.com/o/r.git",
+                BlenderBridgeTool.RedactRemoteUrl("https://ghp_secret@github.com/o/r.git"));
+            Assert.AreEqual("https://github.com/o/r.git",
+                BlenderBridgeTool.RedactRemoteUrl("https://github.com/o/r.git"));
+            Assert.AreEqual("git@github.com:o/r.git",
+                BlenderBridgeTool.RedactRemoteUrl("git@github.com:o/r.git"));
+            Assert.AreEqual(string.Empty, BlenderBridgeTool.RedactRemoteUrl(null));
+        }
+
+        [Test]
         public void ExportScript_WithoutNames_UsesEmptyList()
         {
             string script = BlenderBridgeTool.BuildExportScript("C:/tmp/x.fbx", null, true, false, "fbx");

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderBridgeToolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee2d727142ab4c7bb59d1b547e6a9faa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderSocketClientTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderSocketClientTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using MCPForUnity.Editor.Services.Blender;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace MCPForUnityTests.Editor.Blender
+{
+    /// <summary>
+    /// Covers the framing-free protocol core (parse-when-complete + status unwrap) without a socket.
+    /// </summary>
+    public class BlenderSocketClientTests
+    {
+        private static byte[] Bytes(string s) => Encoding.UTF8.GetBytes(s);
+
+        [Test]
+        public void TryParseResponse_IsFalse_ForAPartialPrefix()
+        {
+            byte[] buf = Bytes("{\"status\": \"success\", \"result\": {\"name\": \"Sce");
+            Assert.IsFalse(BlenderSocketClient.TryParseResponse(buf, buf.Length, out JObject parsed));
+            Assert.IsNull(parsed);
+        }
+
+        [Test]
+        public void TryParseResponse_IsTrue_OnceTheObjectIsComplete()
+        {
+            byte[] buf = Bytes("{\"status\": \"success\", \"result\": {\"name\": \"Scene\", \"object_count\": 3}}");
+            Assert.IsTrue(BlenderSocketClient.TryParseResponse(buf, buf.Length, out JObject parsed));
+            Assert.AreEqual("Scene", (string)parsed["result"]["name"]);
+        }
+
+        [Test]
+        public void TryParseResponse_HonoursLength_NotBufferCapacity()
+        {
+            string json = "{\"status\": \"success\", \"result\": 1}";
+            byte[] buf = new byte[256];
+            byte[] src = Bytes(json);
+            src.CopyTo(buf, 0);
+            Assert.IsTrue(BlenderSocketClient.TryParseResponse(buf, src.Length, out JObject parsed));
+            Assert.AreEqual(1, (int)parsed["result"]);
+        }
+
+        [Test]
+        public void Unwrap_ReturnsResult_OnSuccess()
+        {
+            var response = JObject.Parse("{\"status\": \"success\", \"result\": {\"executed\": true}}");
+            JToken result = BlenderSocketClient.Unwrap(response, "execute_code");
+            Assert.IsTrue((bool)result["executed"]);
+        }
+
+        [Test]
+        public void Unwrap_Throws_WithAddonMessage_OnError()
+        {
+            var response = JObject.Parse("{\"status\": \"error\", \"message\": \"boom\"}");
+            var ex = Assert.Throws<BlenderCommandException>(() => BlenderSocketClient.Unwrap(response, "get_scene_info"));
+            StringAssert.Contains("boom", ex.Message);
+            StringAssert.Contains("get_scene_info", ex.Message);
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderSocketClientTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderSocketClientTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 using MCPForUnity.Editor.Services.Blender;
 using Newtonsoft.Json.Linq;
@@ -54,6 +55,23 @@ namespace MCPForUnityTests.Editor.Blender
             var ex = Assert.Throws<BlenderCommandException>(() => BlenderSocketClient.Unwrap(response, "get_scene_info"));
             StringAssert.Contains("boom", ex.Message);
             StringAssert.Contains("get_scene_info", ex.Message);
+        }
+
+        [Test]
+        public void Unwrap_Rejects_UnknownOrMissingStatus()
+        {
+            var unknown = JObject.Parse("{\"status\": \"pending\", \"result\": 1}");
+            var ex = Assert.Throws<InvalidDataException>(() => BlenderSocketClient.Unwrap(unknown, "get_scene_info"));
+            StringAssert.Contains("pending", ex.Message);
+
+            var missing = JObject.Parse("{\"result\": 1}");
+            Assert.Throws<InvalidDataException>(() => BlenderSocketClient.Unwrap(missing, "get_scene_info"));
+        }
+
+        [Test]
+        public void BlenderEndpoint_FormatsAsHostPort()
+        {
+            Assert.AreEqual("127.0.0.1:9876", new BlenderEndpoint("127.0.0.1", 9876).ToString());
         }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderSocketClientTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Blender/BlenderSocketClientTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c87da22e2a84c888975324698caffb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/website/docs/contributing/dev-setup.md
+++ b/website/docs/contributing/dev-setup.md
@@ -108,6 +108,7 @@ Current server tool groups are:
 - `testing`
 - `probuilder`
 - `profiling`
+- `asset_gen`
 
 Tools with `group=None` are server meta-tools and are always visible. The default enabled group is `core`; other groups can be enabled through the Tools tab or `manage_tools`.
 

--- a/website/docs/guides/tool-groups.md
+++ b/website/docs/guides/tool-groups.md
@@ -3,12 +3,12 @@ id: tool-groups
 slug: /guides/tool-groups
 title: Tool Groups and manage_tools
 sidebar_label: Tool Groups
-description: Per-session visibility for the 47 tools. Activate vfx, animation, ui, testing, etc. only when you need them.
+description: Per-session visibility for the 48 tools. Activate vfx, animation, ui, testing, etc. only when you need them.
 ---
 
 # Tool Groups
 
-MCP for Unity ships 47 tools, but exposing all of them to the LLM at once balloons the prompt and dilutes routing decisions. So tools are sorted into **groups**, and only `core` is enabled by default.
+MCP for Unity ships 48 tools, but exposing all of them to the LLM at once balloons the prompt and dilutes routing decisions. So tools are sorted into **groups**, and only `core` is enabled by default.
 
 ## The groups
 
@@ -65,7 +65,7 @@ Useful when a group's tools are confusing the assistant — e.g., `manage_shader
 Three reasons:
 
 1. **Prompt economy**: each visible tool adds tokens to every assistant call. Hiding what you're not using is real money saved at scale.
-2. **Routing clarity**: when the LLM picks between 47 tools versus the 30 core tools, the wrong-tool rate drops measurably.
+2. **Routing clarity**: when the LLM picks between 48 tools versus the 30 core tools, the wrong-tool rate drops measurably.
 3. **Package hygiene**: tools in `probuilder` only work if `com.unity.probuilder` is installed; hiding them by default avoids confusing errors.
 
 ## Server vs. session state

--- a/website/docs/guides/tool-groups.md
+++ b/website/docs/guides/tool-groups.md
@@ -23,6 +23,7 @@ MCP for Unity ships 47 tools, but exposing all of them to the LLM at once balloo
 | `probuilder` | off | ProBuilder 3D modeling. Requires `com.unity.probuilder` package. |
 | `profiling` | off | Profiler session control, counters, memory snapshots, Frame Debugger. |
 | `docs` | off | Unity API reflection and documentation lookup. |
+| `asset_gen` | off | AI asset generation (3D model, image, audio; bring your own key) and the Blender Bridge. |
 
 ## Enabling a group
 

--- a/website/docs/reference/tools/asset_gen/blender_bridge.md
+++ b/website/docs/reference/tools/asset_gen/blender_bridge.md
@@ -19,7 +19,9 @@ Actions:
 - scene_info / object_info(object_name): read Blender scene / one object.
 - screenshot(max_size, output_folder): Blender viewport → PNG under Library/BlenderBridge (or copied under Assets/ when output_folder is given). Returns the path.
 - run_python(code): execute Python inside Blender; returns stdout.
-- import_model: export from Blender (object_names with their children, or selection_only, else the whole scene) as glb (default; keeps PBR, emission, animation) or fbx, import it through the shared model pipeline, place it in the open scene at position, and scale it so its largest dimension equals target_size meters (0 keeps the imported scale). Set apply_modifiers=false for rigs / shape keys. animation_type applies to FBX only. Returns asset_path, asset_guid, game_object, bounds.
+- import_model: export from Blender (object_names with their children, or selection_only, else the whole scene) as glb (default; keeps PBR, emission, animation) or fbx, import it through the shared model pipeline, place it in the open scene at position, and scale it so its largest dimension equals target_size meters (0 keeps the imported scale). Set apply_modifiers=false for rigs / shape keys. animation_type applies to FBX only. auto_animate (default true) creates a looping AnimatorController for imported clips so the model actually moves; save_prefab stores the placed instance as a prefab; ensure_bloom adds a Bloom volume when the model has emissive materials. Returns asset_path, asset_guid, game_object, bounds, and animation / prefab_path / bloom when applicable.
+- compare_screenshot(game_object, max_size, output_folder): Blender viewport (left) and a Unity capture framed on the placed object (right) composited into one PNG, for eyeballing fidelity.
+- setup_bloom: enable post-processing on the main camera and add a Bloom override to the global volume.
 - check_updates: git fetch the blender-mcp checkout and report how far behind its remotes it is, plus whether Blender's installed addon.py matches the checkout.
 - sync_addon(force): copy the checkout's addon.py into Blender's addons folder (backs up the old file); restart Blender afterwards.
 
@@ -29,7 +31,7 @@ check_updates and sync_addon need the checkout path to be set; the other actions
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `action` | `Literal['status', 'scene_info', 'object_info', 'screenshot', 'run_python', 'import_model', 'check_updates', 'sync_addon']` | yes | Operation to perform. |
+| `action` | `Literal['status', 'scene_info', 'object_info', 'screenshot', 'run_python', 'import_model', 'compare_screenshot', 'setup_bloom', 'check_updates', 'sync_addon']` | yes | Operation to perform. |
 | `object_name` | `str \| None` | — | object_info: name of the Blender object to inspect. |
 | `object_names` | `list[str] \| None` | — | import_model: Blender objects to export (children included). Omit for selection_only or the whole scene. |
 | `selection_only` | `bool \| None` | — | import_model: export only what is currently selected in Blender. |
@@ -41,6 +43,10 @@ check_updates and sync_addon need the checkout path to be set; the other actions
 | `apply_modifiers` | `bool \| None` | — | import_model: bake modifiers on export (default true; false for skinned meshes / shape keys). |
 | `output_folder` | `str \| None` | — | import_model / screenshot: destination folder under Assets/. |
 | `animation_type` | `Literal['none', 'generic', 'humanoid', 'legacy'] \| None` | — | import_model, FBX only: rig/animation import mode (FBX imports zero clips unless set). |
+| `auto_animate` | `bool \| None` | — | import_model: create a looping AnimatorController for imported clips (default true). |
+| `save_prefab` | `bool \| None` | — | import_model: save the placed instance as a prefab next to the asset. |
+| `ensure_bloom` | `bool \| None` | — | import_model: add a Bloom volume when the model has emissive materials. |
+| `game_object` | `str \| None` | — | compare_screenshot: name of the placed GameObject to frame in Unity. |
 | `code` | `str \| None` | — | run_python: Python source to execute inside Blender. |
 | `max_size` | `int \| None` | — | screenshot: max pixels on the longest side (default 1000). |
 | `force` | `bool \| None` | — | sync_addon: overwrite even when the installed addon already matches. |

--- a/website/docs/reference/tools/asset_gen/blender_bridge.md
+++ b/website/docs/reference/tools/asset_gen/blender_bridge.md
@@ -1,0 +1,58 @@
+---
+title: blender_bridge
+sidebar_label: blender_bridge
+description: "Bridge to a running Blender that has the BlenderMCP addon connected (socket, default 127.0.0.1:9876; configured in Window > MCP for Unity > Generative > Blender Bridge)."
+---
+
+# `blender_bridge`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `asset_gen` &nbsp;·&nbsp; **Module:** `services.tools.blender_bridge`
+
+## Description
+
+Bridge to a running Blender that has the BlenderMCP addon connected (socket, default 127.0.0.1:9876; configured in Window > MCP for Unity > Generative > Blender Bridge). Unity talks to the addon directly, so no BlenderMCP client is needed.
+
+Actions:
+- status: is Blender reachable, is the checkout configured, does the installed addon match it.
+- scene_info / object_info(object_name): read Blender scene / one object.
+- screenshot(max_size, output_folder): Blender viewport → PNG under Library/BlenderBridge (or copied under Assets/ when output_folder is given). Returns the path.
+- run_python(code): execute Python inside Blender; returns stdout.
+- import_model: export from Blender (object_names with their children, or selection_only, else the whole scene) as glb (default; keeps PBR, emission, animation) or fbx, import it through the shared model pipeline, place it in the open scene at position, and scale it so its largest dimension equals target_size meters (0 keeps the imported scale). Set apply_modifiers=false for rigs / shape keys. animation_type applies to FBX only. Returns asset_path, asset_guid, game_object, bounds.
+- check_updates: git fetch the blender-mcp checkout and report how far behind its remotes it is, plus whether Blender's installed addon.py matches the checkout.
+- sync_addon(force): copy the checkout's addon.py into Blender's addons folder (backs up the old file); restart Blender afterwards.
+
+check_updates and sync_addon need the checkout path to be set; the other actions only need Blender running with the addon connected.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['status', 'scene_info', 'object_info', 'screenshot', 'run_python', 'import_model', 'check_updates', 'sync_addon']` | yes | Operation to perform. |
+| `object_name` | `str \| None` | — | object_info: name of the Blender object to inspect. |
+| `object_names` | `list[str] \| None` | — | import_model: Blender objects to export (children included). Omit for selection_only or the whole scene. |
+| `selection_only` | `bool \| None` | — | import_model: export only what is currently selected in Blender. |
+| `format` | `Literal['glb', 'fbx'] \| None` | — | import_model: export format (default glb). |
+| `name` | `str \| None` | — | import_model: asset and GameObject name (defaults to the single exported object). |
+| `target_size` | `float \| None` | — | import_model: final size in meters of the largest dimension; 0 keeps the imported scale. |
+| `position` | `list[float] \| None` | — | import_model: world position [x, y, z] for the placed instance. |
+| `place_in_scene` | `bool \| None` | — | import_model: instantiate the imported asset into the open scene (default true). |
+| `apply_modifiers` | `bool \| None` | — | import_model: bake modifiers on export (default true; false for skinned meshes / shape keys). |
+| `output_folder` | `str \| None` | — | import_model / screenshot: destination folder under Assets/. |
+| `animation_type` | `Literal['none', 'generic', 'humanoid', 'legacy'] \| None` | — | import_model, FBX only: rig/animation import mode (FBX imports zero clips unless set). |
+| `code` | `str \| None` | — | run_python: Python source to execute inside Blender. |
+| `max_size` | `int \| None` | — | screenshot: max pixels on the longest side (default 1000). |
+| `force` | `bool \| None` | — | sync_addon: overwrite even when the installed addon already matches. |
+| `timeout_seconds` | `int \| None` | — | Seconds to wait for Blender (default 180; big exports can be slow). |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/asset_gen/index.md
+++ b/website/docs/reference/tools/asset_gen/index.md
@@ -8,6 +8,7 @@ description: "MCP for Unity tools in the asset_gen group."
 
 AI asset generation – 3D model gen/import, 2D image gen & audio gen (bring-your-own-key)
 
+- **[`blender_bridge`](./blender_bridge.md)** — Bridge to a running Blender that has the BlenderMCP addon connected (socket, default 127.0.0.1:9876; configured in Window > MCP for Unity > Generative > Blender Bridge).
 - **[`generate_audio`](./generate_audio.md)** — Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project.
 - **[`generate_image`](./generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project.
 - **[`generate_model`](./generate_model.md)** — Generate 3D models with AI providers (Tripo, Meshy) and import them into the Unity project.

--- a/website/docs/reference/tools/index.md
+++ b/website/docs/reference/tools/index.md
@@ -16,8 +16,9 @@ Every tool MCP for Unity exposes, generated directly from the Python `@mcp_for_u
 Animator control & AnimationClip creation
 - **[`manage_animation`](./animation/manage_animation.md)** — Manage Unity animation: Animator control and AnimationClip creation.
 
-## `asset_gen` &nbsp; (5 tools)
+## `asset_gen` &nbsp; (6 tools)
 AI asset generation – 3D model gen/import, 2D image gen & audio gen (bring-your-own-key)
+- **[`blender_bridge`](./asset_gen/blender_bridge.md)** — Bridge to a running Blender that has the BlenderMCP addon connected (socket, default 127.0.0.1:9876; configured in Window > MCP for Unity > Generative > Blender Bridge).
 - **[`generate_audio`](./asset_gen/generate_audio.md)** — Generate audio (sound effects and background music) with fal.ai models and import them as AudioClips into the Unity project.
 - **[`generate_image`](./asset_gen/generate_image.md)** — Generate 2D images with AI providers (fal.ai, OpenRouter) and import them as textures/sprites into the Unity project.
 - **[`generate_model`](./asset_gen/generate_model.md)** — Generate 3D models with AI providers (Tripo, Meshy) and import them into the Unity project.


### PR DESCRIPTION
## Description

MCP for Unity already ships an informational "Blender → Unity Handoff" row in the Asset Gen tab and a `blender-to-unity` skill, but the handoff itself still needs an AI client to orchestrate BlenderMCP and MCP for Unity step by step: export via `execute_blender_code`, then `import_model_file`, then place, then measure bounds and rescale. That is six manual steps for the most common DCC → Unity round trip, and it does not work at all without an AI client attached.

This PR lets the Unity Editor talk to the BlenderMCP addon socket directly, so the handoff is one `blender_bridge` call, and gives the feature a real settings panel in the existing Asset Gen tab. Menu items drive the same handler, so it also works with no AI client connected.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

**New tool `blender_bridge`** — group `asset_gen`, C# `MCPForUnity/Editor/Tools/Blender/BlenderBridgeTool.cs` + Python `Server/src/services/tools/blender_bridge.py`:

| Action | Behaviour |
|---|---|
| `status` | Is Blender reachable, is a blender-mcp checkout configured, does the installed addon match it |
| `scene_info`, `object_info` | Read Blender's scene / one object |
| `screenshot` | Viewport → PNG under `Library/BlenderBridge` (or under `Assets/` with `output_folder`) |
| `run_python` | Execute Python inside Blender, return stdout |
| `import_model` | Export named objects (children included) / the selection / the whole scene as GLB (default) or FBX, import through the shared `ImportModelFile` pipeline, place at `position`, scale so the largest dimension is `target_size` m. `auto_animate` builds a looping `AnimatorController` for imported clips, `save_prefab` stores the placed instance, `ensure_bloom` adds Bloom when the model has emissive materials |
| `compare_screenshot` | Blender viewport (left) and a Unity capture framed on the placed object (right) in one PNG |
| `setup_bloom` | Enable camera post-processing and add a Bloom override to the global volume |
| `check_updates` | `git fetch` the blender-mcp checkout, report commits behind per remote, compare the installed addon's hash |
| `sync_addon` | Copy the checkout's `addon.py` into Blender's user addons folder, keeping a backup |

**Asset Gen tab — "Blender Bridge" panel** (`McpAssetGenSection.uxml` + new `McpBlenderBridgePanel.cs`), replacing the informational handoff row: addon socket host/port with Test Connection, blender-mcp checkout (Select/Clear, validated for `addon.py`), Blender addons folder (newest version auto-detected, overridable) with an addon-in-sync indicator, and Sync Addon / Check Updates / Import Selection buttons. Settings are non-secret EditorPrefs under `MCPForUnity.Blender.*` (`BlenderBridgePrefs`) with no machine-specific defaults; an empty checkout path only disables the two checkout-dependent actions and shows a banner.

**Supporting changes**
- `BlenderSocketClient` (`Editor/Services/Blender`): one TCP connection per command, framing-free JSON parse, strict `status` unwrap (anything other than `success`/`error` is rejected rather than surfacing a null payload). Socket and git work runs on the thread pool; Unity API calls happen after the await on the editor thread.
- `BlenderDetection` gains user addons directory discovery (`UserConfigRoots`, `UserAddonsDirs`, and a pure `PickAddonsDir` for tests) alongside the existing app detection.
- Menu items under `Window/MCP for Unity/Blender Bridge`.
- CLI group `unity-mcp blender …` mirroring the tool, registered in `cli/main.py`.
- Export prefers a first-class `export_scene` addon command when the installed BlenderMCP addon has one and falls back to the `execute_code` script otherwise; the generated script embeds all caller values as a single JSON literal parsed inside Blender, so names containing quotes cannot alter the program.
- `check_updates` runs remote URLs through `RedactRemoteUrl`, which strips user info, query and fragment, so a token embedded in a remote never reaches the response or the editor log.
- Docs: `website/docs/reference/tools/asset_gen/blender_bridge.md` and the two index pages regenerated with `tools/generate_docs_reference.py`; `asset_gen` added to the group lists in `CLAUDE.md`, `website/docs/contributing/dev-setup.md` and `website/docs/guides/tool-groups.md` (the group already existed in `tool_registry.py` but was missing from the guides); tool count 47 → 48.

## Compatibility / Package Source

- Unity version(s) tested: **2021.3.45f2, 2022.3.62f1, 6000.0.75f1, 6000.4.8f1** — every version in `tools/unity-versions.json`, EditMode, on Windows. Also opened on 6000.5.10f1 (see Additional Notes).
- Package source used: `file:` — `TestProjects/UnityMCPTests` references `file:../../../MCPForUnity`, so each run compiled this branch's package directly. Separately dogfooded from a real project via `https://github.com/Seungpyo1007/unity-mcp.git?path=/MCPForUnity#feat/blender-bridge`.
- Resolved commit hash: `538c1707` (this branch merged with `beta` at `2fcc179`).

## Testing/Screenshots/Recordings

- [x] Python tests (`cd Server && uv run pytest tests/ -v`) — 1400 passed, 3 skipped
- [x] Unity EditMode tests — 1186 passed, 0 failed, 80 skipped (1266 total) on each of the four matrix versions
- [ ] Unity PlayMode tests
- [x] Package import/compile check — clean on all four versions
- [ ] Not applicable (explain why in Additional Notes)

PlayMode is not exercised because the feature is editor-only: no runtime assembly changes, and every entry point is an editor tool, menu item or editor window control.

Manual verification against Blender 5.2.1 with the BlenderMCP addon connected: rigged/animated mesh (GLB and FBX with `animation_type`), shape keys, image-textured material, multiple objects in one call, emissive materials driving `ensure_bloom`, and `compare_screenshot`.

## Documentation Updates

- [x] I have added/removed/modified tools or resources
- [x] If yes, I have updated all documentation files using:
  - [x] The LLM prompt at `tools/UPDATE_DOCS_PROMPT.md` (recommended)
  - [x] Manual review of the generated changes

`uv --project Server run python tools/generate_docs_reference.py --check` reports the generated reference is up to date on this branch.

## Related Issues

None.

## Additional Notes

**Version audit.** Following the review request, every Unity, UI Toolkit, .NET and C# construct the branch adds was audited against the CI matrix and the full EditMode suite was run per version. It found two real problems on the floor, both fixed here:

- `IntegerField` is still editor-only (`UnityEditor.UIElements`) on 2021.3 and only moved to `UnityEngine.UIElements` in 2022.1, so the panel did not compile there. The port field is a `TextField` with int parsing, which resolves identically across the whole range.
- `Object.FindObjectsByType(Type, FindObjectsSortMode)` in the Bloom setup only exists from 2023.1. It now goes through the existing `UnityFindObjectsCompat.FindAll(Type)` shim, so no new `#if UNITY_*` branch was added.

A Windows-only test flake surfaced on the way: the generated Blender export script inherited the checkout's CRLF, so the template is now normalized to LF.

Everything else the branch relies on (`AssetDatabase.*`, `PrefabUtility.SaveAsPrefabAssetAndConnect`, `ModelImporter.clipAnimations`, `AnimatorController.CreateAnimatorControllerAtPath`, `AnimationUtility`, `ImageConversion.LoadImage`, `EditorPrefs`) has existed since 2019 or earlier with no renames across the matrix. URP `Volume` / `UniversalAdditionalCameraData` are reached through `Type.GetType` reflection and `manage_graphics`, so there is no compile-time dependency on URP or HDRP and the action degrades to "nothing to do" when the assembly is absent. The Python side uses `dict[str, Any]` and `X | None`, matching `requires-python >= 3.10`.

**Unity 6000.5.** The package compiles, but the existing test assembly does not: several tests under `Tests/EditMode/Tools/*` call `Object.GetInstanceID()`, which 6.5 marks obsolete-as-error. That is pre-existing and unrelated to this branch — the `$coverageGap` note in `unity-versions.json` already tracks 6.5+ having no GameCI image.

**Prerequisites for the feature.** Blender running with the BlenderMCP addon connected (N panel → *Connect to MCP server*, socket `127.0.0.1:9876` by default); GLB import needs glTFast. `check_updates` and `sync_addon` additionally need a local blender-mcp checkout, which is why they are the only actions gated behind the checkout path.

**CI.** Fork PRs skip the Unity legs, so the matrix results above are from local runs. Pushing the branch into the main repo would produce the same signal from the GameCI images; happy to fix anything that turns up.
