### PR TITLE
test(setup): look up UpdateDependencyStatus as static too

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/Characterization/Windows_Characterization.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/Characterization/Windows_Characterization.cs
@@ -135,7 +135,11 @@ namespace MCPForUnityTests.Editor.Windows.Characterization
         public void MCPSetupWindow_ModifiesClassListForStatus_ValidInvalidPattern()
         {
             var type = typeof(MCPSetupWindow);
-            var method = type.GetMethod("UpdateDependencyStatus", BindingFlags.NonPublic | BindingFlags.Instance);
+            // Static as well as Instance: the method takes every element it touches as an argument,
+            // so it carries no instance state and is declared static. Looking it up with Instance
+            // alone returned null and failed this test rather than reporting a behaviour change.
+            var method = type.GetMethod("UpdateDependencyStatus",
+                BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
 
             Assert.IsNotNull(method, "Should have UpdateDependencyStatus method");
 


### PR DESCRIPTION
## Description

`beta` is red on `WindowsCharacterizationTests.MCPSetupWindow_ModifiesClassListForStatus_ValidInvalidPattern` and has been since 9d93c42c (#1383).

```
Should have UpdateDependencyStatus method
Expected: not null
But was:  null
```

#1383 made `MCPSetupWindow.UpdateDependencyStatus` `internal static` so the new `GitDetectionTests` could drive it directly. The characterization test still looks it up with `BindingFlags.NonPublic | BindingFlags.Instance`, which no longer matches a static method, so `GetMethod` returns `null` and the fixture dies on its `Assert.IsNotNull` guard rather than on the behaviour it exists to describe.

## Changes Made

Adds `BindingFlags.Static` alongside `Instance`, so the lookup works whichever way the method is declared. The test is a characterization test — it records that the window drives `"valid"`/`"invalid"` class lists on the indicators, which is still exactly what the method does, so the assertion it makes is unchanged and correct.

## Why it was not caught

#1383 came from a fork, where the Unity test legs report Skipped, and the pre-merge EditMode run was filtered to `GitDetectionTests`. Nothing ran the characterization fixture.

This is the second floor-only miss this cycle. Widening `compile-check.yml` past `defaultVersion` is worth doing on its own, but only a real test run catches this class — worth considering whether the maintainer-side pre-merge check should always run the unfiltered suite.

## Compatibility / Package Source
- Unity version(s) tested: 2021.3.45f2 (the package floor, and what `TestProjects/UnityMCPTests` is pinned to)
- Package source used: `file:`
- Test-only change; no package code touched.

## Testing
- [x] Unity EditMode tests — full suite on 2021.3.45f2: **1243 total, 1163 passed, 0 failed, 80 skipped**. `WindowsCharacterizationTests` on its own: 31/31.
- [ ] Python tests — not applicable, no `Server/` change
- [ ] PlayMode tests — not applicable

Before this commit the same full run was 1 failed.

## Documentation Updates
- [ ] No tools or resources changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for dependency status updates to support both static and instance method implementations.
  * Improved test reliability after changes to the underlying method declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->